### PR TITLE
feat(llm): 新增 Video 多模态内容类型

### DIFF
--- a/src/kernel/llm/__init__.py
+++ b/src/kernel/llm/__init__.py
@@ -23,6 +23,7 @@ from .types import ModelEntry, ModelSet, RequestType
 
 from .payload import (
 	Audio,
+	Video,
 	Content,
 	Image,
 	LLMPayload,

--- a/src/kernel/llm/__init__.py
+++ b/src/kernel/llm/__init__.py
@@ -31,6 +31,7 @@ from .payload import (
 	ToolCall,
 	ToolResult,
 	ToolRegistry,
+	Video,
 )
 
 from .monitor import (
@@ -76,6 +77,7 @@ __all__ = [
 	"Text",
 	"Image",
 	"Audio",
+	"Video",
 	# 工具相关
 	"ToolResult",
 	"ToolCall",

--- a/src/kernel/llm/model_client/openai_client.py
+++ b/src/kernel/llm/model_client/openai_client.py
@@ -367,7 +367,7 @@ def _payloads_to_openai_messages(
                 url = _image_to_data_url(part.value)
                 parts.append({"type": "image_url", "image_url": {"url": url}})
             elif isinstance(part, Video):
-                data_url = f"data:video/mp4;base64,{part.value}"
+                data_url = f"data:{part.mime_type};base64,{part.value}"
                 parts.append({"type": "image_url", "image_url": {"url": data_url}})
             else:
                 parts.append({"type": "text", "text": str(part)})

--- a/src/kernel/llm/model_client/openai_client.py
+++ b/src/kernel/llm/model_client/openai_client.py
@@ -22,6 +22,7 @@ from src.kernel.llm.tool_call_compat import (
 
 from ..exceptions import LLMConfigurationError, LLMContentFilterError
 from ..payload import Image, LLMPayload, Text, ToolCall, ToolResult
+from ..payload.content import Video
 from ..roles import ROLE
 from ..token_counter import count_payload_tokens
 from .base import StreamEvent
@@ -365,6 +366,9 @@ def _payloads_to_openai_messages(
             elif isinstance(part, Image):
                 url = _image_to_data_url(part.value)
                 parts.append({"type": "image_url", "image_url": {"url": url}})
+            elif isinstance(part, Video):
+                data_url = f"data:video/mp4;base64,{part.value}"
+                parts.append({"type": "image_url", "image_url": {"url": data_url}})
             else:
                 parts.append({"type": "text", "text": str(part)})
 

--- a/src/kernel/llm/payload/__init__.py
+++ b/src/kernel/llm/payload/__init__.py
@@ -1,6 +1,6 @@
 """LLM payload models."""
 
-from .content import Audio, Content, File, Image, Text
+from .content import Audio, Content, File, Image, Text, Video
 from .payload import LLMPayload
 from .tooling import LLMUsable, ToolCall, ToolResult, ToolRegistry
 
@@ -9,6 +9,7 @@ __all__ = [
 	"Text",
 	"Image",
 	"Audio",
+	"Video",
 	"File",
 	"ToolResult",
 	"ToolCall",

--- a/src/kernel/llm/payload/content.py
+++ b/src/kernel/llm/payload/content.py
@@ -210,6 +210,7 @@ class Video(File):
     """视频内容，用于多模态 LLM。
 
     继承自 :class:`File`，在构造时将输入统一规范化为纯 base64 字符串。
+    同时记录 MIME 类型（默认 ``video/mp4``），可从 data URL 自动推断。
 
     支持与 :class:`File` 完全相同的三种输入形式：
 
@@ -219,13 +220,38 @@ class Video(File):
 
     示例::
 
-        v1 = Video("clip.mp4")                             # 文件路径
-        v2 = Video(open("clip.mp4", "rb"))                 # 文件对象
-        v3 = Video("data:video/mp4;base64,AAAAB...")       # data URL
-        v4 = Video("AAAAB...")                             # 纯 base64 字符串
+        v1 = Video("clip.mp4")                             # 文件路径，默认 video/mp4
+        v2 = Video("clip.webm", mime_type="video/webm")    # 指定 MIME 类型
+        v3 = Video(open("clip.mp4", "rb"))                 # 文件对象
+        v4 = Video("data:video/webm;base64,AAAAB...")      # data URL，自动推断 mime_type
+        v5 = Video("AAAAB...")                             # 纯 base64 字符串
     """
+
+    __slots__ = ("value", "mime_type")
+
+    mime_type: str
+
+    def __init__(
+        self,
+        source: Union[str, "PathLike[str]", BinaryIO],
+        mime_type: str = "video/mp4",
+    ) -> None:
+        """构造 Video 实例。
+
+        Args:
+            source: 文件路径（str/Path）、文件对象（BinaryIO）或 base64/data URL 字符串。
+            mime_type: 视频 MIME 类型，默认 ``video/mp4``。
+                当 source 为 data URL 时，会自动从中提取 MIME 类型并忽略此参数。
+        """
+        # 从 data URL 自动提取 mime_type
+        if isinstance(source, str) and source.startswith("data:") and ";base64," in source:
+            extracted = source.split(";", 1)[0][len("data:"):]
+            if extracted:
+                mime_type = extracted
+        super().__init__(source)
+        object.__setattr__(self, "mime_type", mime_type)
 
     def __repr__(self) -> str:
         """返回对象的字符串表示。"""
         preview = self.value[:16] + "..." if len(self.value) > 16 else self.value
-        return f"Video(value={preview!r})"
+        return f"Video(mime_type={self.mime_type!r}, value={preview!r})"

--- a/src/kernel/llm/payload/content.py
+++ b/src/kernel/llm/payload/content.py
@@ -204,3 +204,28 @@ class Audio(File):
         """返回对象的字符串表示。"""
         preview = self.value[:16] + "..." if len(self.value) > 16 else self.value
         return f"Audio(value={preview!r})"
+
+
+class Video(File):
+    """视频内容，用于多模态 LLM。
+
+    继承自 :class:`File`，在构造时将输入统一规范化为纯 base64 字符串。
+
+    支持与 :class:`File` 完全相同的三种输入形式：
+
+    - **文件路径**（``str`` 或 ``Path``）：读取视频文件并 base64 编码。
+    - **文件对象**（``BinaryIO``）：读取并编码。
+    - **base64 / data URL / base64| 字符串**：剥离前缀后存储纯 base64。
+
+    示例::
+
+        v1 = Video("clip.mp4")                             # 文件路径
+        v2 = Video(open("clip.mp4", "rb"))                 # 文件对象
+        v3 = Video("data:video/mp4;base64,AAAAB...")       # data URL
+        v4 = Video("AAAAB...")                             # 纯 base64 字符串
+    """
+
+    def __repr__(self) -> str:
+        """返回对象的字符串表示。"""
+        preview = self.value[:16] + "..." if len(self.value) > 16 else self.value
+        return f"Video(value={preview!r})"

--- a/test/kernel/llm/test_content.py
+++ b/test/kernel/llm/test_content.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, Mock
 
 import pytest
 
-from src.kernel.llm.payload.content import Audio, Content, File, Image, Text
+from src.kernel.llm.payload.content import Audio, Content, File, Image, Text, Video
 
 
 class TestContent:
@@ -355,3 +355,64 @@ class TestMixedContent:
         assert len(content_list) == 2
         assert any(isinstance(c, Text) for c in content_list)
         assert any(isinstance(c, Image) for c in content_list)
+
+
+class TestVideo:
+    """Test cases for Video content."""
+
+    def test_video_default_mime_type(self) -> None:
+        """Test that Video defaults to video/mp4 MIME type."""
+        b64 = base64.b64encode(b"fake_video_data").decode("utf-8")
+        video = Video(b64)
+        assert video.mime_type == "video/mp4"
+        assert video.value == b64
+
+    def test_video_infers_mime_type_from_data_url(self) -> None:
+        """Test that Video infers MIME type from data URL."""
+        b64 = base64.b64encode(b"fake_video_data").decode("utf-8")
+        video = Video(f"data:video/webm;base64,{b64}")
+        assert video.mime_type == "video/webm"
+        assert video.value == b64
+
+    def test_video_explicit_mime_type(self) -> None:
+        """Test that Video accepts explicit MIME type."""
+        b64 = base64.b64encode(b"fake_video_data").decode("utf-8")
+        video = Video(b64, mime_type="video/mov")
+        assert video.mime_type == "video/mov"
+
+    def test_video_creation_with_file_path(self, tmp_path: Path) -> None:
+        """Test creating Video with a file path."""
+        video_file = tmp_path / "clip.mp4"
+        video_file.write_bytes(b"\x00\x00\x00\x18ftyp")
+        video = Video(str(video_file))
+        assert video.value == base64.b64encode(b"\x00\x00\x00\x18ftyp").decode("utf-8")
+        assert video.mime_type == "video/mp4"
+
+    def test_video_creation_from_bytesio(self) -> None:
+        """Test creating Video from a BytesIO object."""
+        data = b"fake_video_bytes"
+        video = Video(BytesIO(data))
+        assert video.value == base64.b64encode(data).decode("utf-8")
+
+    def test_video_is_content_subclass(self) -> None:
+        """Test that Video is a Content subclass."""
+        b64 = base64.b64encode(b"x").decode("utf-8")
+        assert isinstance(Video(b64), Content)
+
+    def test_video_is_file_subclass(self) -> None:
+        """Test that Video is also a File subclass."""
+        b64 = base64.b64encode(b"x").decode("utf-8")
+        assert isinstance(Video(b64), File)
+
+    def test_video_is_frozen(self) -> None:
+        """Test that Video is frozen (immutable)."""
+        b64 = base64.b64encode(b"x").decode("utf-8")
+        video = Video(b64)
+        with pytest.raises(AttributeError):
+            video.value = "modified"  # type: ignore[misc]
+
+    def test_video_repr_includes_mime_type(self) -> None:
+        """Test that repr includes mime_type."""
+        b64 = base64.b64encode(b"x").decode("utf-8")
+        video = Video(b64, mime_type="video/webm")
+        assert "video/webm" in repr(video)


### PR DESCRIPTION
## 改动内容

在 `src/kernel/llm/` 中新增 `Video` 多模态内容类型，与现有的 `Image`、`Audio` 类型保持一致的设计风格。

### 文件变动

| 文件 | 改动 |
|------|------|
| `src/kernel/llm/payload/content.py` | 新增 `Video(File)` 类 |
| `src/kernel/llm/payload/__init__.py` | 导出 `Video` |
| `src/kernel/llm/__init__.py` | 导出 `Video` |
| `src/kernel/llm/model_client/openai_client.py` | `_payloads_to_openai_messages` 处理 `Video` payload |

### 设计说明

**`Video` 类**（继承自 `File`）支持三种输入形式：
- 文件路径（`str` 或 `Path`）：读取后 base64 编码
- 文件对象（`BinaryIO`）：读取后编码
- base64 / data URL 字符串：剥离前缀后存储纯 base64

**OpenAI 客户端适配**：`Video` payload 被转换为 `data:video/mp4;base64,...` 格式，通过 `image_url` 字段发送（Gemini 等支持 inline video 的模型可识别）。

### 测试

此改动已在 `video_analyzer` 插件中实际使用并验证可用（B站/抖音视频分析）。

## Summary by Sourcery

Add a Video multimodal content type and wire it through the LLM payload and OpenAI client pipeline.

New Features:
- Introduce a Video payload class for video content alongside existing Image and Audio types.
- Support sending Video payloads via the OpenAI client by encoding them as inline data URLs.

Enhancements:
- Re-export the new Video content type from the llm and payload packages for external use.