### PR TITLE
Feat/reasoning content

### DIFF
--- a/src/kernel/llm/__init__.py
+++ b/src/kernel/llm/__init__.py
@@ -27,6 +27,7 @@ from .payload import (
 	Image,
 	LLMPayload,
 	LLMUsable,
+	ReasoningText,
 	Text,
 	ToolCall,
 	ToolResult,
@@ -73,6 +74,7 @@ __all__ = [
 	"ModelSet",
 	# 内容类型
 	"Content",
+	"ReasoningText",
 	"Text",
 	"Image",
 	"Audio",

--- a/src/kernel/llm/model_client/base.py
+++ b/src/kernel/llm/model_client/base.py
@@ -11,6 +11,7 @@ class StreamEvent:
     """provider-agnostic 的流事件。"""
 
     text_delta: str | None = None
+    reasoning_delta: str | None = None
     tool_call_id: str | None = None
     tool_name: str | None = None
     tool_args_delta: str | None = None
@@ -26,13 +27,14 @@ class ChatModelClient(Protocol):
         request_name: str,
         model_set: Any,
         stream: bool,
-    ) -> tuple[str | None, list[dict[str, Any]] | None, AsyncIterator[StreamEvent] | None]:
+    ) -> tuple[str | None, list[dict[str, Any]] | None, AsyncIterator[StreamEvent] | None, str | None]:
         """发起一次聊天请求。
 
-        返回三元组：
+        返回四元组：
         - message: 非流时的完整文本；流式则为 None
         - tool_calls: 非流时解析出的工具调用列表；流式则为 None（将通过 StreamEvent 解析）
         - stream_iter: 流式迭代器；非流则为 None
+        - reasoning_content: 非流时的推理内容；流式则为 None（将通过 StreamEvent 解析）
         """
         ...
 

--- a/src/kernel/llm/model_client/openai_client.py
+++ b/src/kernel/llm/model_client/openai_client.py
@@ -487,6 +487,17 @@ def _normalize_reasoning_value(value: Any) -> str | None:
     return None
 
 
+def _should_backfill_reasoning_content(messages: list[dict[str, Any]]) -> bool:
+    """当上下文中已存在 reasoning_content 时，为缺失的 assistant 历史统一回填。"""
+    for message in messages:
+        if message.get("role") != "assistant":
+            continue
+        reasoning_content = message.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content.strip():
+            return True
+    return False
+
+
 # _ClientCacheKey: (api_key, base_url, loop_id, timeout, trust_env, force_ipv4)
 _ClientCacheKey = tuple[str, str | None, int, float | None, bool, bool]
 
@@ -800,16 +811,9 @@ class OpenAIChatClient:
             else:
                 params["extra_body"] = extra_body
 
