### PR TITLE
feat(plugin_system): 将 Stop 导出到 plugin_system.base 公开 API

### DIFF
--- a/src/app/plugin_system/base/__init__.py
+++ b/src/app/plugin_system/base/__init__.py
@@ -14,6 +14,7 @@ from src.core.components.base import (
     BaseTool,
     CommandNode,
     Failure,
+    Stop,
     Success,
     Wait,
 )
@@ -40,6 +41,7 @@ __all__ = [
     "SectionBase",
     "config_section",
     "Failure",
+    "Stop",
     "Success",
     "Wait",
 ]


### PR DESCRIPTION
## 变更说明

`Stop` 是 `Chatter.execute()` 的合法返回值（与 `Failure`、`Success`、`Wait` 并列），表示聊天器请求停用自身。

### 问题

在 `plugin_system.base` 未导出 `Stop` 之前，插件开发者若需要使用 `Stop` 返回值，只能直接从内部模块导入：

```python
# 违规写法（违反插件开发规范）
from src.core.components.base import Stop
```

这违反了插件开发规范中"插件只能通过 `src.app.plugin_system.base` 访问框架能力"的要求。

### 解决方案

将 `Stop` 添加到 `src/app/plugin_system/base/__init__.py` 的导入和 `__all__` 列表中：

```python
# 规范写法
from src.app.plugin_system.base import Stop
```

### 变更文件

- `src/app/plugin_system/base/__init__.py`：新增 `Stop` 导入及 `__all__` 导出

### 测试

变更已通过 `ruff check` 静态分析检查（无新增警告）。

## Summary by Sourcery

Export the Stop result type through the public plugin_system.base API and enhance the Booku memory plugin’s time-related metadata and retrieval behavior.

New Features:
- Expose Stop in the plugin_system.base public API for use by plugins.
- Include human-readable created_at_readable and updated_at_readable timestamps in Booku memory record metadata.

Enhancements:
- Strengthen Booku memory read agent prompting to enforce two-layer (emergent + archived) retrieval and to use readable timestamps for recency judgments.
- Tighten Booku memory write agent prompting with mandatory absolute-date recording for time-sensitive memories.
- Change Booku memory grep tool defaults so archived memories are searched by default.