### PR TITLE
fix(docker): exclude config/ from Docker build context to prevent secret leakage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ env/
 data/*
 !data/chroma_db/  # 如果有初始化数据可以放这里
 logs/*
+config/*
 
 # IDE 和配置
 .vscode/


### PR DESCRIPTION
### Motivation
- The runtime `Dockerfile` uses `COPY . .`, which can bake any files present in the build context into image layers, and configuration files under `config/` can contain API keys and other secrets. 
- `.dockerignore` previously did not exclude `config/`, so local `config/*.toml` would be sent to the build context and risk being embedded in images.

### Description
- Added `config/*` to `.dockerignore` to prevent local runtime configuration files from being included in the Docker build context. 
- This is a minimal, low-risk change that preserves runtime behavior while preventing accidental secret leakage via image layers. 

### Testing
- Verified the vulnerable pattern still existed in `Dockerfile` (`COPY . .`) and confirmed the new ignore rule is present using `nl -ba .dockerignore | sed -n '1,60p'`, which shows `config/*` was added. (succeeded)
- Inspected the repository diff with `git diff -- .dockerignore` and committed the change with `git commit`, then confirmed the commit via `git rev-parse --short HEAD` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69b520db638c832a9f8ec1a98f039356)

## Summary by Sourcery

Build:
- Add config/* to .dockerignore so local config files are not sent in the Docker build context.