-        # 兼容：部分 OpenAI 兼容网关（如 Kimi）在开启 thinking 时，
-        # 要求 assistant 历史消息回传 reasoning_content 字段。
-        # 若旧上下文里缺失该字段，则做保底补齐，避免直接 400。
-        thinking_enabled = False
-        extra_body_params = params.get("extra_body")
-        if isinstance(extra_body_params, dict):
-            enable_thinking = extra_body_params.get("enable_thinking")
-            thinking_enabled = bool(enable_thinking) if enable_thinking is not None else False
-
-        if thinking_enabled:
+        # 若上下文中已存在带 reasoning_content 的 assistant 响应，
+        # 则为其余缺失字段的 assistant 历史统一回填，避免 follow-up 400。
+        if _should_backfill_reasoning_content(messages):
             for msg in messages:
                 if (
                     msg.get("role") == "assistant"

--- a/src/kernel/llm/model_client/openai_client.py
+++ b/src/kernel/llm/model_client/openai_client.py
@@ -21,7 +21,7 @@ from src.kernel.llm.tool_call_compat import (
 )
 
 from ..exceptions import LLMConfigurationError, LLMContentFilterError
-from ..payload import Image, LLMPayload, Text, ToolCall, ToolResult
+from ..payload import Image, LLMPayload, ReasoningText, Text, ToolCall, ToolResult
 from ..roles import ROLE
 from ..token_counter import count_payload_tokens
 from .base import StreamEvent
@@ -317,6 +317,7 @@ def _payloads_to_openai_messages(
         if payload.role == ROLE.ASSISTANT:
             tool_calls_list: list[dict[str, Any]] = []
             text_parts: list[str] = []
+            reasoning_parts: list[str] = []
 
             for idx, part in enumerate(payload.content):
                 if isinstance(part, ToolCall):
@@ -338,18 +339,31 @@ def _payloads_to_openai_messages(
                     )
                     continue
 
+                if isinstance(part, ReasoningText):
+                    reasoning_parts.append(part.text)
+                    continue
+
                 if isinstance(part, Text):
                     text_parts.append(part.text)
                     continue
 
+            reasoning_content = "".join(reasoning_parts)
             if tool_calls_list:
-                messages.append(
-                    {
-                        "role": role,
-                        "content": "".join(text_parts),
-                        "tool_calls": tool_calls_list,
-                    }
-                )
+                message: dict[str, Any] = {
+                    "role": role,
+                    "content": "".join(text_parts),
+                    "tool_calls": tool_calls_list,
+                }
+                if reasoning_content:
+                    message["reasoning_content"] = reasoning_content
+                messages.append(message)
+                continue
+
+            if all(isinstance(part, (Text, ReasoningText)) for part in payload.content):
+                message = {"role": role, "content": "".join(text_parts)}
+                if reasoning_content:
+                    message["reasoning_content"] = reasoning_content
+                messages.append(message)
                 continue
 
         # 单纯文本消息走简洁格式
@@ -359,34 +373,41 @@ def _payloads_to_openai_messages(
 
         # 多模态内容
         parts: list[dict[str, Any]] = []
+        reasoning_parts: list[str] = []
         for part in payload.content:
             if isinstance(part, Text):
                 parts.append({"type": "text", "text": part.text})
+            elif isinstance(part, ReasoningText):
+                reasoning_parts.append(part.text)
             elif isinstance(part, Image):
                 url = _image_to_data_url(part.value)
                 parts.append({"type": "image_url", "image_url": {"url": url}})
             else:
                 parts.append({"type": "text", "text": str(part)})
 
-        messages.append({"role": role, "content": parts})
+        message = {"role": role, "content": parts}
+        if payload.role == ROLE.ASSISTANT and reasoning_parts:
+            message["reasoning_content"] = "".join(reasoning_parts)
+        messages.append(message)
 
     return messages, tools
 
 
 def _parse_completion_message(
     msg: Any,
-) -> tuple[str, list[dict[str, Any]]]:
+) -> tuple[str, list[dict[str, Any]], str | None]:
     """从 OpenAI 响应消息对象中提取文本内容与工具调用列表。
 
     Args:
         msg: OpenAI ``ChatCompletionMessage`` 对象。
 
     Returns:
-        二元组 (message_content, tool_calls)。
+        三元组 (message_content, tool_calls, reasoning_content)。
         tool_calls 中每个元素形如 ``{"id": ..., "name": ..., "args": ...}``。
     """
     message_content: str = msg.content or ""
     tool_calls: list[dict[str, Any]] = []
+    reasoning_content = _extract_reasoning_content(msg)
 
     if getattr(msg, "tool_calls", None):
         for tc in msg.tool_calls:
@@ -423,7 +444,47 @@ def _parse_completion_message(
             }
         )
 
-    return message_content, tool_calls
+    return message_content, tool_calls, reasoning_content
+
+
+def _extract_reasoning_content(message: Any) -> str | None:
+    """从 provider 响应对象中提取 reasoning_content。"""
+    for attr_name in ("reasoning_content", "reasoning"):
+        normalized = _normalize_reasoning_value(getattr(message, attr_name, None))
+        if normalized:
+            return normalized
+    return None
+
+
+def _normalize_reasoning_value(value: Any) -> str | None:
+    """将不同 provider 的 reasoning 字段统一归一化为字符串。"""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        chunks: list[str] = []
+        for item in value:
+            normalized = _normalize_reasoning_value(item)
+            if normalized:
+                chunks.append(normalized)
+        return "".join(chunks) or None
+
+    text = getattr(value, "text", None)
+    if isinstance(text, str):
+        return text
+
+    content = getattr(value, "content", None)
+    if isinstance(content, str):
+        return content
+
+    if isinstance(value, dict):
+        for key in ("text", "content", "reasoning_content", "reasoning"):
+            normalized = _normalize_reasoning_value(value.get(key))
+            if normalized:
+                return normalized
+
+    return None
 
 
 # _ClientCacheKey: (api_key, base_url, loop_id, timeout, trust_env, force_ipv4)
@@ -649,7 +710,7 @@ class OpenAIChatClient:
         request_name: str,
         model_set: Any,
         stream: bool,
-    ) -> tuple[str | None, list[dict[str, Any]] | None, AsyncIterator[StreamEvent] | None]:
+    ) -> tuple[str | None, list[dict[str, Any]] | None, AsyncIterator[StreamEvent] | None, str | None]:
         """发起一次聊天请求。
 
         Args:
@@ -661,10 +722,10 @@ class OpenAIChatClient:
             stream: 是否开启流式输出。
 
         Returns:
-            三元组 ``(message, tool_calls, stream_iter)``：
+            四元组 ``(message, tool_calls, stream_iter, reasoning_content)``：
 
-            - 非流时：``(完整文本, 工具调用列表, None)``
-            - 流式时：``(None, None, AsyncIterator[StreamEvent])``
+            - 非流时：``(完整文本, 工具调用列表, None, 推理内容)``
+            - 流式时：``(None, None, AsyncIterator[StreamEvent], None)``
 
         Raises:
             TypeError: model_set 不是 dict 时抛出。
@@ -740,8 +801,8 @@ class OpenAIChatClient:
                 params["extra_body"] = extra_body
 
         # 兼容：部分 OpenAI 兼容网关（如 Kimi）在开启 thinking 时，
-        # 要求所有包含 tool_calls 的 assistant 消息携带 reasoning_content 字段。
-        # 否则会返回 400（thinking enabled but reasoning_content is missing）。
+        # 要求 assistant 历史消息回传 reasoning_content 字段。
+        # 若旧上下文里缺失该字段，则做保底补齐，避免直接 400。
         thinking_enabled = False
         extra_body_params = params.get("extra_body")
         if isinstance(extra_body_params, dict):
@@ -752,7 +813,6 @@ class OpenAIChatClient:
             for msg in messages:
                 if (
                     msg.get("role") == "assistant"
-                    and msg.get("tool_calls")
                     and "reasoning_content" not in msg
                 ):
                     content = msg.get("content")
@@ -795,7 +855,7 @@ class OpenAIChatClient:
         trust_env: bool,
         force_ipv4: bool,
         model_name: str,
-    ) -> tuple[str | None, list[dict[str, Any]] | None, None]:
+    ) -> tuple[str | None, list[dict[str, Any]] | None, None, str | None]:
         """执行非流式聊天请求并返回解析结果。
 
         遇到网络/超时异常时会驱逐缓存的客户端，以便下次请求重建连接。
