### PR TITLE
feat: 实现批次发送消息功能（按换行拆分文本）

### DIFF
--- a/plugins/emoji_sender/manifest.json
+++ b/plugins/emoji_sender/manifest.json
@@ -19,6 +19,12 @@
       "component_name": "send_emoji_meme",
       "dependencies": [],
       "enabled": true
+    },
+    {
+      "component_type": "action",
+      "component_name": "recognize_emoji",
+      "dependencies": [],
+      "enabled": true
     }
   ],
   "entry_point": "plugin.py",

--- a/plugins/emoji_sender/plugin.py
+++ b/plugins/emoji_sender/plugin.py
@@ -15,6 +15,7 @@ from src.kernel.logger import get_logger
 
 from .action import SendEmojiMemeAction
 from .config import EmojiSenderConfig
+from .recognize_action import RecognizeEmojiAction
 from .service import EmojiSenderService
 
 
@@ -81,7 +82,7 @@ class EmojiSenderPlugin(BasePlugin):
 
     def get_components(self) -> list[type]:
         """返回本插件提供的组件类。"""
-        return [EmojiSenderService, SendEmojiMemeAction]
+        return [EmojiSenderService, SendEmojiMemeAction, RecognizeEmojiAction]
 
     async def on_plugin_loaded(self) -> None:
         """插件加载完成后：初始化配置并注册周期任务。"""

