### PR TITLE
Feature/http-router-fix

### DIFF
--- a/src/app/runtime/bot.py
+++ b/src/app/runtime/bot.py
@@ -76,6 +76,7 @@ class Bot:
         # Core 层组件（延迟初始化）
         self.plugin_loader: Any = None
         self.plugin_manager: Any = None
+        self.http_server: Any = None
         self.load_order: list[str] = []
         self.manifests: dict[str, Any] = {}
         self.load_results: dict[str, bool] = {}
@@ -246,6 +247,16 @@ class Bot:
         initialize_event_manager()
 
         self.ui.update_phase_status("核心管理器", "已初始化")
+        
+        # Step 3: 启动 HTTP 服务器
+        from src.core.transport.router.http_server import get_http_server
+        
+        host = "127.0.0.1"
+        port = 8000
+        
+        self.http_server = get_http_server(host=host, port=port)
+        await self.http_server.start()
+        self.ui.update_phase_status("HTTP服务器", "已启动")
 
     async def _discover_plugins(self) -> None:
         """发现插件并解析依赖"""
@@ -472,11 +483,17 @@ class Bot:
             await self.scheduler.stop()
             self._stats["scheduler_running"] = False
 
-            # 4. 停止 WatchDog
+            # 4. 停止 HTTP 服务器
+            if self.http_server and self.http_server.is_running():
+                if self.logger:
+                    self.logger.info("停止 HTTP 服务器...")
+                await self.http_server.stop()
+
+            # 5. 停止 WatchDog
             if self.watchdog:
                 self.watchdog.stop()
 
-            # 5. 停止任务管理器（取消所有活动任务）
+            # 6. 停止任务管理器（取消所有活动任务）
             active_tasks = self.task_manager.get_active_tasks()
             for task_info in active_tasks:
                 self.task_manager.cancel_task(task_info.task_id)
@@ -487,18 +504,18 @@ class Bot:
             # 清理已完成的任务
             self.task_manager.cleanup_tasks()
 
-            # 6. 关闭数据库
+            # 7. 关闭数据库
             from src.kernel.db import close_engine
 
             await close_engine()
             self._stats["db_connected"] = False
 
-            # 7. 关闭向量数据库
+            # 8. 关闭向量数据库
             from src.kernel.vector_db import close_all_vector_db_services
 
             await close_all_vector_db_services()
 
-            # 8. 关闭日志系统（停止事件广播）
+            # 9. 关闭日志系统（停止事件广播）
             from src.kernel.logger import shutdown_logger_system
 
             shutdown_logger_system()

--- a/src/core/managers/router_manager.py
+++ b/src/core/managers/router_manager.py
@@ -174,7 +174,7 @@ class RouterManager:
     async def unmount_router(self, signature: str) -> None:
         """卸载单个 Router。
 
-        调用关闭钩子并从管理器中移除。
+        调用关闭钩子，从HTTP服务器卸载路由，并从管理器中移除。
 
         Args:
             signature: Router 组件签名
@@ -192,6 +192,38 @@ class RouterManager:
             await router_instance.shutdown()
         except Exception as e:
             logger.error(f"Router 关闭钩子执行失败 ({signature}): {e}")
+
+        # 从 HTTP 服务器卸载路由
+        # 注意：通过直接修改 app.routes 列表卸载 Mount 路由是可行的，
+        # 因为 Starlette 会在每次请求时遍历 routes 列表进行匹配。
+        # 但需要注意路径匹配的准确性（尾部斜杠等）。
+        try:
+            http_server = get_http_server()
+            route_path = router_instance.get_route_path()
+            
+            # 查找并移除对应的 Mount 路由
+            from starlette.routing import Mount
+            
+            # 标准化路径（移除尾部斜杠以精确匹配）
+            normalized_path = route_path.rstrip("/")
+            
+            routes_to_remove = [
+                route for route in http_server.app.routes
+                if isinstance(route, Mount) and route.path.rstrip("/") == normalized_path
+            ]
+            
+            if not routes_to_remove:
+                logger.warning(f"未找到匹配的 Mount 路由: {route_path}")
+            
+            for route in routes_to_remove:
+                http_server.app.routes.remove(route)
+                logger.debug(f"已从HTTP服务器移除路由: {route.path}")
+                
+            # 清理路由器（触发重新构建路由表）
+            # 注意：Starlette/FastAPI 会在下次请求时自动重建路由表，无需手动触发
+            
+        except Exception as e:
+            logger.error(f"从HTTP服务器卸载路由失败 ({signature}): {e}")
 
         # 移除实例
         self._mounted_routers.pop(signature, None)

--- a/src/core/transport/router/http_server.py
+++ b/src/core/transport/router/http_server.py
@@ -71,7 +71,6 @@ class HTTPServer:
         self._running: bool = False
         self._server_task: asyncio.Task | None = None
 
-        logger.info(f"HTTP 服务器初始化: {host}:{port}")
 
     async def start(self) -> None:
         """启动服务器。
@@ -92,7 +91,7 @@ class HTTPServer:
             app=self.app,
             host=self.host,
             port=self.port,
-            log_level="info",
+            log_level="error",
         )
 
         self.server = uvicorn.Server(config)


### PR DESCRIPTION
# PR 标题
feat: HTTP路由管理器启动流程和卸载逻辑优化

# PR 描述

## 概述
本次提交优化了 HTTP 路由管理器的生命周期管理，解决了路由卸载不完整和服务器日志过多的问题。

## 主要变更

1. HTTP 服务器启动流程优化
- 在主程序启动时（`src/app/runtime/bot.py`）集中初始化 HTTP 服务器
- 将 HTTP 服务器实例保存到 `Bot` 类中统一管理
- 在核心管理器初始化后立即启动 HTTP 服务器（默认：`127.0.0.1:8000`）
- 添加了启动状态 UI 反馈

2. 路由卸载逻辑完善
- 在 `src/core/managers/router_manager.py` 的 `unmount_router()` 中新增从 HTTP 服务器卸载路由的逻辑
- 实现从 HTTP 服务器的 `app.routes` 列表中移除 `Mount` 路由
- 添加路径标准化处理（移除尾部斜杠）以确保精确匹配
- 添加详细的日志记录与错误处理

3. 服务器关闭流程优化
- 在 `Bot` 关闭时正确停止 HTTP 服务器
- 调整关闭顺序以匹配新的资源依赖（启动顺序的逆序停止）
- 更新关闭步骤编号以反映新的流程

4. 日志等级调整
- 将 uvicorn 服务器的日志等级从 `info` 调整为 `error`
- 移除 HTTP 服务器初始化时的重复日志输出
- 减少运行时日志噪音，提升用户体验

变更统计
- 修改文件：3 个
- 新增代码：56 行
- 删除代码：8 行

### 技术细节
路由卸载实现原理：
- 利用 Starlette 在每次请求时遍历 `routes` 列表的机制，直接从 `app.routes` 中移除对应的 `Mount` 对象
- 标准化路径以处理尾部斜杠差异
- Starlette/FastAPI 将在下次请求时自动使用更新后的路由表，无需手动触发重建

### 相关文件
- `src/app/runtime/bot.py`
- `src/core/managers/router_manager.py`
- `src/core/transport/router/http_server.py`