@@ -813,7 +873,7 @@ class OpenAIChatClient:
             model_name: 模型名称（用于错误信息）。
 
         Returns:
-            三元组 ``(message_content, tool_calls, None)``。
+            四元组 ``(message_content, tool_calls, None, reasoning_content)``。
 
         Raises:
             LLMContentFilterError: 模型返回空 choices 时抛出。
@@ -849,22 +909,22 @@ class OpenAIChatClient:
             )
 
         msg = resp.choices[0].message
-        message_content, tool_calls = _parse_completion_message(msg)
+        message_content, tool_calls, reasoning_content = _parse_completion_message(msg)
 
         if tool_call_compat and openai_tools and not tool_calls:
             parsed_message, parsed_calls = parse_tool_call_compat_response(
                 message_content
             )
-            return parsed_message, parsed_calls, None
+            return parsed_message, parsed_calls, None, reasoning_content
 
-        return message_content, tool_calls, None
+        return message_content, tool_calls, None, reasoning_content
 
     async def _create_stream(
         self,
         *,
         client: Any,
         params: dict[str, Any],
-    ) -> tuple[None, None, AsyncIterator[StreamEvent]]:
+    ) -> tuple[None, None, AsyncIterator[StreamEvent], None]:
         """执行流式聊天请求并返回事件迭代器。
 
         Args:
@@ -872,7 +932,7 @@ class OpenAIChatClient:
             params: 请求参数 dict（不含 ``stream`` 键）。
 
         Returns:
-            三元组 ``(None, None, AsyncIterator[StreamEvent])``。
+            四元组 ``(None, None, AsyncIterator[StreamEvent], None)``。
         """
         stream_params = dict(params)
         stream_params["stream"] = True
