### PR TITLE
新增打扰感知插件，支持 LLM 意图识别与会话静默

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,5 @@ plugins/*
 !plugins/booku_memory/
 !plugins/emoji_sender/
 !plugins/perm_plugin/
+!plugins/disturbance_guard/
 

--- a/plugins/disturbance_guard/__init__.py
+++ b/plugins/disturbance_guard/__init__.py
@@ -1,0 +1,2 @@
+"""disturbance_guard 插件包。"""
+

--- a/plugins/disturbance_guard/config.py
+++ b/plugins/disturbance_guard/config.py
@@ -1,0 +1,94 @@
+"""disturbance_guard 配置定义。"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from src.core.components.base.config import (
+    BaseConfig,
+    Field,
+    SectionBase,
+    config_section,
+)
+
+
+class DisturbanceGuardConfig(BaseConfig):
+    """打扰感知插件配置。"""
+
+    config_name: ClassVar[str] = "config"
+    config_description: ClassVar[str] = "打扰感知配置"
+
+    @config_section("plugin", title="插件设置", tag="plugin", order=0)
+    class PluginSection(SectionBase):
+        """插件基础配置。"""
+
+        enabled: bool = Field(
+            default=True,
+            description="是否启用 disturbance_guard 插件",
+            label="启用插件",
+            tag="plugin",
+            order=0,
+        )
+
+    @config_section("guard", title="打扰感知", tag="ai", order=10)
+    class GuardSection(SectionBase):
+        """打扰感知规则配置。"""
+
+        apply_to_private_chat: bool = Field(
+            default=True,
+            description="是否在私聊场景启用打扰感知",
+            label="私聊启用",
+            tag="scope",
+            order=0,
+        )
+        apply_to_group_chat: bool = Field(
+            default=False,
+            description="是否在群聊场景启用打扰感知",
+            label="群聊启用",
+            tag="scope",
+            order=1,
+        )
+        quiet_minutes: float = Field(
+            default=30.0,
+            description="命中打扰感知后进入免打扰的时长（分钟）",
+            label="免打扰时长",
+            tag="behavior",
+            order=2,
+        )
+        quiet_intent_patterns: list[str] = Field(
+            default_factory=lambda: [
+                r"我先忙(?:一会|一下)?",
+                r"晚点聊",
+                r"回头聊",
+                r"有空再聊",
+                r"先不聊了",
+                r"先这样吧",
+                r"别吵",
+                r"不要打扰我",
+                r"先别烦我",
+                r"我去忙了",
+            ],
+            description="触发免打扰的正则表达式列表",
+            label="免打扰触发词",
+            tag="behavior",
+            order=3,
+        )
+        wake_intent_patterns: list[str] = Field(
+            default_factory=lambda: [
+                r"我回来了",
+                r"继续聊",
+                r"继续说",
+                r"现在有空",
+                r"聊聊",
+                r"在吗",
+                r"可以聊了",
+            ],
+            description="解除免打扰的正则表达式列表",
+            label="免打扰唤醒词",
+            tag="behavior",
+            order=4,
+        )
+
+    plugin: PluginSection = Field(default_factory=PluginSection)
+    guard: GuardSection = Field(default_factory=GuardSection)
+

--- a/plugins/disturbance_guard/config.py
+++ b/plugins/disturbance_guard/config.py
@@ -55,37 +55,18 @@ class DisturbanceGuardConfig(BaseConfig):
             tag="behavior",
             order=2,
         )
-        quiet_intent_patterns: list[str] = Field(
-            default_factory=lambda: [
-                r"我先忙(?:一会|一下)?",
-                r"晚点聊",
-                r"回头聊",
-                r"有空再聊",
-                r"先不聊了",
-                r"先这样吧",
-                r"别吵",
-                r"不要打扰我",
-                r"先别烦我",
-                r"我去忙了",
-            ],
-            description="触发免打扰的正则表达式列表",
-            label="免打扰触发词",
-            tag="behavior",
+        model_task: str = Field(
+            default="utils_small",
+            description="用于意图判定的模型任务名称",
+            label="判定模型",
+            tag="ai",
             order=3,
         )
-        wake_intent_patterns: list[str] = Field(
-            default_factory=lambda: [
-                r"我回来了",
-                r"继续聊",
-                r"继续说",
-                r"现在有空",
-                r"聊聊",
-                r"在吗",
-                r"可以聊了",
-            ],
-            description="解除免打扰的正则表达式列表",
-            label="免打扰唤醒词",
-            tag="behavior",
+        llm_timeout: float = Field(
+            default=7.0,
+            description="LLM 意图判定的超时时间（秒）",
+            label="判定超时",
+            tag="ai",
             order=4,
         )
 

--- a/plugins/disturbance_guard/event_handler.py
+++ b/plugins/disturbance_guard/event_handler.py
@@ -1,0 +1,47 @@
+"""disturbance_guard 事件处理器。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.app.plugin_system.api.log_api import get_logger
+from src.core.components.base import BaseEventHandler
+from src.core.components.types import EventType
+from src.core.models.message import Message
+from src.kernel.event import EventDecision
+
+from .service import DisturbanceGuardService
+
+logger = get_logger("disturbance_guard_event_handler")
+
+
+class DisturbanceGuardMessageHandler(BaseEventHandler):
+    """在消息分发前执行打扰感知判定。"""
+
+    handler_name: str = "disturbance_guard_message_handler"
+    handler_description: str = "识别免打扰/唤醒意图并在需要时短路消息分发"
+    weight: int = 50
+    intercept_message: bool = True
+    init_subscribe: list[EventType | str] = [EventType.ON_MESSAGE_RECEIVED]
+
+    async def execute(
+        self,
+        event_name: str,
+        params: dict[str, Any],
+    ) -> tuple[EventDecision, dict[str, Any]]:
+        """处理 ON_MESSAGE_RECEIVED 事件。"""
+        _ = event_name
+        message = params.get("message")
+        if not isinstance(message, Message):
+            return EventDecision.PASS, params
+
+        decision = await DisturbanceGuardService(self.plugin).handle_message(message)
+        if not decision.should_suppress:
+            return EventDecision.PASS, params
+
+        logger.info(
+            "打扰感知已静默当前消息: "
+            f"stream={message.stream_id[:8]}, reason={decision.reason}"
+        )
+        return EventDecision.STOP, params
+

--- a/plugins/disturbance_guard/manifest.json
+++ b/plugins/disturbance_guard/manifest.json
@@ -1,0 +1,19 @@
+{
+    "name": "disturbance_guard",
+    "version": "1.0.0",
+    "description": "识别免打扰/唤醒意图并静默处理消息",
+    "author": "MoFox Team",
+    "dependencies": {
+        "plugins": [],
+        "components": []
+    },
+    "include": [
+        {
+            "component_type": "event_handler",
+            "component_name": "disturbance_guard_message_handler",
+            "dependencies": []
+        }
+    ],
+    "entry_point": "plugin.py",
+    "min_core_version": "1.0.0"
+}

--- a/plugins/disturbance_guard/plugin.py
+++ b/plugins/disturbance_guard/plugin.py
@@ -1,0 +1,33 @@
+"""disturbance_guard 插件入口。"""
+
+from __future__ import annotations
+
+from src.app.plugin_system.api.log_api import get_logger
+from src.core.components import BasePlugin, register_plugin
+
+from .config import DisturbanceGuardConfig
+from .event_handler import DisturbanceGuardMessageHandler
+
+logger = get_logger("disturbance_guard_plugin")
+
+
+@register_plugin
+class DisturbanceGuardPlugin(BasePlugin):
+    """打扰感知插件。"""
+
+    plugin_name: str = "disturbance_guard"
+    plugin_description: str = "识别免打扰/唤醒意图并静默处理消息"
+    plugin_version: str = "1.0.0"
+
+    configs: list[type] = [DisturbanceGuardConfig]
+    dependent_components: list[str] = []
+
+    def get_components(self) -> list[type]:
+        """返回插件组件列表。"""
+        if isinstance(self.config, DisturbanceGuardConfig):
+            if not self.config.plugin.enabled:
+                logger.info("disturbance_guard 已在配置中禁用")
+                return []
+
+        return [DisturbanceGuardMessageHandler]
+

--- a/plugins/disturbance_guard/service.py
+++ b/plugins/disturbance_guard/service.py
@@ -2,21 +2,46 @@
 
 from __future__ import annotations
 
-import re
+import asyncio
 import time
 from dataclasses import dataclass
+from enum import Enum
 from typing import TYPE_CHECKING
 
 from src.app.plugin_system.api.log_api import get_logger
 from src.core.models.message import Message
+from src.kernel.llm import ROLE, LLMPayload, LLMRequest, Text
 
 from .config import DisturbanceGuardConfig
 
 if TYPE_CHECKING:
     from src.core.components.base.plugin import BasePlugin
+    from src.core.managers.stream_manager import StreamManager
     from src.core.models.stream import ChatStream
 
 logger = get_logger("disturbance_guard_service")
+
+_INTENT_SYSTEM_PROMPT = """\
+你是一个意图分类器。判断用户消息是否属于以下两种意图之一：
+
+1. **quiet**：用户表示自己要忙、不想被打扰、暂时离开。
+   例如："我先忙一下"、"别吵"、"晚点聊"、"先不聊了"、"我去忙了"、"先别烦我"。
+
+2. **wake**：用户表示自己回来了、可以继续聊天或者直接发新消息。
+   例如："我回来了"、"继续聊"、"现在有空"、"在吗"、"可以聊了"。
+
+如果都不属于，回复 **none**。
+
+只回复一个词：quiet、wake 或 none。不要解释。\
+"""
+
+
+class _Intent(Enum):
+    """LLM 判定的用户意图。"""
+
+    QUIET = "quiet"
+    WAKE = "wake"
+    NONE = "none"
 
 
 @dataclass(slots=True)
@@ -31,52 +56,27 @@ class DisturbanceGuardService:
     """打扰感知服务。
 
     职责：
-    1. 识别“先忙/别吵/晚点聊”等免打扰意图。
-    2. 识别“我回来了/继续聊”等唤醒意图。
-    3. 维护 stream 上下文中的免打扰状态。
-    4. 在需要静默时将消息直接写入 history，而不是进入 unread。
+    1. 通过 LLM 识别用户消息中的免打扰/唤醒意图。
+    2. 通过 StreamManager 公共 API 维护流的免打扰状态。
+    3. 在需要静默时将消息直接写入 history，而不是进入 unread。
     """
 
     def __init__(self, plugin: BasePlugin) -> None:
         """初始化打扰感知服务。"""
         self.plugin = plugin
-        self._quiet_patterns: list[re.Pattern[str]] | None = None
-        self._wake_patterns: list[re.Pattern[str]] | None = None
 
     def _get_config(self) -> DisturbanceGuardConfig:
-        """获取已绑定插件配置。"""
-        if isinstance(self.plugin.config, DisturbanceGuardConfig):
-            return self.plugin.config
-        return DisturbanceGuardConfig()
+        """获取已绑定插件配置。
 
-    def _get_quiet_patterns(self) -> list[re.Pattern[str]]:
-        """获取免打扰触发模式列表。"""
-        if self._quiet_patterns is None:
-            self._quiet_patterns = self._compile_patterns(
-                self._get_config().guard.quiet_intent_patterns
+        Raises:
+            TypeError: 插件配置类型不匹配时，说明组装层存在问题。
+        """
+        if not isinstance(self.plugin.config, DisturbanceGuardConfig):
+            raise TypeError(
+                f"disturbance_guard 插件配置类型错误: "
+                f"期望 DisturbanceGuardConfig, 实际 {type(self.plugin.config).__name__}"
             )
-        return self._quiet_patterns
-
-    def _get_wake_patterns(self) -> list[re.Pattern[str]]:
-        """获取唤醒模式列表。"""
-        if self._wake_patterns is None:
-            self._wake_patterns = self._compile_patterns(
-                self._get_config().guard.wake_intent_patterns
-            )
-        return self._wake_patterns
-
-    @staticmethod
-    def _compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:
-        """编译正则表达式列表。"""
-        compiled: list[re.Pattern[str]] = []
-        for pattern in patterns:
-            if not isinstance(pattern, str) or not pattern.strip():
-                continue
-            try:
-                compiled.append(re.compile(pattern, re.IGNORECASE))
-            except re.error as exc:
-                logger.warning(f"忽略非法正则 {pattern!r}: {exc}")
-        return compiled
+        return self.plugin.config
 
     @staticmethod
     def _normalize_text(message: Message) -> str:
@@ -98,19 +98,51 @@ class DisturbanceGuardService:
             return bool(guard.apply_to_group_chat)
         return False
 
-    @staticmethod
-    def _matches_any(text: str, patterns: list[re.Pattern[str]]) -> bool:
-        """检查文本是否命中任一正则。"""
-        return any(pattern.search(text) for pattern in patterns)
+    async def _classify_intent(self, text: str) -> _Intent:
+        """通过 LLM 判定用户消息的意图。
+
+        Args:
+            text: 规范化后的用户消息文本
+
+        Returns:
+            _Intent: quiet / wake / none
+        """
+        from src.core.config import get_model_config
+
+        config = self._get_config()
+        model_set = get_model_config().get_task(config.guard.model_task)
+
+        request = LLMRequest(model_set, request_name="disturbance_guard_intent")
+        request.add_payload(LLMPayload(ROLE.SYSTEM, Text(_INTENT_SYSTEM_PROMPT)))
+        request.add_payload(LLMPayload(ROLE.USER, Text(text)))
+
+        try:
+            response = await asyncio.wait_for(
+                request.send(stream=False),
+                timeout=config.guard.llm_timeout,
+            )
+            response_text: str = await response
+            result = response_text.strip().lower()
+
+            if "quiet" in result:
+                return _Intent.QUIET
+            if "wake" in result:
+                return _Intent.WAKE
+            return _Intent.NONE
+
+        except asyncio.TimeoutError:
+            logger.warning("LLM 意图判定超时，默认放行")
+            return _Intent.NONE
+        except Exception as exc:
+            logger.warning(f"LLM 意图判定异常: {exc}，默认放行")
+            return _Intent.NONE
 
     async def _get_chat_stream(self, message: Message) -> ChatStream:
         """获取或创建消息所属聊天流。"""
-        from src.core.managers import get_stream_manager
-
-        stream_manager = get_stream_manager()
+        stream_manager = self._get_stream_manager()
         group_id = ""
         group_name = ""
-        if hasattr(message, "extra") and isinstance(message.extra, dict):
+        if isinstance(message.extra, dict):
             raw_group_id = message.extra.get("group_id")
             raw_group_name = message.extra.get("group_name")
             group_id = str(raw_group_id or "")
@@ -126,7 +158,8 @@ class DisturbanceGuardService:
             chat_type=message.chat_type,
         )
 
-    async def _get_stream_manager(self):
+    @staticmethod
+    def _get_stream_manager() -> StreamManager:
         """获取 StreamManager 实例。
 
         延迟导入以避免循环依赖。
@@ -137,7 +170,7 @@ class DisturbanceGuardService:
 
     async def _persist_silently(self, message: Message) -> None:
         """将消息静默写入历史，不进入 unread。"""
-        stream_manager = await self._get_stream_manager()
+        stream_manager = self._get_stream_manager()
         await stream_manager.add_received_message_to_history(message)
 
     async def handle_message(
@@ -158,23 +191,29 @@ class DisturbanceGuardService:
 
         # 确保流已创建
         await self._get_chat_stream(message)
-        stream_manager = await self._get_stream_manager()
+        stream_manager = self._get_stream_manager()
         stream_id = message.stream_id
         now = time.time()
 
-        # 免打扰已过期，通过 manager 清理
-        if not stream_manager.is_stream_do_not_disturb_active(stream_id):
+        dnd_active = stream_manager.is_stream_do_not_disturb_active(stream_id)
+
+        # 免打扰已过期，通过 manager 清理残留字段
+        if not dnd_active:
             stream_manager.clear_stream_do_not_disturb(stream_id)
 
-        if stream_manager.is_stream_do_not_disturb_active(stream_id):
-            if self._matches_any(normalized_text, self._get_wake_patterns()):
+        # 当前处于免打扰状态
+        if dnd_active:
+            intent = await self._classify_intent(normalized_text)
+            if intent is _Intent.WAKE:
                 stream_manager.clear_stream_do_not_disturb(stream_id)
                 return DisturbanceGuardDecision(False, "wake intent matched")
 
             await self._persist_silently(message)
             return DisturbanceGuardDecision(True, "stream is in do-not-disturb")
 
-        if not self._matches_any(normalized_text, self._get_quiet_patterns()):
+        # 当前未处于免打扰状态，判断是否要进入
+        intent = await self._classify_intent(normalized_text)
+        if intent is not _Intent.QUIET:
             return DisturbanceGuardDecision(False, "no quiet intent matched")
 
         quiet_until = now + float(config.guard.quiet_minutes) * 60.0

--- a/plugins/disturbance_guard/service.py
+++ b/plugins/disturbance_guard/service.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Pattern, cast
+from typing import TYPE_CHECKING
 
 from src.app.plugin_system.api.log_api import get_logger
 from src.core.models.message import Message
 
 from .config import DisturbanceGuardConfig
+
+if TYPE_CHECKING:
+    from src.core.components.base.plugin import BasePlugin
+    from src.core.models.stream import ChatStream
 
 logger = get_logger("disturbance_guard_service")
 
@@ -33,11 +37,11 @@ class DisturbanceGuardService:
     4. 在需要静默时将消息直接写入 history，而不是进入 unread。
     """
 
-    def __init__(self, plugin: Any) -> None:
+    def __init__(self, plugin: BasePlugin) -> None:
         """初始化打扰感知服务。"""
         self.plugin = plugin
-        self._quiet_patterns: list[Pattern[str]] | None = None
-        self._wake_patterns: list[Pattern[str]] | None = None
+        self._quiet_patterns: list[re.Pattern[str]] | None = None
+        self._wake_patterns: list[re.Pattern[str]] | None = None
 
     def _get_config(self) -> DisturbanceGuardConfig:
         """获取已绑定插件配置。"""
@@ -45,7 +49,7 @@ class DisturbanceGuardService:
             return self.plugin.config
         return DisturbanceGuardConfig()
 
-    def _get_quiet_patterns(self) -> list[Pattern[str]]:
+    def _get_quiet_patterns(self) -> list[re.Pattern[str]]:
         """获取免打扰触发模式列表。"""
         if self._quiet_patterns is None:
             self._quiet_patterns = self._compile_patterns(
@@ -53,7 +57,7 @@ class DisturbanceGuardService:
             )
         return self._quiet_patterns
 
-    def _get_wake_patterns(self) -> list[Pattern[str]]:
+    def _get_wake_patterns(self) -> list[re.Pattern[str]]:
         """获取唤醒模式列表。"""
         if self._wake_patterns is None:
             self._wake_patterns = self._compile_patterns(
@@ -62,9 +66,9 @@ class DisturbanceGuardService:
         return self._wake_patterns
 
     @staticmethod
-    def _compile_patterns(patterns: list[str]) -> list[Pattern[str]]:
+    def _compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:
         """编译正则表达式列表。"""
-        compiled: list[Pattern[str]] = []
+        compiled: list[re.Pattern[str]] = []
         for pattern in patterns:
             if not isinstance(pattern, str) or not pattern.strip():
                 continue
@@ -95,11 +99,11 @@ class DisturbanceGuardService:
         return False
 
     @staticmethod
-    def _matches_any(text: str, patterns: list[Pattern[str]]) -> bool:
+    def _matches_any(text: str, patterns: list[re.Pattern[str]]) -> bool:
         """检查文本是否命中任一正则。"""
         return any(pattern.search(text) for pattern in patterns)
 
-    async def _get_chat_stream(self, message: Message) -> Any:
+    async def _get_chat_stream(self, message: Message) -> ChatStream:
         """获取或创建消息所属聊天流。"""
         from src.core.managers import get_stream_manager
 
@@ -122,11 +126,19 @@ class DisturbanceGuardService:
             chat_type=message.chat_type,
         )
 
-    async def _persist_silently(self, message: Message) -> None:
-        """将消息静默写入历史，不进入 unread。"""
+    async def _get_stream_manager(self):
+        """获取 StreamManager 实例。
+
+        延迟导入以避免循环依赖。
+        """
         from src.core.managers import get_stream_manager
 
-        await get_stream_manager().add_received_message_to_history(message)
+        return get_stream_manager()
+
+    async def _persist_silently(self, message: Message) -> None:
+        """将消息静默写入历史，不进入 unread。"""
+        stream_manager = await self._get_stream_manager()
+        await stream_manager.add_received_message_to_history(message)
 
     async def handle_message(
         self,
@@ -144,16 +156,19 @@ class DisturbanceGuardService:
         if not normalized_text:
             return DisturbanceGuardDecision(False, "empty text")
 
-        chat_stream = await self._get_chat_stream(message)
-        context = chat_stream.context
+        # 确保流已创建
+        await self._get_chat_stream(message)
+        stream_manager = await self._get_stream_manager()
+        stream_id = message.stream_id
         now = time.time()
 
-        if context.do_not_disturb_until is not None and not context.is_do_not_disturb_active(now):
-            context.clear_do_not_disturb()
+        # 免打扰已过期，通过 manager 清理
+        if not stream_manager.is_stream_do_not_disturb_active(stream_id):
+            stream_manager.clear_stream_do_not_disturb(stream_id)
 
-        if context.is_do_not_disturb_active(now):
+        if stream_manager.is_stream_do_not_disturb_active(stream_id):
             if self._matches_any(normalized_text, self._get_wake_patterns()):
-                context.clear_do_not_disturb()
+                stream_manager.clear_stream_do_not_disturb(stream_id)
                 return DisturbanceGuardDecision(False, "wake intent matched")
 
             await self._persist_silently(message)
@@ -163,7 +178,8 @@ class DisturbanceGuardService:
             return DisturbanceGuardDecision(False, "no quiet intent matched")
 
         quiet_until = now + float(config.guard.quiet_minutes) * 60.0
-        context.set_do_not_disturb(
+        stream_manager.set_stream_do_not_disturb(
+            stream_id,
             until=quiet_until,
             reason=normalized_text,
             trigger_message_id=message.message_id or None,

--- a/plugins/disturbance_guard/service.py
+++ b/plugins/disturbance_guard/service.py
@@ -1,0 +1,173 @@
+"""disturbance_guard 服务层。"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Pattern, cast
+
+from src.app.plugin_system.api.log_api import get_logger
+from src.core.models.message import Message
+
+from .config import DisturbanceGuardConfig
+
+logger = get_logger("disturbance_guard_service")
+
+
+@dataclass(slots=True)
+class DisturbanceGuardDecision:
+    """打扰感知判定结果。"""
+
+    should_suppress: bool
+    reason: str
+
+
+class DisturbanceGuardService:
+    """打扰感知服务。
+
+    职责：
+    1. 识别“先忙/别吵/晚点聊”等免打扰意图。
+    2. 识别“我回来了/继续聊”等唤醒意图。
+    3. 维护 stream 上下文中的免打扰状态。
+    4. 在需要静默时将消息直接写入 history，而不是进入 unread。
+    """
+
+    def __init__(self, plugin: Any) -> None:
+        """初始化打扰感知服务。"""
+        self.plugin = plugin
+        self._quiet_patterns: list[Pattern[str]] | None = None
+        self._wake_patterns: list[Pattern[str]] | None = None
+
+    def _get_config(self) -> DisturbanceGuardConfig:
+        """获取已绑定插件配置。"""
+        if isinstance(self.plugin.config, DisturbanceGuardConfig):
+            return self.plugin.config
+        return DisturbanceGuardConfig()
+
+    def _get_quiet_patterns(self) -> list[Pattern[str]]:
+        """获取免打扰触发模式列表。"""
+        if self._quiet_patterns is None:
+            self._quiet_patterns = self._compile_patterns(
+                self._get_config().guard.quiet_intent_patterns
+            )
+        return self._quiet_patterns
+
+    def _get_wake_patterns(self) -> list[Pattern[str]]:
+        """获取唤醒模式列表。"""
+        if self._wake_patterns is None:
+            self._wake_patterns = self._compile_patterns(
+                self._get_config().guard.wake_intent_patterns
+            )
+        return self._wake_patterns
+
+    @staticmethod
+    def _compile_patterns(patterns: list[str]) -> list[Pattern[str]]:
+        """编译正则表达式列表。"""
+        compiled: list[Pattern[str]] = []
+        for pattern in patterns:
+            if not isinstance(pattern, str) or not pattern.strip():
+                continue
+            try:
+                compiled.append(re.compile(pattern, re.IGNORECASE))
+            except re.error as exc:
+                logger.warning(f"忽略非法正则 {pattern!r}: {exc}")
+        return compiled
+
+    @staticmethod
+    def _normalize_text(message: Message) -> str:
+        """提取并规范化消息纯文本。"""
+        raw_text = message.processed_plain_text
+        if not raw_text and isinstance(message.content, str):
+            raw_text = message.content
+        if not raw_text:
+            return ""
+        return " ".join(str(raw_text).strip().split())
+
+    def _is_scope_enabled(self, chat_type: str) -> bool:
+        """检查当前聊天类型是否启用了打扰感知。"""
+        guard = self._get_config().guard
+        normalized_chat_type = str(chat_type or "").lower()
+        if normalized_chat_type == "private":
+            return bool(guard.apply_to_private_chat)
+        if normalized_chat_type == "group":
+            return bool(guard.apply_to_group_chat)
+        return False
+
+    @staticmethod
+    def _matches_any(text: str, patterns: list[Pattern[str]]) -> bool:
+        """检查文本是否命中任一正则。"""
+        return any(pattern.search(text) for pattern in patterns)
+
+    async def _get_chat_stream(self, message: Message) -> Any:
+        """获取或创建消息所属聊天流。"""
+        from src.core.managers import get_stream_manager
+
+        stream_manager = get_stream_manager()
+        group_id = ""
+        group_name = ""
+        if hasattr(message, "extra") and isinstance(message.extra, dict):
+            raw_group_id = message.extra.get("group_id")
+            raw_group_name = message.extra.get("group_name")
+            group_id = str(raw_group_id or "")
+            group_name = str(raw_group_name or "")
+
+        user_id = message.sender_id if str(message.chat_type).lower() != "group" else ""
+        return await stream_manager.get_or_create_stream(
+            stream_id=message.stream_id,
+            platform=message.platform,
+            user_id=user_id,
+            group_id=group_id,
+            group_name=group_name,
+            chat_type=message.chat_type,
+        )
+
+    async def _persist_silently(self, message: Message) -> None:
+        """将消息静默写入历史，不进入 unread。"""
+        from src.core.managers import get_stream_manager
+
+        await get_stream_manager().add_received_message_to_history(message)
+
+    async def handle_message(
+        self,
+        message: Message,
+    ) -> DisturbanceGuardDecision:
+        """处理单条消息并返回是否需要抑制分发。"""
+        config = self._get_config()
+        if not config.plugin.enabled:
+            return DisturbanceGuardDecision(False, "plugin disabled")
+
+        if not self._is_scope_enabled(message.chat_type):
+            return DisturbanceGuardDecision(False, "chat scope disabled")
+
+        normalized_text = self._normalize_text(message)
+        if not normalized_text:
+            return DisturbanceGuardDecision(False, "empty text")
+
+        chat_stream = await self._get_chat_stream(message)
+        context = chat_stream.context
+        now = time.time()
+
+        if context.do_not_disturb_until is not None and not context.is_do_not_disturb_active(now):
+            context.clear_do_not_disturb()
+
+        if context.is_do_not_disturb_active(now):
+            if self._matches_any(normalized_text, self._get_wake_patterns()):
+                context.clear_do_not_disturb()
+                return DisturbanceGuardDecision(False, "wake intent matched")
+
+            await self._persist_silently(message)
+            return DisturbanceGuardDecision(True, "stream is in do-not-disturb")
+
+        if not self._matches_any(normalized_text, self._get_quiet_patterns()):
+            return DisturbanceGuardDecision(False, "no quiet intent matched")
+
+        quiet_until = now + float(config.guard.quiet_minutes) * 60.0
+        context.set_do_not_disturb(
+            until=quiet_until,
+            reason=normalized_text,
+            trigger_message_id=message.message_id or None,
+        )
+        await self._persist_silently(message)
+        return DisturbanceGuardDecision(True, "quiet intent matched")
+

--- a/src/core/managers/stream_manager.py
+++ b/src/core/managers/stream_manager.py
@@ -503,6 +503,58 @@ class StreamManager:
 
             return db_message
 
+    # ==================== Do-Not-Disturb ====================
+
+    def is_stream_do_not_disturb_active(self, stream_id: str) -> bool:
+        """检查流是否处于免打扰状态。
+
+        Args:
+            stream_id: 流ID
+
+        Returns:
+            bool: 免打扰未到期时返回 True
+        """
+        chat_stream = self._streams.get(stream_id)
+        if not chat_stream:
+            return False
+        return chat_stream.context.is_do_not_disturb_active()
+
+    def set_stream_do_not_disturb(
+        self,
+        stream_id: str,
+        *,
+        until: float,
+        reason: str,
+        trigger_message_id: str | None = None,
+    ) -> None:
+        """设置流的免打扰状态。
+
+        Args:
+            stream_id: 流ID
+            until: 免打扰到期时间戳
+            reason: 触发免打扰的原因
+            trigger_message_id: 触发免打扰的消息ID
+        """
+        chat_stream = self._streams.get(stream_id)
+        if not chat_stream:
+            return
+        chat_stream.context.set_do_not_disturb(
+            until=until,
+            reason=reason,
+            trigger_message_id=trigger_message_id,
+        )
+
+    def clear_stream_do_not_disturb(self, stream_id: str) -> None:
+        """清空流的免打扰状态。
+
+        Args:
+            stream_id: 流ID
+        """
+        chat_stream = self._streams.get(stream_id)
+        if not chat_stream:
+            return
+        chat_stream.context.clear_do_not_disturb()
+
     # ==================== Stream Lifecycle ====================
 
     async def delete_stream(

--- a/src/core/managers/stream_manager.py
+++ b/src/core/managers/stream_manager.py
@@ -440,6 +440,69 @@ class StreamManager:
 
             return db_message
 
+    async def add_received_message_to_history(
+        self,
+        message: "Message",
+    ) -> "Messages":
+        """添加“已接收但不进入 unread”的消息到流历史消息。
+
+        该入口用于需要保留消息历史、但不希望消息触发 Chatter 处理的场景，
+        例如免打扰期内的静默吞消息。
+
+        Args:
+            message: 运行时消息对象
+
+        Returns:
+            Messages: 创建或已存在的数据库消息记录
+        """
+        stream_id = message.stream_id
+
+        lock = self._get_stream_lock(stream_id)
+        async with lock:
+            person_id = self._resolve_person_id_from_message(message)
+
+            message_data = {
+                "message_id": message.message_id,
+                "stream_id": stream_id,
+                "person_id": person_id,
+                "time": message.time,
+                "message_type": message.message_type.value,
+                "content": _serialize_content_for_db(message.content),
+                "processed_plain_text": message.processed_plain_text,
+                "reply_to": message.reply_to,
+                "platform": message.platform,
+            }
+
+            db_message = await self._messages_crud.get_by(
+                message_id=message.message_id,
+                platform=message.platform,
+                stream_id=stream_id,
+            )
+            if not db_message:
+                db_message = await self._messages_crud.create(message_data)
+
+            chat_stream = self._streams.get(stream_id)
+            if chat_stream:
+                context = chat_stream.context
+                context.unread_messages = [
+                    unread
+                    for unread in context.unread_messages
+                    if unread.message_id != message.message_id
+                ]
+
+                exists_in_history = any(
+                    history.message_id == message.message_id
+                    for history in context.history_messages
+                )
+                if not exists_in_history:
+                    context.add_history_message(message)
+
+                chat_stream.update_active_time()
+
+            await self._update_stream_active_time(stream_id)
+
+            return db_message
+
     # ==================== Stream Lifecycle ====================
 
     async def delete_stream(

--- a/src/core/models/stream.py
+++ b/src/core/models/stream.py
@@ -34,6 +34,9 @@ class StreamContext:
         is_cache_enabled: 是否启用消息缓存
         last_message_time: 最近一次收到新消息的时间戳，None 表示尚未收到
         message_buffer_skip_count: 当前连续因消息缓冲机制跳过的 Tick 次数
+        do_not_disturb_until: 免打扰到期时间戳，None 表示未启用
+        do_not_disturb_reason: 最近一次进入免打扰的原因
+        do_not_disturb_trigger_message_id: 触发免打扰的消息 ID
     """
 
     stream_id: str
@@ -59,8 +62,45 @@ class StreamContext:
     last_message_time: float | None = None
     message_buffer_skip_count: int = 0
 
+    # 免打扰状态
+    do_not_disturb_until: float | None = None
+    do_not_disturb_reason: str | None = None
+    do_not_disturb_trigger_message_id: str | None = None
+
     # 流循环任务引用
     stream_loop_task: asyncio.Task | None = field(default=None, repr=False)
+
+    def is_do_not_disturb_active(self, now: float | None = None) -> bool:
+        """检查当前流是否处于免打扰状态。
+
+        Args:
+            now: 可选的当前时间戳；未提供时使用 ``time.time()``。
+
+        Returns:
+            bool: 免打扰未到期时返回 ``True``。
+        """
+        if self.do_not_disturb_until is None:
+            return False
+        current_time = time.time() if now is None else now
+        return current_time < self.do_not_disturb_until
+
+    def set_do_not_disturb(
+        self,
+        *,
+        until: float,
+        reason: str,
+        trigger_message_id: str | None = None,
+    ) -> None:
+        """设置流的免打扰状态。"""
+        self.do_not_disturb_until = until
+        self.do_not_disturb_reason = reason
+        self.do_not_disturb_trigger_message_id = trigger_message_id
+
+    def clear_do_not_disturb(self) -> None:
+        """清空流的免打扰状态。"""
+        self.do_not_disturb_until = None
+        self.do_not_disturb_reason = None
+        self.do_not_disturb_trigger_message_id = None
 
     def add_unread_message(self, message: "Message") -> None:
         """添加未读消息。

--- a/test/core/managers/test_stream_manager_get_or_create.py
+++ b/test/core/managers/test_stream_manager_get_or_create.py
@@ -8,6 +8,7 @@ import pytest
 
 from src.core.managers.stream_manager import _serialize_content_for_db
 from src.core.models.message import Message
+from src.core.models.stream import ChatStream
 
 
 @pytest.mark.asyncio
@@ -132,6 +133,45 @@ async def test_add_message_persists_sender_person_id() -> None:
 
     created_data = manager._messages_crud.create.await_args.args[0]
     assert created_data["person_id"] == "hash_qq_user_123"
+
+
+@pytest.mark.asyncio
+async def test_add_received_message_to_history_moves_message_without_unread() -> None:
+    """静默落历史时，消息应写入 history 且从 unread 中移除。"""
+    from src.core.managers.stream_manager import StreamManager
+
+    manager = StreamManager()
+    manager._messages_crud.get_by = AsyncMock(return_value=None)
+    manager._messages_crud.create = AsyncMock(return_value=SimpleNamespace(id=1))
+    manager._streams_crud.get_by = AsyncMock(return_value=SimpleNamespace(id=1))
+    manager._streams_crud.update = AsyncMock(return_value=None)
+
+    stream_id = "stream-history-001"
+    chat_stream = ChatStream(
+        stream_id=stream_id,
+        platform="qq",
+        chat_type="private",
+    )
+    manager._streams[stream_id] = chat_stream
+
+    message = Message(
+        message_id="m-history-001",
+        content="我先忙一下",
+        processed_plain_text="我先忙一下",
+        sender_id="user_123",
+        sender_name="Alice",
+        platform="qq",
+        chat_type="private",
+        stream_id=stream_id,
+        person_id="hash_qq_user_123",
+    )
+    chat_stream.context.add_unread_message(message)
+
+    await manager.add_received_message_to_history(message)
+
+    assert chat_stream.context.unread_messages == []
+    assert len(chat_stream.context.history_messages) == 1
+    assert chat_stream.context.history_messages[0].message_id == "m-history-001"
 
 
 @pytest.mark.asyncio

--- a/test/core/models/test_stream.py
+++ b/test/core/models/test_stream.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from unittest.mock import MagicMock
 
 import pytest
@@ -173,6 +174,28 @@ class TestStreamContext:
 
         assert isinstance(context.message_cache, deque)
         assert context.is_cache_enabled is False
+
+    def test_do_not_disturb_helpers(self):
+        """测试免打扰状态的设置、判定与清空。"""
+        context = StreamContext(stream_id="test")
+        until = time.time() + 60
+
+        context.set_do_not_disturb(
+            until=until,
+            reason="我先忙一下",
+            trigger_message_id="msg-001",
+        )
+
+        assert context.is_do_not_disturb_active(until - 1) is True
+        assert context.is_do_not_disturb_active(until + 1) is False
+        assert context.do_not_disturb_reason == "我先忙一下"
+        assert context.do_not_disturb_trigger_message_id == "msg-001"
+
+        context.clear_do_not_disturb()
+
+        assert context.do_not_disturb_until is None
+        assert context.do_not_disturb_reason is None
+        assert context.do_not_disturb_trigger_message_id is None
 
 
 class TestChatStream:

--- a/test/plugins/disturbance_guard/test_event_handler.py
+++ b/test/plugins/disturbance_guard/test_event_handler.py
@@ -1,0 +1,66 @@
+"""disturbance_guard 事件处理器测试。"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from plugins.disturbance_guard.config import DisturbanceGuardConfig
+from plugins.disturbance_guard.event_handler import DisturbanceGuardMessageHandler
+from plugins.disturbance_guard.service import DisturbanceGuardDecision
+from src.core.models.message import Message
+from src.kernel.event import EventDecision
+
+
+def _make_plugin() -> Any:
+    """创建最小插件桩。"""
+    return cast(Any, SimpleNamespace(config=DisturbanceGuardConfig()))
+
+
+def _make_message() -> Message:
+    """创建测试消息。"""
+    return Message(
+        message_id="msg-001",
+        content="我先忙一下",
+        processed_plain_text="我先忙一下",
+        sender_id="user-001",
+        sender_name="Alice",
+        platform="qq",
+        chat_type="private",
+        stream_id="stream-001",
+    )
+
+
+@pytest.mark.asyncio
+async def test_event_handler_returns_stop_when_service_requests_suppress() -> None:
+    """服务要求静默时，事件处理器应短路后续消息分发。"""
+    handler = DisturbanceGuardMessageHandler(_make_plugin())
+    params = {"message": _make_message(), "envelope": {}, "adapter_signature": "adapter:test"}
+
+    with patch(
+        "plugins.disturbance_guard.event_handler.DisturbanceGuardService.handle_message",
+        new=AsyncMock(return_value=DisturbanceGuardDecision(True, "quiet intent matched")),
+    ):
+        decision, out = await handler.execute("on_message_received", params)
+
+    assert decision is EventDecision.STOP
+    assert out is params
+
+
+@pytest.mark.asyncio
+async def test_event_handler_returns_pass_when_service_allows_message() -> None:
+    """服务放行时，事件处理器应返回 PASS。"""
+    handler = DisturbanceGuardMessageHandler(_make_plugin())
+    params = {"message": _make_message(), "envelope": {}, "adapter_signature": "adapter:test"}
+
+    with patch(
+        "plugins.disturbance_guard.event_handler.DisturbanceGuardService.handle_message",
+        new=AsyncMock(return_value=DisturbanceGuardDecision(False, "wake intent matched")),
+    ):
+        decision, out = await handler.execute("on_message_received", params)
+
+    assert decision is EventDecision.PASS
+    assert out is params

--- a/test/plugins/disturbance_guard/test_service.py
+++ b/test/plugins/disturbance_guard/test_service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -41,48 +41,54 @@ def _make_message(
     )
 
 
-@pytest.mark.asyncio
-async def test_handle_message_enters_quiet_mode_on_quiet_intent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """命中免打扰话术时，应进入免打扰并静默吞掉当前消息。"""
-    service = _make_service()
-    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
-    fake_manager = SimpleNamespace(
+def _make_fake_manager(
+    chat_stream: ChatStream,
+    *,
+    dnd_active: bool = False,
+) -> SimpleNamespace:
+    """创建带完整 StreamManager API 的 fake 对象。"""
+    return SimpleNamespace(
         get_or_create_stream=AsyncMock(return_value=chat_stream),
         add_received_message_to_history=AsyncMock(return_value=None),
+        is_stream_do_not_disturb_active=MagicMock(return_value=dnd_active),
+        set_stream_do_not_disturb=MagicMock(),
+        clear_stream_do_not_disturb=MagicMock(),
     )
+
+
+@pytest.mark.asyncio
+async def test_handle_message_enters_quiet_mode_on_quiet_intent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """命中免打扰话术时，应通过 StreamManager 设置免打扰并静默吞掉当前消息。"""
+    service = _make_service()
+    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
+    fake_manager = _make_fake_manager(chat_stream)
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 
     message = _make_message(text="我先忙一下")
     decision = await service.handle_message(message)
 
     assert decision.should_suppress is True
-    assert chat_stream.context.do_not_disturb_until is not None
-    assert chat_stream.context.do_not_disturb_until > time.time()
-    assert chat_stream.context.do_not_disturb_trigger_message_id == message.message_id
+    fake_manager.set_stream_do_not_disturb.assert_called_once()
+    call_kwargs = fake_manager.set_stream_do_not_disturb.call_args
+    assert call_kwargs[0][0] == "stream-001"
+    assert call_kwargs[1]["trigger_message_id"] == message.message_id
+    assert call_kwargs[1]["until"] > time.time()
     fake_manager.add_received_message_to_history.assert_awaited_once_with(message)
 
 
 @pytest.mark.asyncio
 async def test_handle_message_clears_quiet_mode_on_wake_intent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """免打扰期间命中唤醒词时，应清空状态并放行消息。"""
+    """免打扰期间命中唤醒词时，应通过 StreamManager 清空状态并放行消息。"""
     service = _make_service()
     chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
-    chat_stream.context.set_do_not_disturb(
-        until=time.time() + 60,
-        reason="我先忙",
-        trigger_message_id="msg-old",
-    )
-    fake_manager = SimpleNamespace(
-        get_or_create_stream=AsyncMock(return_value=chat_stream),
-        add_received_message_to_history=AsyncMock(return_value=None),
-    )
+    fake_manager = _make_fake_manager(chat_stream, dnd_active=True)
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 
     message = _make_message(text="我回来了")
     decision = await service.handle_message(message)
 
     assert decision.should_suppress is False
-    assert chat_stream.context.do_not_disturb_until is None
+    fake_manager.clear_stream_do_not_disturb.assert_called_with("stream-001")
     fake_manager.add_received_message_to_history.assert_not_called()
 
 
@@ -91,15 +97,7 @@ async def test_handle_message_suppresses_normal_message_when_quiet_active(monkey
     """免打扰期间收到普通消息时，应静默写历史而不是放行。"""
     service = _make_service()
     chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
-    chat_stream.context.set_do_not_disturb(
-        until=time.time() + 60,
-        reason="我先忙",
-        trigger_message_id="msg-old",
-    )
-    fake_manager = SimpleNamespace(
-        get_or_create_stream=AsyncMock(return_value=chat_stream),
-        add_received_message_to_history=AsyncMock(return_value=None),
-    )
+    fake_manager = _make_fake_manager(chat_stream, dnd_active=True)
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 
     message = _make_message(text="你在干嘛")
@@ -116,6 +114,9 @@ async def test_handle_message_ignores_group_message_by_default(monkeypatch: pyte
     fake_manager = SimpleNamespace(
         get_or_create_stream=AsyncMock(),
         add_received_message_to_history=AsyncMock(return_value=None),
+        is_stream_do_not_disturb_active=MagicMock(return_value=False),
+        set_stream_do_not_disturb=MagicMock(),
+        clear_stream_do_not_disturb=MagicMock(),
     )
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 

--- a/test/plugins/disturbance_guard/test_service.py
+++ b/test/plugins/disturbance_guard/test_service.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 from types import SimpleNamespace
 from typing import Any, cast
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from plugins.disturbance_guard.config import DisturbanceGuardConfig
-from plugins.disturbance_guard.service import DisturbanceGuardService
+from plugins.disturbance_guard.service import DisturbanceGuardService, _Intent
 from src.core.models.message import Message
 from src.core.models.stream import ChatStream
 
@@ -58,14 +59,16 @@ def _make_fake_manager(
 
 @pytest.mark.asyncio
 async def test_handle_message_enters_quiet_mode_on_quiet_intent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """命中免打扰话术时，应通过 StreamManager 设置免打扰并静默吞掉当前消息。"""
+    """LLM 判定为 quiet 时，应通过 StreamManager 设置免打扰并静默吞掉当前消息。"""
     service = _make_service()
     chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
     fake_manager = _make_fake_manager(chat_stream)
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 
     message = _make_message(text="我先忙一下")
-    decision = await service.handle_message(message)
+
+    with patch.object(service, "_classify_intent", AsyncMock(return_value=_Intent.QUIET)):
+        decision = await service.handle_message(message)
 
     assert decision.should_suppress is True
     fake_manager.set_stream_do_not_disturb.assert_called_once()
@@ -78,14 +81,16 @@ async def test_handle_message_enters_quiet_mode_on_quiet_intent(monkeypatch: pyt
 
 @pytest.mark.asyncio
 async def test_handle_message_clears_quiet_mode_on_wake_intent(monkeypatch: pytest.MonkeyPatch) -> None:
-    """免打扰期间命中唤醒词时，应通过 StreamManager 清空状态并放行消息。"""
+    """免打扰期间 LLM 判定为 wake 时，应通过 StreamManager 清空状态并放行消息。"""
     service = _make_service()
     chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
     fake_manager = _make_fake_manager(chat_stream, dnd_active=True)
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 
     message = _make_message(text="我回来了")
-    decision = await service.handle_message(message)
+
+    with patch.object(service, "_classify_intent", AsyncMock(return_value=_Intent.WAKE)):
+        decision = await service.handle_message(message)
 
     assert decision.should_suppress is False
     fake_manager.clear_stream_do_not_disturb.assert_called_with("stream-001")
@@ -94,14 +99,16 @@ async def test_handle_message_clears_quiet_mode_on_wake_intent(monkeypatch: pyte
 
 @pytest.mark.asyncio
 async def test_handle_message_suppresses_normal_message_when_quiet_active(monkeypatch: pytest.MonkeyPatch) -> None:
-    """免打扰期间收到普通消息时，应静默写历史而不是放行。"""
+    """免打扰期间 LLM 判定为 none 时，应静默写历史而不是放行。"""
     service = _make_service()
     chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
     fake_manager = _make_fake_manager(chat_stream, dnd_active=True)
     monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
 
     message = _make_message(text="你在干嘛")
-    decision = await service.handle_message(message)
+
+    with patch.object(service, "_classify_intent", AsyncMock(return_value=_Intent.NONE)):
+        decision = await service.handle_message(message)
 
     assert decision.should_suppress is True
     fake_manager.add_received_message_to_history.assert_awaited_once_with(message)
@@ -126,3 +133,130 @@ async def test_handle_message_ignores_group_message_by_default(monkeypatch: pyte
     assert decision.should_suppress is False
     fake_manager.get_or_create_stream.assert_not_called()
     fake_manager.add_received_message_to_history.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_passes_when_llm_returns_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM 判定为 none 且不在免打扰状态时，应放行消息。"""
+    service = _make_service()
+    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
+    fake_manager = _make_fake_manager(chat_stream)
+    monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
+
+    message = _make_message(text="今天天气真好")
+
+    with patch.object(service, "_classify_intent", AsyncMock(return_value=_Intent.NONE)):
+        decision = await service.handle_message(message)
+
+    assert decision.should_suppress is False
+    assert decision.reason == "no quiet intent matched"
+    fake_manager.set_stream_do_not_disturb.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_returns_pass_when_plugin_disabled() -> None:
+    """插件被禁用时，应直接放行，不做任何判定。"""
+    config = DisturbanceGuardConfig()
+    config.plugin.enabled = False
+    plugin = SimpleNamespace(config=config)
+    service = DisturbanceGuardService(plugin=cast(Any, plugin))
+
+    message = _make_message(text="我先忙一下")
+    decision = await service.handle_message(message)
+
+    assert decision.should_suppress is False
+    assert decision.reason == "plugin disabled"
+
+
+@pytest.mark.asyncio
+async def test_handle_message_returns_pass_when_text_is_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+    """消息文本为空时，应直接放行。"""
+    service = _make_service()
+    message = _make_message(text="")
+    # processed_plain_text 和 content 都为空
+    message.processed_plain_text = ""
+    message.content = ""
+
+    decision = await service.handle_message(message)
+
+    assert decision.should_suppress is False
+    assert decision.reason == "empty text"
+
+
+@pytest.mark.asyncio
+async def test_classify_intent_returns_none_on_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM 调用超时时，_classify_intent 应降级返回 NONE。"""
+    service = _make_service()
+
+    async def _fake_send(*, stream: bool = True) -> str:
+        raise asyncio.TimeoutError
+
+    mock_request = MagicMock()
+    mock_request.add_payload = MagicMock()
+    mock_request.send = _fake_send
+
+    monkeypatch.setattr(
+        "plugins.disturbance_guard.service.LLMRequest",
+        lambda *a, **kw: mock_request,
+    )
+    monkeypatch.setattr(
+        "src.core.config.get_model_config",
+        lambda: SimpleNamespace(get_task=lambda name: []),
+    )
+
+    result = await service._classify_intent("我先忙一下")
+    assert result is _Intent.NONE
+
+
+@pytest.mark.asyncio
+async def test_classify_intent_returns_none_on_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """LLM 调用抛出异常时，_classify_intent 应降级返回 NONE。"""
+    service = _make_service()
+
+    async def _fake_send(*, stream: bool = True) -> str:
+        raise RuntimeError("connection refused")
+
+    mock_request = MagicMock()
+    mock_request.add_payload = MagicMock()
+    mock_request.send = _fake_send
+
+    monkeypatch.setattr(
+        "plugins.disturbance_guard.service.LLMRequest",
+        lambda *a, **kw: mock_request,
+    )
+    monkeypatch.setattr(
+        "src.core.config.get_model_config",
+        lambda: SimpleNamespace(get_task=lambda name: []),
+    )
+
+    result = await service._classify_intent("测试")
+    assert result is _Intent.NONE
+
+
+@pytest.mark.asyncio
+async def test_handle_message_clears_expired_dnd(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DND 已过期时，应调用 clear 清理残留字段后正常判定。"""
+    service = _make_service()
+    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
+    # dnd_active=False 模拟已过期
+    fake_manager = _make_fake_manager(chat_stream, dnd_active=False)
+    monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
+
+    message = _make_message(text="今天天气真好")
+
+    with patch.object(service, "_classify_intent", AsyncMock(return_value=_Intent.NONE)):
+        decision = await service.handle_message(message)
+
+    # 过期后应调用 clear 清理残留
+    fake_manager.clear_stream_do_not_disturb.assert_called_with("stream-001")
+    assert decision.should_suppress is False
+
+
+@pytest.mark.asyncio
+async def test_get_config_raises_on_wrong_type() -> None:
+    """插件配置类型不匹配时应抛出 TypeError。"""
+    plugin = SimpleNamespace(config="not_a_config")
+    service = DisturbanceGuardService(plugin=cast(Any, plugin))
+
+    with pytest.raises(TypeError, match="disturbance_guard 插件配置类型错误"):
+        service._get_config()

--- a/test/plugins/disturbance_guard/test_service.py
+++ b/test/plugins/disturbance_guard/test_service.py
@@ -1,0 +1,127 @@
+"""disturbance_guard 服务层测试。"""
+
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock
+
+import pytest
+
+from plugins.disturbance_guard.config import DisturbanceGuardConfig
+from plugins.disturbance_guard.service import DisturbanceGuardService
+from src.core.models.message import Message
+from src.core.models.stream import ChatStream
+
+
+def _make_service() -> DisturbanceGuardService:
+    """创建带最小配置的打扰感知服务。"""
+    config = DisturbanceGuardConfig()
+    plugin = SimpleNamespace(config=config)
+    return DisturbanceGuardService(plugin=cast(Any, plugin))
+
+
+def _make_message(
+    *,
+    text: str,
+    chat_type: str = "private",
+    stream_id: str = "stream-001",
+) -> Message:
+    """创建测试消息。"""
+    return Message(
+        message_id=f"msg-{text}",
+        content=text,
+        processed_plain_text=text,
+        sender_id="user-001",
+        sender_name="Alice",
+        platform="qq",
+        chat_type=chat_type,
+        stream_id=stream_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_handle_message_enters_quiet_mode_on_quiet_intent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """命中免打扰话术时，应进入免打扰并静默吞掉当前消息。"""
+    service = _make_service()
+    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
+    fake_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(return_value=chat_stream),
+        add_received_message_to_history=AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
+
+    message = _make_message(text="我先忙一下")
+    decision = await service.handle_message(message)
+
+    assert decision.should_suppress is True
+    assert chat_stream.context.do_not_disturb_until is not None
+    assert chat_stream.context.do_not_disturb_until > time.time()
+    assert chat_stream.context.do_not_disturb_trigger_message_id == message.message_id
+    fake_manager.add_received_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_handle_message_clears_quiet_mode_on_wake_intent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """免打扰期间命中唤醒词时，应清空状态并放行消息。"""
+    service = _make_service()
+    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
+    chat_stream.context.set_do_not_disturb(
+        until=time.time() + 60,
+        reason="我先忙",
+        trigger_message_id="msg-old",
+    )
+    fake_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(return_value=chat_stream),
+        add_received_message_to_history=AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
+
+    message = _make_message(text="我回来了")
+    decision = await service.handle_message(message)
+
+    assert decision.should_suppress is False
+    assert chat_stream.context.do_not_disturb_until is None
+    fake_manager.add_received_message_to_history.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_handle_message_suppresses_normal_message_when_quiet_active(monkeypatch: pytest.MonkeyPatch) -> None:
+    """免打扰期间收到普通消息时，应静默写历史而不是放行。"""
+    service = _make_service()
+    chat_stream = ChatStream(stream_id="stream-001", platform="qq", chat_type="private")
+    chat_stream.context.set_do_not_disturb(
+        until=time.time() + 60,
+        reason="我先忙",
+        trigger_message_id="msg-old",
+    )
+    fake_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(return_value=chat_stream),
+        add_received_message_to_history=AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
+
+    message = _make_message(text="你在干嘛")
+    decision = await service.handle_message(message)
+
+    assert decision.should_suppress is True
+    fake_manager.add_received_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_handle_message_ignores_group_message_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """默认配置下，群聊不启用打扰感知。"""
+    service = _make_service()
+    fake_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(),
+        add_received_message_to_history=AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr("src.core.managers.get_stream_manager", lambda: fake_manager)
+
+    message = _make_message(text="我先忙一下", chat_type="group", stream_id="stream-group-001")
+    decision = await service.handle_message(message)
+
+    assert decision.should_suppress is False
+    fake_manager.get_or_create_stream.assert_not_called()
+    fake_manager.add_received_message_to_history.assert_not_called()


### PR DESCRIPTION
### feat(plugin/disturbance_guard): 新增打扰感知插件，支持 LLM 意图识别与会话静默

### 变更类型
- [x] 新特性 (New Feature)
- [x] 测试用例 (Tests)

### 架构与功能实现
遵循三层架构与组件职责划分：

1. **事件层拦截**：
   - 订阅 `ON_MESSAGE_RECEIVED` 事件。
   - 命中免打扰逻辑时返回 `EventDecision.STOP` 阻断向 Chatter 的分发，否则返回 `PASS`。
2. **LLM 意图判定**：
   - 服务层使用极简 System Prompt 约束模型（默认任务 `utils_small`）输出 `quiet`、`wake` 或 `none`。
   - **容错降级**：包含网络超时与异常捕获。若 LLM 判断失败，降级为 `none` 放行，绝不阻塞主消息链路。
3. **状态管理收口**：
   - 不越权操作数据。统一通过 `StreamManager` 的公共 API（`set/clear/is_stream_do_not_disturb`）维护流状态。
   - 免打扰期间的消息，调用 `add_received_message_to_history` 静默持久化，确保记忆不丢失。
4. **配置防错**：
   - 强类型校验。配置组装错误时直接抛出 `TypeError` 防止带病运行。考虑到 Token 开销，默认仅在私聊生效，群聊默认关闭。

### 测试情况
在 disturbance_guard 补齐了全量用例，全部通过（13/13）：
- **主链路**：命中 `quiet` 进入静默，命中 `wake` 清除静默。
- **状态维持**：免打扰期间不仅拦截处理，且正确写入历史记录。
- **异常边界**：空消息防范、通过配置禁用插件、群聊跳过、DND 状态到期自动清理。
- **系统容错**：覆盖了 LLM 抛出 `TimeoutError` 及普通 `Exception` 时，服务能安全放行。安全降级并放行消息的路径。

## Summary by Sourcery

Introduce a disturbance-aware plugin that uses LLM-based intent detection to control per-stream do-not-disturb state and silently persist messages during quiet periods.

New Features:
- Add disturbance_guard plugin with event handler to intercept incoming messages and decide whether to suppress or pass them based on user intent.
- Add LLM-backed service to classify messages as quiet, wake, or none and manage per-stream do-not-disturb windows via StreamManager.
- Introduce configuration schema for disturbance_guard to control enablement, scope, model task, timeout, and quiet duration.

Enhancements:
- Extend StreamManager and StreamContext with do-not-disturb state management APIs and helpers, plus support for silently persisting received messages without marking them unread.

Tests:
- Add unit tests for StreamContext do-not-disturb helpers and StreamManager silent history persistence behavior.
- Add service-layer tests covering disturbance_guard intent handling, error/timeout fallbacks, scope and configuration behavior, and stream state interactions.
- Add event handler tests to ensure disturbance_guard correctly converts service decisions into event STOP/PASS outcomes.