### PR TITLE
refactor: 使用 asyncio.to_thread 优化文件读取和编码操作, 避免阻塞异步任务事件循环

### DIFF
--- a/plugins/booku_memory/service/booku_knowledge_service.py
+++ b/plugins/booku_memory/service/booku_knowledge_service.py
@@ -690,9 +690,9 @@ class BookuKnowledgeService(BaseService):
             suffix = resolved_path.suffix.lower()
             is_markdown = suffix in {".md", ".markdown"}
             if suffix in {".txt", ".md", ".markdown", ".json", ".csv", ".log"}:
-                text = resolved_path.read_text(encoding="utf-8", errors="ignore")
+                text = await asyncio.to_thread(resolved_path.read_text, encoding="utf-8", errors="ignore")
             elif suffix == ".docx":
-                text = _extract_docx_text(resolved_path)
+                text = await asyncio.to_thread(_extract_docx_text, resolved_path)
             else:
                 raise ValueError("仅支持 txt/md/json/csv/log/docx 文件上传")
             if not title.strip():

--- a/plugins/emoji_sender/service.py
+++ b/plugins/emoji_sender/service.py
@@ -483,20 +483,6 @@ class EmojiSenderService(BaseService):
             return None
         return random.choice(candidates)
 
-    async def _already_ingested(self, source_hash: str) -> bool:
-        """检查某个表情包（按 hash）是否已入库。"""
-        vdb = self._vector_db()
-        collection = self._collection_name()
-        await vdb.get_or_create_collection(collection)
-        data = await vdb.get(
-            collection_name=collection,
-            where={"source_hash": source_hash},
-            limit=1,
-            include=["metadatas"],
-        )
-        ids: list[str] = list(data.get("ids") or [])
-        return bool(ids)
-
     async def _vlm_decide_and_label(
         self,
         *,
@@ -632,7 +618,7 @@ class EmojiSenderService(BaseService):
                 return
 
             try:
-                payload = source.read_bytes()
+                payload = await asyncio.to_thread(source.read_bytes)
             except Exception as e:
                 logger.warning(f"读取候选表情包失败: {source} - {e}")
                 return
@@ -644,7 +630,7 @@ class EmojiSenderService(BaseService):
             # 压缩图片用于 VLM
             try:
                 mime = self._guess_mime(source.suffix)
-                vlm_bytes, vlm_mime, is_gif_collage = self._compress_image_for_vlm(payload, mime)
+                vlm_bytes, vlm_mime, is_gif_collage = await asyncio.to_thread(self._compress_image_for_vlm, payload, mime)
             except Exception as e:
                 logger.warning(f"压缩图片失败: {source} - {e}")
                 return

--- a/plugins/napcat_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/napcat_adapter/src/handlers/to_core/message_handler.py
@@ -232,9 +232,6 @@ class MessageHandler:
 
         try:
             image_base64 = await get_image_base64(image_url)
-        except TimeoutError:
-            logger.error(f"图片消息处理超时: {image_url}")
-            return {"type": "text", "data": "[图片处理超时]"}
         except Exception as e:
             logger.error(f"图片消息处理失败: {e!s}")
             return None

--- a/plugins/napcat_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/napcat_adapter/src/handlers/to_core/message_handler.py
@@ -231,8 +231,7 @@ class MessageHandler:
             return None
 
         try:
-            async with asyncio.timeout(10): # 兜底超时处理
-                image_base64 = await get_image_base64(image_url)
+            image_base64 = await get_image_base64(image_url)
         except TimeoutError:
             logger.error(f"图片消息处理超时: {image_url}")
             return {"type": "text", "data": "[图片处理超时]"}
@@ -353,7 +352,8 @@ class MessageHandler:
             if file_path and Path(file_path).exists():
                 # 本地文件处理
                 video_data = await asyncio.to_thread(Path(file_path).read_bytes)
-                video_base64 = base64.b64encode(video_data).decode("utf-8")
+                video_base64 = await asyncio.to_thread(base64.b64encode, video_data)
+                video_base64 = video_base64.decode("utf-8")
                 logger.debug(f"视频文件大小: {len(video_data) / (1024 * 1024):.2f} MB")
 
                 return {
@@ -377,7 +377,8 @@ class MessageHandler:
                     logger.warning(f"视频下载失败: {download_result.get('error', '未知错误')}")
                     return {"type": "text", "data": f"[视频消息] ({download_result.get('error', '下载失败')})"}
 
-                video_base64 = base64.b64encode(download_result["data"]).decode("utf-8")
+                video_base64 = await asyncio.to_thread(base64.b64encode, download_result["data"])
+                video_base64 = video_base64.decode("utf-8")
                 logger.debug(f"视频下载成功，大小: {len(download_result['data']) / (1024 * 1024):.2f} MB")
 
                 return {

--- a/plugins/napcat_adapter/src/handlers/utils.py
+++ b/plugins/napcat_adapter/src/handlers/utils.py
@@ -257,7 +257,7 @@ async def get_image_base64(url: str) -> str:
 
         if not image_bytes:
             raise ValueError("图片内容为空")
-        return base64.b64encode(image_bytes).decode("utf-8")
+        return (await asyncio.to_thread(base64.b64encode, image_bytes)).decode("utf-8")
     except httpx.TimeoutException as e:
         logger.error(f"图片下载超时: {e!s}")
         raise


### PR DESCRIPTION
## Summary by Sourcery

Use asyncio.to_thread to offload blocking file I/O and CPU-bound encoding/compression in media and document handling to avoid blocking the event loop.

Enhancements:
- Offload file reading and image compression in emoji ingestion to background threads to keep async tasks responsive.
- Offload video file reading and base64 encoding to background threads in Napcat message handling for images and videos.
- Offload text and DOCX extraction in document ingestion to background threads to prevent blocking on large files.
- Simplify image message handling timeout logic while centralizing base64 encoding work in a thread pool.
- Remove an unused ingestion-helper method from the emoji sender service.