@@ -896,6 +956,10 @@ class OpenAIChatClient:
                     content = getattr(delta, "content", None)
                     if content:
                         yield StreamEvent(text_delta=content)
+
+                    reasoning_content = _extract_reasoning_content(delta)
+                    if reasoning_content:
+                        yield StreamEvent(reasoning_delta=reasoning_content)
 
                     tool_calls_delta = getattr(delta, "tool_calls", None)
                     if tool_calls_delta:
@@ -942,7 +1006,7 @@ class OpenAIChatClient:
                 if callable(close_sync):
                     close_sync()
 
-        return None, None, iter_events()
+        return None, None, iter_events(), None
 
     async def create_embedding(
         self,

--- a/src/kernel/llm/payload/__init__.py
+++ b/src/kernel/llm/payload/__init__.py
@@ -1,11 +1,12 @@
 """LLM payload models."""
 
-from .content import Audio, Content, File, Image, Text
+from .content import Audio, Content, File, Image, ReasoningText, Text
 from .payload import LLMPayload
 from .tooling import LLMUsable, ToolCall, ToolResult, ToolRegistry
 
 __all__ = [
 	"Content",
+	"ReasoningText",
 	"Text",
 	"Image",
 	"Audio",

--- a/src/kernel/llm/payload/content.py
+++ b/src/kernel/llm/payload/content.py
@@ -154,6 +154,13 @@ class Text(Content):
     text: str
 
 
+@dataclass(frozen=True, slots=True)
+class ReasoningText(Content):
+    """思维链/推理内容。"""
+
+    text: str
+
+
 class Image(File):
     """图片内容。
 

--- a/src/kernel/llm/request.py
+++ b/src/kernel/llm/request.py
@@ -284,12 +284,12 @@ class LLMRequest:
                         isinstance(timeout_seconds, (int, float))
                         and timeout_seconds > 0
                     ):
-                        message, tool_calls, stream_iter = await asyncio.wait_for(
+                        message, tool_calls, stream_iter, reasoning_content = await asyncio.wait_for(
                             create_task,
                             timeout=float(timeout_seconds),
                         )
                     else:
-                        message, tool_calls, stream_iter = await create_task
+                        message, tool_calls, stream_iter, reasoning_content = await create_task
 
                 resp = LLMResponse(
                     _stream=stream_iter,
@@ -300,6 +300,7 @@ class LLMRequest:
                     context_manager=self.context_manager,
                     tool_call_compat=bool(model.get("tool_call_compat", False)),
                     message=message,
+                    reasoning_content=reasoning_content,
                     call_list=[],
                 )
 

--- a/src/kernel/llm/response.py
+++ b/src/kernel/llm/response.py
@@ -46,6 +46,7 @@ class LLMResponse:
     tool_call_compat: bool = False
 
     _consumed: bool = False
+    _appended_to_context: bool = False
 
     def __post_init__(self) -> None:
         """确保 message 和 call_list 不为 None，方便后续处理；如果 context_manager 为空且上层存在，则继承上层的 context_manager。"""
@@ -178,10 +179,12 @@ class LLMResponse:
         assistant_payload = LLMPayload(ROLE.ASSISTANT, content_parts)  # type: ignore[arg-type]
         if self.context_manager is not None:
             self.payloads = self.context_manager.add_payload(self.payloads, assistant_payload)
+            self._appended_to_context = True
             return
 
         self.payloads.append(assistant_payload)
         self._maybe_apply_context_manager()
+        self._appended_to_context = True
 
     def _maybe_apply_context_manager(self) -> None:
         """如果启用了上下文管理器，则尝试裁剪 payloads，以适应上下文限制。"""
@@ -248,6 +251,13 @@ class LLMResponse:
         Returns:
             LLMResponse: 新的请求的响应对象。
         """
+        if not self._consumed:
+            await self._collect_full_response()
+
+        if not self._appended_to_context:
+            self.add_payload(self.to_payload())
+            self._appended_to_context = True
+
         # 延迟导入，避免循环依赖
         from .request import LLMRequest
 

--- a/src/kernel/llm/response.py
+++ b/src/kernel/llm/response.py
@@ -18,7 +18,7 @@ from typing import Any, AsyncIterator, Self, TYPE_CHECKING
 
 from .exceptions import LLMResponseConsumedError
 from .model_client import StreamEvent
-from .payload import LLMPayload, Text, ToolCall
+from .payload import LLMPayload, ReasoningText, Text, ToolCall
 from .roles import ROLE
 from .tool_call_compat import parse_tool_call_compat_response
 
@@ -41,6 +41,7 @@ class LLMResponse:
     context_manager: LLMContextManager | None = None
 
     message: str | None = None
+    reasoning_content: str | None = None
     call_list: list[ToolCall] | None = None
     tool_call_compat: bool = False
 
@@ -90,6 +91,7 @@ class LLMResponse:
             return
 
         full_content: list[str] = []
+        full_reasoning: list[str] = []
         tool_acc = _ToolCallAccumulator()
         stream_error: Exception | None = None
         try:
@@ -97,6 +99,8 @@ class LLMResponse:
                 if event.text_delta:
                     full_content.append(event.text_delta)
                     yield event.text_delta
+                if event.reasoning_delta:
+                    full_reasoning.append(event.reasoning_delta)
                 if event.tool_name or event.tool_args_delta or event.tool_call_id:
                     tool_acc.apply(event)
         except Exception as e:
@@ -105,6 +109,7 @@ class LLMResponse:
             stream_error = e
 
         self.message = "".join(full_content)
+        self.reasoning_content = "".join(full_reasoning) or self.reasoning_content
         self.call_list = tool_acc.finalize()
         self._maybe_apply_tool_call_compat()
         self._maybe_append_response_to_context()
@@ -126,12 +131,15 @@ class LLMResponse:
 
         # 流式处理的情况，收集完整文本并解析工具调用信息
         full_content: list[str] = []
+        full_reasoning: list[str] = []
         tool_acc = _ToolCallAccumulator()
         stream_error: Exception | None = None
         try:
             async for event in self._stream:
                 if event.text_delta:
                     full_content.append(event.text_delta)
+                if event.reasoning_delta:
+                    full_reasoning.append(event.reasoning_delta)
                 if event.tool_name or event.tool_args_delta or event.tool_call_id:
                     tool_acc.apply(event)
         except Exception as e:
@@ -140,6 +148,7 @@ class LLMResponse:
             stream_error = e
 
         self.message = "".join(full_content)
+        self.reasoning_content = "".join(full_reasoning) or self.reasoning_content
         self.call_list = tool_acc.finalize()
         self._maybe_apply_tool_call_compat()
         self._maybe_append_response_to_context()
@@ -156,6 +165,8 @@ class LLMResponse:
             return
 
         content_parts: list[object] = []
+        if self.reasoning_content:
+            content_parts.append(ReasoningText(self.reasoning_content))
         if self.message:
             content_parts.append(Text(self.message))
         if self.call_list:
@@ -181,6 +192,8 @@ class LLMResponse:
     def to_payload(self) -> LLMPayload:
         """将当前响应转换为一个 LLMPayload 对象，适用于需要将响应作为消息追加到上下文中的场景。"""
         content_parts: list[object] = []
+        if self.reasoning_content:
+            content_parts.append(ReasoningText(self.reasoning_content))
         if self.message:
             content_parts.append(Text(self.message))
         if self.call_list:

--- a/test/kernel/llm/test_openai_client.py
+++ b/test/kernel/llm/test_openai_client.py
@@ -789,6 +789,117 @@ class TestOpenAIChatClient:
         assert tool_call_message["reasoning_content"] == tool_call_message["content"]
 
     @pytest.mark.asyncio
+    async def test_create_backfills_reasoning_content_when_history_already_contains_it(self):
+        """测试当上下文中已有 reasoning_content 时，会为其他 assistant 历史回填。"""
+        from src.kernel.llm.model_client.openai_client import OpenAIChatClient
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = "OK"
+        mock_completion.choices[0].message.tool_calls = None
+
+        mock_chat = AsyncMock()
+        mock_chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.chat.completions.create = mock_chat.completions.create
+
+        client = OpenAIChatClient()
+        client._clients = {}
+        client._get_client = MagicMock(return_value=mock_openai_client)
+
+        payloads = [
+            LLMPayload(ROLE.USER, Text("Hi")),
+            LLMPayload(ROLE.ASSISTANT, [ReasoningText("先思考"), Text("已有思考回复")]),
+            LLMPayload(
+                ROLE.ASSISTANT,
+                [
+                    Text("I'll call a tool"),
+                    ToolCall(id="call_1", name="calculator", args={"a": 1}),
+                ],
+            ),
+        ]
+        model_set = {
+            "api_key": "test-key",
+            "base_url": None,
+            "timeout": None,
+            "max_tokens": None,
+            "temperature": None,
+            "extra_params": {},
+        }
+
+        await client.create(
+            model_name="gpt-4",
+            payloads=payloads,
+            tools=[],
+            request_name="test",
+            model_set=model_set,
+            stream=False,
+        )
+
+        call_kwargs = mock_chat.completions.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        first_assistant_message = messages[1]
+        tool_call_message = messages[2]
+        assert first_assistant_message["reasoning_content"] == "先思考"
+        assert tool_call_message["role"] == "assistant"
+        assert tool_call_message["reasoning_content"] == tool_call_message["content"]
+
+    @pytest.mark.asyncio
+    async def test_create_does_not_backfill_reasoning_content_without_reasoning_history(self):
+        """测试当历史中没有 reasoning_content 时，不会额外回填。"""
+        from src.kernel.llm.model_client.openai_client import OpenAIChatClient
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = "OK"
+        mock_completion.choices[0].message.tool_calls = None
+
+        mock_chat = AsyncMock()
+        mock_chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.chat.completions.create = mock_chat.completions.create
+
+        client = OpenAIChatClient()
+        client._clients = {}
+        client._get_client = MagicMock(return_value=mock_openai_client)
+
+        payloads = [
+            LLMPayload(ROLE.USER, Text("Hi")),
+            LLMPayload(
+                ROLE.ASSISTANT,
+                [
+                    Text("I'll call a tool"),
+                    ToolCall(id="call_1", name="calculator", args={"a": 1}),
+                ],
+            ),
+        ]
+        model_set = {
+            "api_key": "test-key",
+            "base_url": None,
+            "timeout": None,
+            "max_tokens": None,
+            "temperature": None,
+            "extra_params": {},
+        }
+
+        await client.create(
+            model_name="gpt-4",
+            payloads=payloads,
+            tools=[],
+            request_name="test",
+            model_set=model_set,
+            stream=False,
+        )
+
+        call_kwargs = mock_chat.completions.create.call_args.kwargs
+        messages = call_kwargs["messages"]
+        tool_call_message = messages[1]
+        assert tool_call_message["role"] == "assistant"
+        assert "reasoning_content" not in tool_call_message
+
+    @pytest.mark.asyncio
     async def test_create_preserves_reasoning_content_from_completion_message(self):
         """测试非流式响应中的 reasoning_content 会被返回。"""
         from src.kernel.llm.model_client.openai_client import OpenAIChatClient

--- a/test/kernel/llm/test_openai_client.py
+++ b/test/kernel/llm/test_openai_client.py
@@ -12,6 +12,7 @@ import pytest
 from src.kernel.llm import (
     Image,
     LLMPayload,
+    ReasoningText,
     ROLE,
     Text,
     ToolCall,
@@ -116,6 +117,21 @@ class TestPayloadsToOpenAIMessages:
         assert len(messages) == 1
         assert messages[0]["role"] == "assistant"
         assert messages[0]["content"] == "Hi there"
+
+    def test_assistant_message_with_reasoning_content(self):
+        """测试助手消息会保留 reasoning_content。"""
+        from src.kernel.llm.model_client.openai_client import _payloads_to_openai_messages
+
+        payloads = [
+            LLMPayload(ROLE.ASSISTANT, [ReasoningText("先想一下"), Text("再回答")])
+        ]
+        messages, tools = _payloads_to_openai_messages(payloads)
+
+        assert len(messages) == 1
+        assert len(tools) == 0
+        assert messages[0]["role"] == "assistant"
+        assert messages[0]["content"] == "再回答"
+        assert messages[0]["reasoning_content"] == "先想一下"
 
     def test_multimodal_content(self):
         """测试多模态内容（文本+图片）。"""
@@ -433,7 +449,7 @@ class TestOpenAIChatClient:
             "extra_params": {},
         }
 
-        message, tool_calls, stream_iter = await client.create(
+        message, tool_calls, stream_iter, reasoning_content = await client.create(
             model_name="gpt-4",
             payloads=payloads,
             tools=[],
@@ -445,6 +461,7 @@ class TestOpenAIChatClient:
         assert message == "Hello, world!"
         assert tool_calls == []
         assert stream_iter is None
+        assert reasoning_content is None
 
     @pytest.mark.asyncio
     async def test_create_with_tool_calls(self):
@@ -482,7 +499,7 @@ class TestOpenAIChatClient:
             "extra_params": {},
         }
 
-        message, tool_calls, stream_iter = await client.create(
+        message, tool_calls, stream_iter, reasoning_content = await client.create(
             model_name="gpt-4",
             payloads=payloads,
             tools=[],
@@ -497,6 +514,7 @@ class TestOpenAIChatClient:
         assert tool_calls[0]["id"] == "call_123"
         assert tool_calls[0]["name"] == "calculator"
         assert tool_calls[0]["args"] == {"a": 1, "b": 2}
+        assert reasoning_content is None
 
     @pytest.mark.asyncio
     async def test_create_omits_tool_choice_without_tool_payloads(self):
@@ -771,6 +789,46 @@ class TestOpenAIChatClient:
         assert tool_call_message["reasoning_content"] == tool_call_message["content"]
 
     @pytest.mark.asyncio
+    async def test_create_preserves_reasoning_content_from_completion_message(self):
+        """测试非流式响应中的 reasoning_content 会被返回。"""
+        from src.kernel.llm.model_client.openai_client import OpenAIChatClient
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = "最终回答"
+        mock_completion.choices[0].message.reasoning_content = "中间思考"
+        mock_completion.choices[0].message.tool_calls = None
+
+        mock_chat = AsyncMock()
+        mock_chat.completions.create = AsyncMock(return_value=mock_completion)
+
+        mock_openai_client = MagicMock()
+        mock_openai_client.chat.completions.create = mock_chat.completions.create
+
+        client = OpenAIChatClient()
+        client._clients = {}
+        client._get_client = MagicMock(return_value=mock_openai_client)
+
+        result = await client.create(
+            model_name="moonshotai/kimi-k2.5",
+            payloads=[LLMPayload(ROLE.USER, Text("Hi"))],
+            tools=[],
+            request_name="test",
+            model_set={
+                "api_key": "test-key",
+                "base_url": None,
+                "timeout": None,
+                "max_tokens": None,
+                "temperature": None,
+                "extra_params": {"enable_thinking": True},
+            },
+            stream=False,
+        )
+
+        assert result[0] == "最终回答"
+        assert result[3] == "中间思考"
+
+    @pytest.mark.asyncio
     async def test_default_tool_choice_is_auto_for_deepseek(self):
         """测试 DeepSeek 场景下默认 tool_choice 为 auto（避免 required 触发 grammar 编译失败）。"""
         from src.kernel.llm.model_client.openai_client import OpenAIChatClient
@@ -925,7 +983,7 @@ class TestOpenAIChatClient:
             "extra_params": {},
         }
 
-        message, tool_calls, _ = await client.create(
+        message, tool_calls, _, reasoning_content = await client.create(
             model_name="gpt-4",
             payloads=payloads,
             tools=[],
@@ -945,6 +1003,7 @@ class TestOpenAIChatClient:
         assert len(tool_calls) == 1
         assert tool_calls[0]["name"] == "calculator"
         assert tool_calls[0]["args"] == {"a": 1}
+        assert reasoning_content is None
 
     @pytest.mark.asyncio
     async def test_stream_iterator_closes_underlying_stream_on_early_stop(self):
@@ -1001,7 +1060,7 @@ class TestOpenAIChatClient:
             "extra_params": {},
         }
 
-        message, tool_calls, stream_iter = await client.create(
+        message, tool_calls, stream_iter, reasoning_content = await client.create(
             model_name="gpt-4",
             payloads=payloads,
             tools=[],
@@ -1013,6 +1072,7 @@ class TestOpenAIChatClient:
         assert message is None
         assert tool_calls is None
         assert stream_iter is not None
+        assert reasoning_content is None
 
         event = await anext(stream_iter)
         assert event.text_delta == "hello"

--- a/test/kernel/llm/test_response.py
+++ b/test/kernel/llm/test_response.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from collections.abc import AsyncIterator
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from src.kernel.llm.exceptions import LLMResponseConsumedError
 from src.kernel.llm.model_client.base import StreamEvent
-from src.kernel.llm.payload import LLMPayload, Text
+from src.kernel.llm.payload import LLMPayload, ReasoningText, Text, ToolCall
 from src.kernel.llm.request import LLMRequest
 from src.kernel.llm.response import LLMResponse, _ToolCallAccumulator
 from src.kernel.llm.roles import ROLE
@@ -551,6 +551,61 @@ class TestLLMResponseSend:
             assert mock_send.called
             call_kwargs = mock_send.call_args.kwargs
             assert call_kwargs["stream"] is False
+
+    @pytest.mark.asyncio
+    async def test_send_appends_current_response_before_follow_up(
+        self, mock_model_set: list[dict[str, Any]], sample_payloads: list[LLMPayload]
+    ) -> None:
+        """Test that send includes the current assistant response in the next request payloads."""
+        captured_payloads: list[LLMPayload] = []
+
+        async def fake_send(
+            request_self: LLMRequest,
+            *,
+            auto_append_response: bool = True,
+            stream: bool = True,
+        ) -> LLMResponse:
+            del auto_append_response, stream
+            captured_payloads.extend(request_self.payloads)
+            return LLMResponse(
+                _stream=None,
+                _upper=request_self,
+                _auto_append_response=False,
+                payloads=list(request_self.payloads),
+                model_set=mock_model_set,
+                message="Chained response",
+                call_list=[],
+            )
+
+        response = LLMResponse(
+            _stream=None,
+            _upper=LLMRequest(mock_model_set, "test"),
+            _auto_append_response=False,
+            payloads=list(sample_payloads),
+            model_set=mock_model_set,
+            message="Test",
+            reasoning_content="Thinking",
+            call_list=[ToolCall(id="call_1", name="demo_tool", args={"value": 1})],
+        )
+
+        with patch.object(LLMRequest, "send", new=fake_send):
+            await response.send(stream=False)
+
+        assert captured_payloads
+        assistant_payload = captured_payloads[-1]
+        assert assistant_payload.role == ROLE.ASSISTANT
+        assert any(
+            isinstance(part, ReasoningText) and part.text == "Thinking"
+            for part in assistant_payload.content
+        )
+        assert any(
+            isinstance(part, Text) and part.text == "Test"
+            for part in assistant_payload.content
+        )
+        assert any(
+            isinstance(part, ToolCall) and part.id == "call_1"
+            for part in assistant_payload.content
+        )
 
 
 class TestLLMResponseStreamWithCallback:


### PR DESCRIPTION
增加reasoning content回传

## Summary by Sourcery

Add first-class support for reasoning content in LLM payloads, responses, and OpenAI chat client integration.

New Features:
- Introduce a ReasoningText content type and expose it from the public LLM kernel API.
- Return reasoning_content from non-streaming OpenAI chat completions and propagate it through LLMResponse and follow-up requests.
- Support reasoning deltas in streaming responses via an extended StreamEvent model.

Bug Fixes:
- Backfill missing reasoning_content on assistant history messages when any prior assistant message already contains reasoning_content to avoid provider errors.

Enhancements:
- Preserve and forward reasoning_content in assistant messages when converting payloads to OpenAI messages, including multimodal and tool-call scenarios.
- Ensure LLMResponse.send always appends the fully collected current assistant response, including reasoning content and tool calls, into subsequent request payloads.
- Normalize provider-specific reasoning fields into a unified reasoning_content string via helper extraction utilities.

Tests:
- Extend OpenAI client and LLMResponse tests to cover reasoning_content handling, backfilling behavior, streaming aggregation, and context appending semantics.