--- a/plugins/emoji_sender/recognize_action.py
+++ b/plugins/emoji_sender/recognize_action.py
@@ -1,0 +1,86 @@
+"""emoji_sender Action：识别用户发送的表情包。
+
+该 Action 面向 LLM Tool Calling：
+- 从当前消息中获取表情包数据
+- 对 GIF 动态表情包提取多帧，综合识别内容并返回详细描述
+- 输出：表情包的描述、情感标签、是否为动图
+
+主要用于 AI 主动识别用户发送的表情包，特别是 GIF 动图。
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from src.app.plugin_system.api.service_api import get_service
+from src.core.components.base.action import BaseAction
+
+
+class RecognizeEmojiAction(BaseAction):
+    """识别表情包动作。
+
+    用于识别用户发送的表情包，支持 GIF 动态表情包的多帧识别。
+    当用户发送表情包时，AI 可以调用此动作获取详细描述。
+    """
+
+    action_name: str = "recognize_emoji"
+    action_description: str = (
+        "识别用户发送的表情包内容，支持 GIF 动图。"
+        "当用户发送表情包而你想要了解其具体内容时，调用此动作。"
+        "返回表情包的详细描述、情感标签以及是否为动图。"
+        "无需传入参数，会自动从当前消息中获取表情包数据。"
+    )
+    primary_action: bool = False
+
+    async def execute(self) -> tuple[bool, str]:
+        """执行识别表情包动作。
+
+        从当前聊天消息中获取表情包数据并识别。
+
+        Returns:
+            (成功与否, 描述信息或错误原因)
+        """
+        current_message = self.chat_stream.context.current_message
+        if current_message is None:
+            return False, "当前没有消息"
+
+        media_list: list[dict] | None = getattr(current_message, "media", None)
+        if not media_list:
+            return False, "当前消息中没有媒体数据"
+
+        emoji_data = None
+        for media in media_list:
+            if media.get("type") in ("emoji", "image"):
+                emoji_data = media.get("data")
+                break
+
+        if not emoji_data:
+            return False, "当前消息中没有表情包或图片"
+
+        service = get_service("emoji_sender:service:emoji_sender")
+        if service is None:
+            return False, "emoji_sender service 未加载"
+
+        from .service import EmojiSenderService
+
+        service = cast(EmojiSenderService, service)
+
+        result = await service.recognize_emoji(emoji_data)
+
+        if result is None:
+            return False, "表情包识别失败，可能是 VLM 服务不可用或图片格式不支持"
+
+        description = result.get("description", "")
+        emotion_tags = result.get("emotion_tags", [])
+        is_gif = result.get("is_gif", False)
+
+        tags_str = "、".join(emotion_tags) if emotion_tags else "无"
+        gif_hint = "（GIF 动图）" if is_gif else "（静态图）"
+
+        detail = (
+            f"表情包识别结果{gif_hint}：\n"
+            f"- 描述：{description}\n"
+            f"- 情感标签：{tags_str}"
+        )
+
+        return True, detail

--- a/plugins/emoji_sender/service.py
+++ b/plugins/emoji_sender/service.py
@@ -591,6 +591,148 @@ class EmojiSenderService(BaseService):
             "emotion_tags": filtered_tags,
         }
 
+    async def recognize_emoji(
+        self,
+        base64_data: str,
+    ) -> dict[str, Any] | None:
+        """识别用户发送的表情包（支持 GIF 动态表情包）。
+
+        对 GIF 表情包会提取多帧拼接成网格图，让 VLM 综合所有帧内容进行描述。
+
+        Args:
+            base64_data: base64 编码的表情包数据（可带 data:image/xxx;base64, 前缀）
+
+        Returns:
+            识别结果字典，包含：
+            - description: 表情包描述
+            - emotion_tags: 情感标签列表
+            - is_gif: 是否为 GIF 动图
+            若识别失败返回 None
+        """
+        try:
+            model_set = get_model_set_by_task("vlm")
+        except Exception:
+            logger.debug("未配置 VLM 任务模型，跳过识别")
+            return None
+
+        clean_base64 = self._extract_clean_base64(base64_data)
+        try:
+            image_bytes = base64.b64decode(clean_base64)
+        except Exception as e:
+            logger.warning(f"base64 解码失败: {e}")
+            return None
+
+        mime = self._detect_mime_from_bytes(image_bytes)
+        is_gif = mime == "image/gif"
+
+        try:
+            vlm_bytes, vlm_mime, is_gif_collage = self._compress_image_for_vlm(
+                image_bytes, mime, max_size_mb=5.0
+            )
+        except Exception as e:
+            logger.warning(f"压缩图片失败: {e}")
+            return None
+
+        vlm_base64 = base64.b64encode(vlm_bytes).decode("utf-8")
+
+        persona = self._build_persona_prompt()
+        tag_list = "、".join(EMOTION_TAG_PRESET)
+
+        gif_hint = (
+            "注意：这是一个 GIF 动图表情包的关键帧截图（网格排列），请综合所有帧的内容进行描述，包括动态效果和动作。\n"
+            if is_gif_collage else ""
+        )
+
+        prompt = (
+            "你将看到一张表情包图片。请仔细观察并描述它的内容。\n"
+            + gif_hint
+            + "你必须输出严格 JSON（不要输出任何额外文字），格式如下：\n"
+            '{"description": "描述内容，文字：\'图中文字\'", "emotion_tags": ["标签1", "标签2"]}\n\n'
+            "description 要求（文字部分不计入字数限制）：\n"
+            "- 概括表情包传达的核心情绪、氛围和画面主要特征\n"
+            "- 如果是动图，描述动态效果和动作变化\n"
+            "- 准确复述图中所有文字，格式为：文字：'逐字抄录'，放在末尾\n"
+            "- 如果确保认出表情包的具体来源（作品名、角色名等），请补充说明\n"
+            "- 无法确定出处则省略，只做客观描述\n"
+            "- 总体 60 字以内（不计图中文字）\n"
+            "- 无文字则省略文字部分\n\n"
+            "emotion_tags：从预设标签中选择最合适的（可多选）\n"
+            "预设标签：" + tag_list + "\n\n"
+            "人设（来自主配置）：\n" + persona
+        )
+
+        from src.kernel.llm import Image, LLMContextManager, LLMPayload, ROLE, Text
+
+        context_manager = LLMContextManager(max_payloads=2)
+        request = create_llm_request(
+            model_set=model_set,
+            request_name="emoji_recognize",
+            context_manager=context_manager,
+        )
+
+        image_value = f"data:{vlm_mime};base64,{vlm_base64}"
+        request.add_payload(LLMPayload(ROLE.USER, [Text(prompt), Image(image_value)]))
+
+        try:
+            response = await request.send(stream=False)
+            await response
+        except Exception as e:
+            logger.warning(f"VLM 识别失败: {e}")
+            return None
+
+        raw = (response.message or "").strip()
+        obj = self._extract_json_object(raw)
+        if obj is None:
+            logger.warning("VLM 输出无法解析为 JSON")
+            return None
+
+        description = str(obj.get("description") or "").strip()
+        tags = obj.get("emotion_tags")
+        if not isinstance(tags, list):
+            tags = []
+
+        filtered_tags = [
+            str(t).strip() for t in tags if isinstance(t, (str, int, float)) and str(t).strip() in EMOTION_TAG_PRESET
+        ]
+
+        if len(description) > 300:
+            description = description[:297] + "..."
+
+        return {
+            "description": description,
+            "emotion_tags": filtered_tags,
+            "is_gif": is_gif,
+        }
+
+    @staticmethod
+    def _extract_clean_base64(base64_data: str) -> str:
+        """从 base64 数据中提取纯净的 base64 内容。
+
+        支持带 data:image/xxx;base64, 前缀的格式。
+        """
+        if base64_data.startswith("data:"):
+            comma_idx = base64_data.find(",")
+            if comma_idx != -1:
+                return base64_data[comma_idx + 1 :]
+        return base64_data
+
+    @staticmethod
+    def _detect_mime_from_bytes(data: bytes) -> str:
+        """根据文件头判断 MIME 类型。"""
+        if len(data) < 4:
+            return "image/png"
+
+        if data[:6] == b"GIF87a" or data[:6] == b"GIF89a":
+            return "image/gif"
+        elif data[:8] == b"\x89PNG\r\n\x1a\n":
+            return "image/png"
+        elif data[:2] == b"\xff\xd8":
+            return "image/jpeg"
+        elif data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return "image/webp"
+
+        return "image/png"
+
     async def ingest_once(self) -> None:
         """执行一次入库任务。
 

