### PR TITLE
fix: config 渲染多行默认值时注释行产生非法 TOML

### DIFF
--- a/src/kernel/config/core.py
+++ b/src/kernel/config/core.py
@@ -947,8 +947,14 @@ def _render_section_block(
 
         sig_parts = [f"值类型：{type_text}"]
         if default_text is not None:
-            # 多行默认值不能嵌进单行注释，用占位文字代替
-            display_default = "（多行默认值）" if "\n" in default_text else default_text
+            # 多行默认值不能嵌进单行注释，只显示第一行内容并加 ... 省略
+            # TOML 多行字符串格式为 '"""\n{内容}"""'，第 0 行是 '"""'，第 1 行才是第一行内容
+            if "\n" in default_text:
+                parts = default_text.split("\n")
+                first_line = parts[1] if len(parts) > 1 else ""
+                display_default = f'"{first_line}..."'
+            else:
+                display_default = default_text
             sig_parts.append(f"默认值：{display_default}")
         else:
             sig_parts.append("默认值：<必填>")  # 无默认值的必填字段标记

--- a/src/kernel/config/core.py
+++ b/src/kernel/config/core.py
@@ -947,7 +947,9 @@ def _render_section_block(
 
         sig_parts = [f"值类型：{type_text}"]
         if default_text is not None:
-            sig_parts.append(f"默认值：{default_text}")
+            # 多行默认值不能嵌进单行注释，用占位文字代替
+            display_default = "（多行默认值）" if "\n" in default_text else default_text
+            sig_parts.append(f"默认值：{display_default}")
         else:
             sig_parts.append("默认值：<必填>")  # 无默认值的必填字段标记
 

--- a/test/kernel/test_config.py
+++ b/test/kernel/test_config.py
@@ -575,7 +575,11 @@ foo = \"bar\"
             shutil.rmtree(temp_dir)
 
     def test_multiline_default_generates_valid_toml_and_comment(self) -> None:
-        """测试 Field(default=多行字符串) 时，生成的 TOML 合法且注释使用占位文字。"""
+        """测试 Field(default=多行字符串) 时，生成的 TOML 合法且注释只显示第一行加 ..."""
+        import shutil
+        import tempfile
+        import tomllib
+        from pathlib import Path
 
         class MultilineConfig(ConfigBase):
             @config_section("general")
@@ -602,16 +606,20 @@ foo = \"bar\"
 
             content = config_file.read_text(encoding="utf-8")
 
-            # 文件必须是合法 TOML（不会抛出异常）
-            import tomllib
+            # 文件必须是合法 TOML
             parsed = tomllib.loads(content)
             assert parsed["general"]["instructions"] == "第一行\n第二行\n第三行"
 
-            # 签名注释行应使用占位文字而非多行文本
-            assert "# 值类型：str, 默认值：（多行默认值）" in content
+            # 签名注释应显示第一行内容加 ...
+            assert '# 值类型：str, 默认值："第一行..."' in content
 
             # 单行默认值的字段不受影响
             assert '# 值类型：str, 默认值："hello"' in content
+
+            # 确保注释行中不会泄露多行默认值的完整原始内容
+            for line in content.splitlines():
+                if line.lstrip().startswith("#"):
+                    assert "第二行" not in line
         finally:
             shutil.rmtree(temp_dir)
 

--- a/test/kernel/test_config.py
+++ b/test/kernel/test_config.py
@@ -559,8 +559,9 @@ foo = \"bar\"
             assert "# 数据库端口" in updated
             assert "# 功能开关配置" in updated
 
-            # 签名注释应存在
-            assert "# signature:" in updated
+            # 签名注释应存在（类型+默认值格式）
+            assert "# 值类型：str, 默认值：" in updated
+            assert "# 值类型：int, 默认值：" in updated
 
             # 多余节/字段被移除
             assert "[unused]" not in updated
@@ -570,6 +571,47 @@ foo = \"bar\"
             assert 'host = "db.example.com"' in updated
             assert "port = 3306" in updated
             assert "enable_cache = false" in updated
+        finally:
+            shutil.rmtree(temp_dir)
+
+    def test_multiline_default_generates_valid_toml_and_comment(self) -> None:
+        """测试 Field(default=多行字符串) 时，生成的 TOML 合法且注释使用占位文字。"""
+
+        class MultilineConfig(ConfigBase):
+            @config_section("general")
+            class GeneralSection(SectionBase):
+                """通用配置"""
+
+                name: str = Field(default="hello", description="名称")
+                instructions: str = Field(
+                    default="第一行\n第二行\n第三行",
+                    description="多行说明",
+                )
+
+            general: GeneralSection = Field(default_factory=GeneralSection)
+
+        temp_dir = tempfile.mkdtemp()
+        try:
+            config_file = Path(temp_dir) / "multiline.toml"
+            config_file.write_text("", encoding="utf-8")
+
+            cfg = MultilineConfig.load(config_file, auto_update=True)
+
+            # 加载的值应为完整多行默认值
+            assert cfg.general.instructions == "第一行\n第二行\n第三行"
+
+            content = config_file.read_text(encoding="utf-8")
+
+            # 文件必须是合法 TOML（不会抛出异常）
+            import tomllib
+            parsed = tomllib.loads(content)
+            assert parsed["general"]["instructions"] == "第一行\n第二行\n第三行"
+
+            # 签名注释行应使用占位文字而非多行文本
+            assert "# 值类型：str, 默认值：（多行默认值）" in content
+
+            # 单行默认值的字段不受影响
+            assert '# 值类型：str, 默认值："hello"' in content
         finally:
             shutil.rmtree(temp_dir)
 


### PR DESCRIPTION
## 问题描述

当插件配置使用 `Field(default=多行字符串)` 时，`_render_section_block` 会将 `_toml_format_value` 返回的多行结果（含换行的 `"""..."""` 格式）直接拼入 `# 注释行`。

注释内的换行导致后续行不以 `#` 开头，生成非法 TOML 文件，插件配置自动生成（`generate_default`）和 `auto_update` 回写时均会触发此问题。

## 修复方案

在 `_render_section_block` 写签名注释前检测 `default_text` 是否含换行：
- 若有 → 注释中用 `（多行默认值）` 占位
- 键值行仍照常输出完整多行文本，实际值不受影响

```python
# 修改前
sig_parts.append(f"默认值：{default_text}")

# 修改后
display_default = "（多行默认值）" if "\n" in default_text else default_text
sig_parts.append(f"默认值：{display_default}")
```

## 变更文件

- `src/kernel/config/core.py` — 修复注释行多行默认值处理逻辑
- `test/kernel/test_config.py` — 新增覆盖本次修复的测试；修复已过时的 `# signature:` 断言（该注释格式在当前实现中不存在）

## 测试结果

```
test/kernel/test_config.py::TestAutoUpdate::test_multiline_default_generates_valid_toml_and_comment PASSED
test/kernel/test_config.py::TestAutoUpdate::test_load_auto_update_rewrites_signature_and_preserves_values PASSED
```

全套 `test/kernel/test_config.py` 除 1 个 pre-existing 失败外均通过，本次改动未引入新失败。

## Summary by Sourcery

Ensure config signature comments remain valid TOML when fields have multiline default values.

Bug Fixes:
- Prevent multiline default values from being inlined into single-line signature comments, which produced invalid TOML.
- Update expectations for auto-update signature comments to match the current type+default format rather than the old `# signature:` marker.

Tests:
- Add regression test verifying that multiline default values generate valid TOML files and use placeholder text in signature comments, while single-line defaults remain unchanged.