### PR TITLE
feat(default_chatter): 新增 debug_mode 调试模式配置

### DIFF
--- a/plugins/default_chatter/config.py
+++ b/plugins/default_chatter/config.py
@@ -73,11 +73,19 @@ class DefaultChatterConfig(BaseConfig):
             hint="关闭可避免因 LLM 设置过长冷却时间导致长时间无法回复",
             order=3
         )
+        debug_mode: bool = Field(
+            default=False,
+            description="调试模式：开启后将在日志（INFO 级别）中完整打印每次发往 actor 模型的提示词",
+            label="调试模式",
+            tag="performance",
+            hint="仅用于开发调试，生产环境请关闭",
+            order=4
+        )
         theme_guide: ThemeGuideSection = Field(
             default_factory=ThemeGuideSection,
             description="按聊天类型区分的额外提示词",
             label="场景引导配置",
-            order=4
+            order=5
         )
 
     plugin: PluginSection = Field(default_factory=PluginSection)

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -547,6 +547,11 @@ class DefaultChatter(BaseChatter):
             if isinstance(plugin_config, DefaultChatterConfig)
             else False
         )
+        debug_mode = (
+            plugin_config.plugin.debug_mode
+            if isinstance(plugin_config, DefaultChatterConfig)
+            else False
+        )
         async for result in run_enhanced(
             chatter=self,
             chat_stream=chat_stream,
@@ -556,6 +561,7 @@ class DefaultChatter(BaseChatter):
             send_text_call_name=_SEND_TEXT,
             suspend_text=_SUSPEND_TEXT,
             enable_cooldown=enable_cooldown,
+            debug_mode=debug_mode,
         ):
             yield result
 
@@ -569,6 +575,11 @@ class DefaultChatter(BaseChatter):
             if isinstance(plugin_config, DefaultChatterConfig)
             else False
         )
+        debug_mode = (
+            plugin_config.plugin.debug_mode
+            if isinstance(plugin_config, DefaultChatterConfig)
+            else False
+        )
         async for result in run_classical(
             chatter=self,
             chat_stream=chat_stream,
@@ -578,6 +589,7 @@ class DefaultChatter(BaseChatter):
             send_text_call_name=_SEND_TEXT,
             suspend_text=_SUSPEND_TEXT,
             enable_cooldown=enable_cooldown,
+            debug_mode=debug_mode,
         ):
             yield result
 

--- a/plugins/default_chatter/runners.py
+++ b/plugins/default_chatter/runners.py
@@ -25,6 +25,25 @@ _PLAIN_TEXT_RETRY_REMINDER = (
 )
 
 
+def _log_request_payloads(
+    payloads: list[LLMPayload],
+    label: str,
+    logger: Logger,
+) -> None:
+    """以 INFO 级别记录 LLM 请求的完整 payload（调试模式专用，不截断）。"""
+    parts: list[str] = [f"=== {label} 完整提示词 ==="]
+    for idx, payload in enumerate(payloads):
+        role = payload.role.value if hasattr(payload.role, "value") else str(payload.role)
+        parts.append(f"--- [{idx + 1}] {role.upper()} ---")
+        for item in payload.content:
+            if isinstance(item, Text):
+                parts.append(item.text)
+            else:
+                parts.append(repr(item))
+    parts.append(f"=== END {label} ===")
+    logger.info("\n".join(parts))
+
+
 class _ToolCallWorkflowPhase(str, Enum):
     """default_chatter 的 toolcall 工作流相位（简化 FSM）。
 
@@ -97,6 +116,7 @@ async def run_enhanced(
     send_text_call_name: str,
     suspend_text: str,
     enable_cooldown: bool = False,
+    debug_mode: bool = False,
 ) -> AsyncGenerator[Wait | Success | Failure | Stop, None]:
     """enhanced 模式执行流程。"""
     try:
@@ -182,6 +202,8 @@ async def run_enhanced(
         if rt.phase in (_ToolCallWorkflowPhase.MODEL_TURN, _ToolCallWorkflowPhase.FOLLOW_UP):
             # FOLLOW_UP 阶段严禁 flush 新未读；MODEL_TURN 才 flush 本轮采纳的 unread。
             try:
+                if debug_mode:
+                    _log_request_payloads(rt.response.payloads, "actor (enhanced)", logger)
                 rt.response = await rt.response.send(stream=False)
                 await rt.response
                 if rt.phase == _ToolCallWorkflowPhase.MODEL_TURN:
@@ -265,6 +287,7 @@ async def run_classical(
     send_text_call_name: str,
     suspend_text: str,
     enable_cooldown: bool = False,
+    debug_mode: bool = False,
 ) -> AsyncGenerator[Wait | Success | Failure | Stop, None]:
     """classical 模式执行流程。"""
     try:
@@ -323,6 +346,8 @@ async def run_classical(
 
         while True:
             try:
+                if debug_mode:
+                    _log_request_payloads(response.payloads, "actor (classical)", logger)
                 response = await response.send(stream=False)
                 await response
             except Exception as error:


### PR DESCRIPTION
### 改动说明

新增 `debug_mode` 配置项，开启后 `default_chatter` 在每次向 LLM 发送请求前，将完整 payload（包括系统提示、对话历史、工具定义）以 INFO 级别打印到日志，不截断内容，方便调试提示词问题。

### 技术细节

- `plugins/default_chatter/config.py`：新增 `debug_mode: bool` 配置字段（默认 False）
- `plugins/default_chatter/runners.py`：新增 `_log_request_payloads()` 辅助函数，在 `run_enhanced` / `run_classical` 执行流程中调用
- `plugins/default_chatter/plugin.py`：从配置读取 `debug_mode` 并传递给 runners

### 使用方法

在 `config/plugins/default_chatter/config.toml` 中设置：

```toml
[plugin]
debug_mode = true
```

重启 Bot 后，所有发送给 LLM 的请求内容将输出到日志（级别 INFO）。

### 相关 Issue

无（主动改进）

### 测试说明

手动测试：开启 debug_mode 后验证日志输出格式和内容完整性。

## Summary by Sourcery

Add an optional debug mode to default_chatter that logs full LLM request payloads for debugging.

New Features:
- Introduce a debug_mode configuration option for default_chatter to enable detailed logging of LLM request payloads.

Enhancements:
- Wire the debug_mode configuration through the plugin execution paths so enhanced and classical runners can conditionally log outgoing actor prompts for each request.