--- a/plugins/napcat_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/napcat_adapter/src/handlers/to_napcat/send_handler.py
@@ -101,21 +101,57 @@ class SendHandler:
         else:
             logger.error("无法识别的消息类型")
             return
-        logger.debug(
-            f"准备发送到napcat的消息体: action='{action}', {id_name}='{target_id}', "
-            f"message={str(processed_message)[:500]}"
-        )
-        response = await self.send_message_to_napcat(
-            action or "",
-            {
-                id_name or "target_id": target_id,
-                "message": processed_message,
-            },
-        )
-        if response.get("status") == "ok":
-            logger.info("消息发送成功")
+        batches: list[list[dict]] = []
+        current_batch: list[dict] = []
+
+        for seg in processed_message:
+            if isinstance(seg, dict) and seg.get("type") == "text":
+                text = seg.get("data", {}).get("text", "")
+                if not text:
+                    continue
+                lines = [line.rstrip("\r") for line in text.split("\n") if line.strip()]
+                for line in lines:
+                    this_batch = []
+                    if batches == [] and len(processed_message) > 0 and processed_message[0].get("type") == "reply":
+                        this_batch.append(processed_message[0])
+                    this_batch.append({"type": "text", "data": {"text": line}})
+                    batches.append(this_batch)
+            else:
+                if current_batch:
+                    batches.append(current_batch)
+                    current_batch = []
+                current_batch.append(seg)
+
+        if current_batch and any(not (isinstance(seg, dict) and seg.get("type") == "text") for seg in current_batch):
+            batches.append(current_batch)
+
+        if not batches:
+            batches = [processed_message]
+
+        all_ok = True
+        for idx, batch in enumerate(batches):
+            if not batch:
+                continue
+            logger.debug(
+                f"发送批次 {idx+1}/{len(batches)} 到napcat: action='{action}', {id_name}='{target_id}'"
+            )
+            response = await self.send_message_to_napcat(
+                action or "",
+                {
+                    id_name or "target_id": target_id,
+                    "message": batch,
+                },
+            )
+            if response.get("status") == "ok":
+                logger.debug(f"批次 {idx+1} 发送成功")
+            else:
+                logger.warning(f"批次 {idx+1} 发送失败，napcat返回：{response!s}")
+                all_ok = False
+
+        if all_ok:
+            logger.info("所有消息发送成功")
         else:
-            logger.warning(f"消息发送失败，napcat返回：{response!s}")
+            logger.warning("部分消息发送失败")
 
     async def send_command(self, envelope: MessageEnvelope) -> None:
         """

--- a/plugins/napcat_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/napcat_adapter/src/handlers/to_napcat/send_handler.py
@@ -117,6 +117,8 @@ class SendHandler:
                     this_batch.append({"type": "text", "data": {"text": line}})
                     batches.append(this_batch)
             else:
+                if seg.get("type") == "reply" and seg == processed_message[0]:
+                    continue
                 if current_batch:
                     batches.append(current_batch)
                     current_batch = []

--- a/src/core/managers/media_manager.py
+++ b/src/core/managers/media_manager.py
@@ -479,18 +479,42 @@ class MediaManager:
                 template = prompt_manager.get_template("media.image_recognition")
             
             # 构建提示词（模板不需要参数，直接build）
+            prompt = ""
             if template:
                 prompt = await template.build()
 
             # 处理 base64 数据：提取纯净的 base64 内容
             clean_base64 = self._extract_clean_base64(base64_data)
             
-            # 使用标准的 data URL 格式（大多数 VLM API 都支持）
-            # 假设是 PNG 图片，如果需要可以根据实际情况调整
-            image_value = f"data:image/png;base64,{clean_base64}"
+            # 解码为二进制数据以检测 MIME 类型
+            try:
+                image_bytes = base64.b64decode(clean_base64)
+            except Exception as e:
+                logger.warning(f"base64 解码失败: {e}")
+                return None
+            
+            # 检测真实的 MIME 类型
+            detected_mime = self._detect_mime_from_bytes(image_bytes)
+            
+            # 压缩图片（包括 GIF 多帧处理）
+            vlm_bytes, vlm_mime, is_gif_collage = self._compress_image_for_vlm(
+                image_bytes, detected_mime
+            )
+            
+            # 重新编码为 base64
+            vlm_base64 = base64.b64encode(vlm_bytes).decode("utf-8")
+            
+            # 对于 GIF 动图，添加提示说明
+            gif_hint = ""
+            if is_gif_collage:
+                gif_hint = "（这是一个 GIF 动图的关键帧截图，请综合所有帧的内容描述动态效果）"
+            
+            # 使用正确的 MIME 类型构建 data URL
+            image_value = f"data:{vlm_mime};base64,{vlm_base64}"
 
             # 添加 payload 并发送请求
-            request.add_payload(LLMPayload(ROLE.USER, [Text(prompt), Image(image_value)]))
+            full_prompt = prompt + gif_hint
+            request.add_payload(LLMPayload(ROLE.USER, [Text(full_prompt), Image(image_value)]))
             response = await request.send(stream=False)
             await response
 
@@ -612,6 +636,164 @@ class MediaManager:
         data = data.replace("\n", "").replace("\r", "").replace(" ", "")
         
         return data
+
+    @staticmethod
+    def _detect_mime_from_bytes(data: bytes) -> str:
+        """根据文件头判断 MIME 类型。
+
+        Args:
+            data: 图片二进制数据
+
+        Returns:
+            MIME 类型字符串
+        """
+        if len(data) < 12:
+            return "image/png"
+
+        if data[:6] == b"GIF87a" or data[:6] == b"GIF89a":
+            return "image/gif"
+        elif data[:8] == b"\x89PNG\r\n\x1a\n":
+            return "image/png"
+        elif data[:2] == b"\xff\xd8":
+            return "image/jpeg"
+        elif data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return "image/webp"
+
+        return "image/png"
+
+    @staticmethod
+    def _compress_image_for_vlm(
+        image_bytes: bytes,
+        mime: str,
+        max_size_mb: float = 5.0
+    ) -> tuple[bytes, str, bool]:
+        """将图片压缩至指定大小用于 VLM 识别。
+
+        - 静态图（JPG/PNG/WebP）：逐步降低质量和分辨率
+        - GIF：均匀采样最多 6 帧拼成网格图，以 JPEG 发给 VLM
+
+        Args:
+            image_bytes: 图片二进制数据
+            mime: MIME 类型
+            max_size_mb: 最大文件大小（MB）
+
+        Returns:
+            (用于 VLM 的 bytes, mime 类型, is_gif_frames_collage)
+        """
+        try:
+            from PIL import Image as PILImage
+            import io as pil_io
+        except ImportError:
+            logger.warning("PIL 未安装，无法压缩图片")
+            return image_bytes, mime, False
+
+        max_bytes = int(max_size_mb * 1024 * 1024)
+
+        # GIF：提取多个关键帧拼成网格图
+        if mime == "image/gif":
+            try:
+                img = PILImage.open(pil_io.BytesIO(image_bytes))
+                total_frames: int = getattr(img, "n_frames", 1)
+
+                max_frames = 6
+                if total_frames <= max_frames:
+                    frame_indices = list(range(total_frames))
+                else:
+                    step = total_frames / max_frames
+                    frame_indices = [int(i * step) for i in range(max_frames)]
+
+                frames: list[Any] = []
+                for idx in frame_indices:
+                    try:
+                        img.seek(idx)
+                        frames.append(img.convert("RGB").copy())
+                    except EOFError:
+                        break
+
+                if not frames:
+                    raise RuntimeError("无法提取 GIF 帧")
+
+                cols = min(3, len(frames))
+                rows = (len(frames) + cols - 1) // cols
+                fw, fh = frames[0].size
+                grid_img = PILImage.new("RGB", (fw * cols, fh * rows), (255, 255, 255))
+                for i, frame in enumerate(frames):
+                    x = (i % cols) * fw
+                    y = (i // cols) * fh
+                    grid_img.paste(frame.resize((fw, fh)), (x, y))
+
+                output = pil_io.BytesIO()
+                grid_img.save(output, format="JPEG", quality=80)
+                result_bytes = output.getvalue()
+
+                if len(result_bytes) > max_bytes:
+                    scale = (max_bytes / len(result_bytes)) ** 0.5
+                    new_w = max(1, int(grid_img.width * scale))
+                    new_h = max(1, int(grid_img.height * scale))
+                    grid_img = grid_img.resize((new_w, new_h), PILImage.Resampling.LANCZOS)
+                    output = pil_io.BytesIO()
+                    grid_img.save(output, format="JPEG", quality=75)
+                    result_bytes = output.getvalue()
+
+                logger.debug(
+                    f"GIF 提取 {len(frames)} 帧拼成网格用于 VLM: "
+                    f"{len(image_bytes)} → {len(result_bytes)} 字节"
+                )
+                return result_bytes, "image/jpeg", True
+
+            except Exception as e:
+                logger.warning(f"GIF 处理失败: {e}")
+                return image_bytes, mime, False
+
+        # 静态图：不超限则直接返回
+        if len(image_bytes) <= max_bytes:
+            return image_bytes, mime, False
+
+        # 静态图：超限则逐步压缩
+        try:
+            img = PILImage.open(pil_io.BytesIO(image_bytes))
+        except Exception as e:
+            logger.warning(f"无法打开图片: {e}")
+            return image_bytes, mime, False
+
+        output_format = {
+            "image/png": "JPEG",
+            "image/jpeg": "JPEG",
+            "image/jpg": "JPEG",
+            "image/webp": "WEBP",
+        }.get(mime, "JPEG")
+        output_mime = "image/jpeg" if output_format == "JPEG" else mime
+
+        quality = 85
+        scale = 1.0
+        compressed = b""
+
+        while quality >= 30 or scale > 0.4:
+            output = pil_io.BytesIO()
+            try:
+                target = img.convert("RGB") if output_format == "JPEG" else img
+                if scale < 1.0:
+                    new_w = max(1, int(target.width * scale))
+                    new_h = max(1, int(target.height * scale))
+                    target = target.resize((new_w, new_h), PILImage.Resampling.LANCZOS)
+                target.save(output, format=output_format, quality=quality)
+                compressed = output.getvalue()
+                if len(compressed) <= max_bytes:
+                    logger.info(
+                        f"图片已压缩: {len(image_bytes)} → {len(compressed)} 字节"
+                    )
+                    return compressed, output_mime, False
+            except Exception as e:
+                logger.warning(f"压缩图片失败: {e}")
+                break
+
+            if quality > 30:
+                quality = max(30, quality - 10)
+            else:
+                scale = round(scale - 0.1, 1)
+
+        logger.warning(f"图片压缩后仍超限，使用最后结果: {len(compressed)} 字节")
+        return compressed, output_mime, False
     
     async def _save_to_pending(
         self,

--- a/src/core/managers/media_manager.py
+++ b/src/core/managers/media_manager.py
@@ -479,18 +479,43 @@ class MediaManager:
                 template = prompt_manager.get_template("media.image_recognition")
             
             # 构建提示词（模板不需要参数，直接build）
+            prompt = ""
             if template:
                 prompt = await template.build()
 
             # 处理 base64 数据：提取纯净的 base64 内容
             clean_base64 = self._extract_clean_base64(base64_data)
             
-            # 使用标准的 data URL 格式（大多数 VLM API 都支持）
-            # 假设是 PNG 图片，如果需要可以根据实际情况调整
-            image_value = f"data:image/png;base64,{clean_base64}"
+            # 解码为二进制数据以检测 MIME 类型
+            try:
+                image_bytes = base64.b64decode(clean_base64)
+            except Exception as e:
+                logger.warning(f"base64 解码失败: {e}")
+                return None
+            
+            # 检测真实的 MIME 类型
+            detected_mime = self._detect_mime_from_bytes(image_bytes)
+            is_gif = detected_mime == "image/gif"
+            
+            # 压缩图片（包括 GIF 多帧处理）
+            vlm_bytes, vlm_mime, is_gif_collage = self._compress_image_for_vlm(
+                image_bytes, detected_mime
+            )
+            
+            # 重新编码为 base64
+            vlm_base64 = base64.b64encode(vlm_bytes).decode("utf-8")
+            
+            # 对于 GIF 动图，添加提示说明
+            gif_hint = ""
+            if is_gif_collage:
+                gif_hint = "（这是一个 GIF 动图的关键帧截图，请综合所有帧的内容描述动态效果）"
+            
+            # 使用正确的 MIME 类型构建 data URL
+            image_value = f"data:{vlm_mime};base64,{vlm_base64}"
 
             # 添加 payload 并发送请求
-            request.add_payload(LLMPayload(ROLE.USER, [Text(prompt), Image(image_value)]))
+            full_prompt = prompt + gif_hint
+            request.add_payload(LLMPayload(ROLE.USER, [Text(full_prompt), Image(image_value)]))
             response = await request.send(stream=False)
             await response
 
@@ -612,6 +637,164 @@ class MediaManager:
         data = data.replace("\n", "").replace("\r", "").replace(" ", "")
         
         return data
+
+    @staticmethod
+    def _detect_mime_from_bytes(data: bytes) -> str:
+        """根据文件头判断 MIME 类型。
+
+        Args:
+            data: 图片二进制数据
+
+        Returns:
+            MIME 类型字符串
+        """
+        if len(data) < 12:
+            return "image/png"
+
+        if data[:6] == b"GIF87a" or data[:6] == b"GIF89a":
+            return "image/gif"
+        elif data[:8] == b"\x89PNG\r\n\x1a\n":
+            return "image/png"
+        elif data[:2] == b"\xff\xd8":
+            return "image/jpeg"
+        elif data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+            return "image/webp"
+
+        return "image/png"
+
+    @staticmethod
+    def _compress_image_for_vlm(
+        image_bytes: bytes,
+        mime: str,
+        max_size_mb: float = 5.0
+    ) -> tuple[bytes, str, bool]:
+        """将图片压缩至指定大小用于 VLM 识别。
+
+        - 静态图（JPG/PNG/WebP）：逐步降低质量和分辨率
+        - GIF：均匀采样最多 6 帧拼成网格图，以 JPEG 发给 VLM
+
+        Args:
+            image_bytes: 图片二进制数据
+            mime: MIME 类型
+            max_size_mb: 最大文件大小（MB）
+
+        Returns:
+            (用于 VLM 的 bytes, mime 类型, is_gif_frames_collage)
+        """
+        try:
+            from PIL import Image as PILImage
+            import io as pil_io
+        except ImportError:
+            logger.warning("PIL 未安装，无法压缩图片")
+            return image_bytes, mime, False
+
+        max_bytes = int(max_size_mb * 1024 * 1024)
+
+        # GIF：提取多个关键帧拼成网格图
+        if mime == "image/gif":
+            try:
+                img = PILImage.open(pil_io.BytesIO(image_bytes))
+                total_frames: int = getattr(img, "n_frames", 1)
+
+                max_frames = 6
+                if total_frames <= max_frames:
+                    frame_indices = list(range(total_frames))
+                else:
+                    step = total_frames / max_frames
+                    frame_indices = [int(i * step) for i in range(max_frames)]
+
+                frames: list[Any] = []
+                for idx in frame_indices:
+                    try:
+                        img.seek(idx)
+                        frames.append(img.convert("RGB").copy())
+                    except EOFError:
+                        break
+
+                if not frames:
+                    raise RuntimeError("无法提取 GIF 帧")
+
+                cols = min(3, len(frames))
+                rows = (len(frames) + cols - 1) // cols
+                fw, fh = frames[0].size
+                grid_img = PILImage.new("RGB", (fw * cols, fh * rows), (255, 255, 255))
+                for i, frame in enumerate(frames):
+                    x = (i % cols) * fw
+                    y = (i // cols) * fh
+                    grid_img.paste(frame.resize((fw, fh)), (x, y))
+
+                output = pil_io.BytesIO()
+                grid_img.save(output, format="JPEG", quality=80)
+                result_bytes = output.getvalue()
+
+                if len(result_bytes) > max_bytes:
+                    scale = (max_bytes / len(result_bytes)) ** 0.5
+                    new_w = max(1, int(grid_img.width * scale))
+                    new_h = max(1, int(grid_img.height * scale))
+                    grid_img = grid_img.resize((new_w, new_h), PILImage.Resampling.LANCZOS)
+                    output = pil_io.BytesIO()
+                    grid_img.save(output, format="JPEG", quality=75)
+                    result_bytes = output.getvalue()
+
+                logger.debug(
+                    f"GIF 提取 {len(frames)} 帧拼成网格用于 VLM: "
+                    f"{len(image_bytes)} → {len(result_bytes)} 字节"
+                )
+                return result_bytes, "image/jpeg", True
+
+            except Exception as e:
+                logger.warning(f"GIF 处理失败: {e}")
+                return image_bytes, mime, False
+
+        # 静态图：不超限则直接返回
+        if len(image_bytes) <= max_bytes:
+            return image_bytes, mime, False
+
+        # 静态图：超限则逐步压缩
+        try:
+            img = PILImage.open(pil_io.BytesIO(image_bytes))
+        except Exception as e:
+            logger.warning(f"无法打开图片: {e}")
+            return image_bytes, mime, False
+
+        output_format = {
+            "image/png": "JPEG",
+            "image/jpeg": "JPEG",
+            "image/jpg": "JPEG",
+            "image/webp": "WEBP",
+        }.get(mime, "JPEG")
+        output_mime = "image/jpeg" if output_format == "JPEG" else mime
+
+        quality = 85
+        scale = 1.0
+        compressed = b""
+
+        while quality >= 30 or scale > 0.4:
+            output = pil_io.BytesIO()
+            try:
+                target = img.convert("RGB") if output_format == "JPEG" else img
+                if scale < 1.0:
+                    new_w = max(1, int(target.width * scale))
+                    new_h = max(1, int(target.height * scale))
+                    target = target.resize((new_w, new_h), PILImage.Resampling.LANCZOS)
+                target.save(output, format=output_format, quality=quality)
+                compressed = output.getvalue()
+                if len(compressed) <= max_bytes:
+                    logger.info(
+                        f"图片已压缩: {len(image_bytes)} → {len(compressed)} 字节"
+                    )
+                    return compressed, output_mime, False
+            except Exception as e:
+                logger.warning(f"压缩图片失败: {e}")
+                break
+
+            if quality > 30:
+                quality = max(30, quality - 10)
+            else:
+                scale = round(scale - 0.1, 1)
+
+        logger.warning(f"图片压缩后仍超限，使用最后结果: {len(compressed)} 字节")
+        return compressed, output_mime, False
     
     async def _save_to_pending(
         self,

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -137,7 +137,10 @@ class MessageConverter:
             if self._should_skip_vlm_for_stream(stream_id):
                 logger.debug(f"聊天流 {stream_id[:8]} 已注册跳过 VLM 识别，保留原始媒体数据")
             else:
-                result = await self._recognize_media_with_manager(result)
+                # 判断是否为群聊（存在 group_info 且不为空即群聊）
+                group_info = message_info.get("group_info")
+                is_group_chat = group_info is not None and group_info != {}
+                result = await self._recognize_media_with_manager(result, is_group_chat)
 
         # 确定消息类型
         # 根据最终解析结果决定消息类型，比如 TEXT/IMAGE 等
@@ -575,11 +578,12 @@ class MessageConverter:
 
         return type_mapping.get(first_media_type, MessageType.UNKNOWN)
 
-    async def _recognize_media_with_manager(self, result: _ParseResult) -> _ParseResult:
+    async def _recognize_media_with_manager(self, result: _ParseResult, is_group_chat: bool) -> _ParseResult:
         """使用 MediaManager 识别媒体内容（图片、表情包）并更新文本描述。
         
         Args:
             result: 解析结果
+            is_group_chat: 是否为群聊消息
             
         Returns:
             更新后的解析结果


### PR DESCRIPTION
- 将长文本按换行符拆分成多条独立消息发送
- 保留 reply 引用消息段在第一个批次
- 非文本消息（图片、表情等）保持原样发送
- 改善 QQ 中多行文本的显示效果
                                  ————————————by 搬石大王

## Summary by Sourcery

Implement batch sending of messages to Napcat by splitting multi-line text into separate messages and handling per-batch results.

New Features:
- Split long text messages by newline into multiple batched messages for sending to Napcat while preserving the original reply segment in the first batch.

Enhancements:
- Improve handling and logging of message sending by processing messages in batches and reporting per-batch and overall success or partial failure.