### PR TITLE
feat: 添加 SkillManager 插件，包含配置、事件处理器和工具组件

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,4 +100,5 @@ plugins/*
 !plugins/booku_memory/
 !plugins/emoji_sender/
 !plugins/perm_plugin/
+!plugins/skill_manager/
 

--- a/plugins/skill_manager/README.md
+++ b/plugins/skill_manager/README.md
@@ -1,0 +1,139 @@
+# Skill Manager
+
+SkillManager 是 Neo-MoFox 的技能索引与按需加载插件。
+
+它会在插件加载完成后扫描本地 skill 目录，建立技能清单，并提供 3 个工具给 LLM 按需调用：
+
+- get_skill：读取并注入 SKILL.md
+- get_reference：读取 skill 内 markdown 引用文件
+- get_script：执行 skill 内 python 脚本（支持参数，返回脚本输出）
+
+## 目录结构
+
+```text
+plugins/skill_manager/
+├── __init__.py
+├── config.py
+├── manifest.json
+├── models.py
+├── plugin.py
+├── tools.py
+└── handlers/
+    ├── __init__.py
+    └── skillmanager.py
+```
+
+## 工作流程
+
+1. 启动时触发 `SkillManagerLoadHandler`。
+2. `SkillManagerPlugin.refresh_skill_catalog()` 扫描配置路径，发现所有包含 `SKILL.md` 的 skill。
+3. 刷新 `skills` 索引并同步 system reminder（actor/sub_actor）。
+4. LLM 在需要时按顺序调用工具：
+   - 先 `get_skill(name)`
+   - 再按需 `get_reference(name, location)` 或 `get_script(name, location, script_args)`
+
+## Skill 发现规则
+
+- 配置路径来自 `manager.paths`，默认是 `skill`。
+- 若路径本身包含 `SKILL.md`，它被视为一个 skill 根目录。
+- 否则会扫描该路径下一层子目录，子目录中存在 `SKILL.md` 的会被识别为 skill。
+- `SKILL.md` front matter 支持解析：
+  - `name`
+  - `description`
+
+## 工具说明
+
+### 1) get_skill
+
+读取指定 skill 的 `SKILL.md` 原文，并标记为“已注入”。
+
+参数：
+
+- `name: str` skill 名称
+
+返回：
+
+- 成功：`(True, <SKILL.md全文>)`
+- 失败：`(False, <错误信息>)`
+
+### 2) get_reference
+
+读取 skill 根目录内的 markdown 引用文件。
+
+参数：
+
+- `name: str` 已注入 skill 名称
+- `location: str` skill 内相对路径（必须是 `.md`）
+
+约束：
+
+- 必须先调用 `get_skill` 注入该 skill。
+- 路径禁止越界（仅允许 skill 根目录内文件）。
+
+返回：
+
+- 成功：`(True, <markdown全文>)`
+- 失败：`(False, <错误信息>)`
+
+### 3) get_script
+
+直接执行 skill 根目录内 python 脚本（等价命令行执行脚本），支持可选参数透传。
+
+参数：
+
+- `name: str` 已注入 skill 名称
+- `location: str` skill 内相对路径（必须是 `.py`）
+- `script_args: list[str] | str | None` 可选
+  - 字符串示例：`"--check 60 --bonus 1"`
+  - 列表示例：`["--check", "60", "--bonus", "1"]`
+
+执行行为：
+
+- 通过 `runpy.run_path(..., run_name="__main__")` 执行脚本。
+- 执行时会临时设置 `sys.argv = [script_path, *script_args]`。
+- 自动捕获脚本的 `stdout/stderr`（包含 print 与标准流日志输出）并拼接到返回内容。
+- `SystemExit(0)` / `SystemExit(None)` 视为成功（例如 argparse `--help`）。
+
+返回：
+
+- 成功：`(True, "脚本已执行: xxx.py\n\n[stdout]/[stderr]...")`
+- 失败：`(False, "执行脚本失败...\n\n[stdout]/[stderr]...")`
+
+## 配置项
+
+配置模型：`SkillManagerConfig`（`plugins/skill_manager/config.py`）
+
+`[manager]`：
+
+- `enabled: bool = true`
+- `paths: list[str] = ["skill"]`
+- `inject_actor_reminder: bool = true`
+- `inject_sub_actor_reminder: bool = true`
+
+示意：
+
+```toml
+[manager]
+enabled = true
+paths = ["skill"]
+inject_actor_reminder = true
+inject_sub_actor_reminder = true
+```
+
+## 常见调用建议
+
+- 调用顺序固定为：先 `get_skill`，再 `get_reference` / `get_script`。
+- `get_script` 优先使用字符串列表参数，避免 shell 分词歧义。
+- 对 argparse 脚本可直接传 `script_args: "--help"` 获取帮助文本。
+
+## 安全与边界
+
+- 所有引用路径都会做目录边界校验，禁止越界访问。
+- `get_reference` 仅允许 `.md`。
+- `get_script` 仅允许 `.py`。
+- 本插件不负责脚本沙箱隔离，脚本执行权限等同当前进程。
+
+## 版本
+
+- Plugin: `1.0.0`
+- Manifest: `plugins/skill_manager/manifest.json`

--- a/plugins/skill_manager/__init__.py
+++ b/plugins/skill_manager/__init__.py
@@ -1,0 +1,3 @@
+"""SkillManager 插件。"""
+
+__version__ = "1.0.0"

--- a/plugins/skill_manager/config.py
+++ b/plugins/skill_manager/config.py
@@ -1,0 +1,38 @@
+"""SkillManager 插件配置。"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from src.core.components.base import BaseConfig
+from src.kernel.config.core import Field, SectionBase, config_section
+
+
+class SkillManagerConfig(BaseConfig):
+    """SkillManager 配置模型。"""
+
+    config_name: ClassVar[str] = "config"
+    config_description: ClassVar[str] = "SkillManager 配置"
+
+    @config_section("manager", title="技能管理", tag="plugin", order=0)
+    class ManagerSection(SectionBase):
+        """技能管理主配置。"""
+
+        enabled: bool = Field(
+            default=True,
+            description="是否启用 SkillManager",
+        )
+        paths: list[str] = Field(
+            default_factory=lambda: ["skill"],
+            description="skill 根目录路径列表；相对路径默认相对项目根目录",
+        )
+        inject_actor_reminder: bool = Field(
+            default=True,
+            description="是否注入 actor system reminder",
+        )
+        inject_sub_actor_reminder: bool = Field(
+            default=True,
+            description="是否注入 sub_actor system reminder",
+        )
+
+    manager: ManagerSection = Field(default_factory=ManagerSection)

--- a/plugins/skill_manager/handlers/__init__.py
+++ b/plugins/skill_manager/handlers/__init__.py
@@ -1,0 +1,5 @@
+"""SkillManager 事件处理器导出。"""
+
+from .skillmanager import SkillManagerLoadHandler
+
+__all__ = ["SkillManagerLoadHandler"]

--- a/plugins/skill_manager/handlers/skillmanager.py
+++ b/plugins/skill_manager/handlers/skillmanager.py
@@ -31,9 +31,6 @@ class SkillManagerLoadHandler(BaseEventHandler):
             return EventDecision.PASS, params
 
         plugin = self.plugin
-        if not hasattr(plugin, "refresh_skill_catalog"):
-            logger.warning("skill_manager 插件实例不支持 refresh_skill_catalog")
-            return EventDecision.PASS, params
 
         try:
             await plugin.refresh_skill_catalog()

--- a/plugins/skill_manager/handlers/skillmanager.py
+++ b/plugins/skill_manager/handlers/skillmanager.py
@@ -1,0 +1,44 @@
+"""SkillManager 加载事件处理器。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.components import BaseEventHandler, EventType
+from src.kernel.event import EventDecision
+from src.kernel.logger import get_logger
+
+logger = get_logger("skill_manager.handler")
+
+
+class SkillManagerLoadHandler(BaseEventHandler):
+    """在所有插件加载完成后刷新 skill 索引。"""
+
+    handler_name: str = "skill_manager_load_handler"
+    handler_description: str = "订阅 on_all_plugin_loaded 并刷新 skill 索引"
+    weight: int = 0
+    intercept_message: bool = False
+    init_subscribe: list[EventType | str] = [EventType.ON_ALL_PLUGIN_LOADED]
+
+    async def execute(
+        self,
+        event_name: str,
+        params: dict[str, Any],
+    ) -> tuple[EventDecision, dict[str, Any]]:
+        """处理插件全量加载完成事件。"""
+
+        if event_name != EventType.ON_ALL_PLUGIN_LOADED.value:
+            return EventDecision.PASS, params
+
+        plugin = self.plugin
+        if not hasattr(plugin, "refresh_skill_catalog"):
+            logger.warning("skill_manager 插件实例不支持 refresh_skill_catalog")
+            return EventDecision.PASS, params
+
+        try:
+            await plugin.refresh_skill_catalog()
+        except Exception as error:
+            logger.exception("刷新 skill 索引失败")
+            return EventDecision.PASS, {**params, "error": str(error)}
+
+        return EventDecision.SUCCESS, params

--- a/plugins/skill_manager/manifest.json
+++ b/plugins/skill_manager/manifest.json
@@ -1,0 +1,34 @@
+{
+  "name": "skill_manager",
+  "version": "1.0.0",
+  "description": "Skill 管理器：索引本地 skill 目录并按需注入 SKILL.md/引用文档/脚本能力",
+  "author": "MoFox Team",
+  "dependencies": {
+    "plugins": [],
+    "components": []
+  },
+  "include": [
+    {
+      "component_type": "event_handler",
+      "component_name": "skill_manager_load_handler",
+      "dependencies": []
+    },
+    {
+      "component_type": "tool",
+      "component_name": "get_skill",
+      "dependencies": []
+    },
+    {
+      "component_type": "tool",
+      "component_name": "get_reference",
+      "dependencies": []
+    },
+    {
+      "component_type": "tool",
+      "component_name": "get_script",
+      "dependencies": []
+    }
+  ],
+  "entry_point": "plugin.py",
+  "min_core_version": "1.0.0"
+}

--- a/plugins/skill_manager/models.py
+++ b/plugins/skill_manager/models.py
@@ -1,0 +1,17 @@
+"""SkillManager 共享数据模型。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(slots=True)
+class SkillEntry:
+    """Skill 索引信息（不包含全文）。"""
+
+    name: str
+    description: str
+    root_dir: Path
+    skill_md_path: Path
+    files: list[str]

--- a/plugins/skill_manager/plugin.py
+++ b/plugins/skill_manager/plugin.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+from src.core.components import BasePlugin, register_plugin
+from src.core.prompt import SystemReminderInsertType
+from src.kernel.logger import get_logger
+
+from .config import SkillManagerConfig
+from .handlers import SkillManagerLoadHandler
+from .models import SkillEntry
+from .tools import SkillGetReferenceTool, SkillGetScriptTool, SkillGetTool
+
+logger = get_logger("skill_manager")
+_FRONT_MATTER_FIELD_RE = re.compile(r"^(name|description)\s*:\s*(.+)$", re.IGNORECASE)
+
+
+def _is_path_inside(base_dir: Path, target_path: Path) -> bool:
+    """判断目标路径是否在指定根目录内部。"""
+
+    try:
+        target_path.resolve().relative_to(base_dir.resolve())
+        return True
+    except ValueError:
+        return False
+
+
+def _strip_quoted_text(value: str) -> str:
+    """去除首尾引号并清理空白。"""
+
+    text = value.strip()
+    if len(text) >= 2 and text[0] == text[-1] and text[0] in {'"', "'"}:
+        return text[1:-1].strip()
+    return text
+
+
+def _parse_skill_front_matter(raw_text: str) -> tuple[str | None, str | None]:
+    """从 SKILL.md 首段 front matter 提取 name 和 description。"""
+
+    lines = raw_text.splitlines()
+    if len(lines) < 3:
+        return None, None
+    if lines[0].strip() != "---":
+        return None, None
+
+    parsed_name: str | None = None
+    parsed_description: str | None = None
+    for line in lines[1:]:
+        if line.strip() == "---":
+            break
+        matched = _FRONT_MATTER_FIELD_RE.match(line.strip())
+        if not matched:
+            continue
+        key, value = matched.groups()
+        normalized_value = _strip_quoted_text(value)
+        if key.lower() == "name":
+            parsed_name = normalized_value
+        elif key.lower() == "description":
+            parsed_description = normalized_value
+    return parsed_name, parsed_description
+
+
+@register_plugin
+class SkillManagerPlugin(BasePlugin):
+    """Skill 管理器插件。"""
+
+    plugin_name: str = "skill_manager"
+    plugin_description: str = "技能管理器"
+    plugin_version: str = "1.0.0"
+
+    configs: list[type] = [SkillManagerConfig]
+
+    def __init__(self, config: SkillManagerConfig | None = None) -> None:
+        """初始化 SkillManager 运行态。"""
+
+        super().__init__(config)
+        self._workspace_root: Path = Path(__file__).resolve().parents[2]
+        self.paths: list[str] = []
+        self.skills: dict[str, SkillEntry] = {}
+        self.skill_contents: dict[str, str] = {}
+        self.injected_skills: set[str] = set()
+
+    def get_components(self) -> list[type]:
+        """返回插件组件列表。"""
+
+        if (
+            isinstance(self.config, SkillManagerConfig)
+            and not self.config.manager.enabled
+        ):
+            logger.info("skill_manager 已在配置中禁用")
+            return []
+        return [
+            SkillManagerLoadHandler,
+            SkillGetTool,
+            SkillGetReferenceTool,
+            SkillGetScriptTool,
+        ]
+
+    async def on_plugin_unloaded(self) -> None:
+        """插件卸载时清理 system reminder。"""
+
+        from src.core.prompt import get_system_reminder_store
+
+        store = get_system_reminder_store()
+        store.delete("actor", "skill_manager_catalog")
+        store.delete("sub_actor", "skill_manager_catalog")
+
+    async def refresh_skill_catalog(self) -> None:
+        """扫描配置路径并刷新 skill 索引。"""
+
+        configured_paths = self._resolve_skill_paths()
+        self.paths = [str(item) for item in configured_paths]
+
+        discovered: dict[str, SkillEntry] = {}
+        for base_dir in configured_paths:
+            if not base_dir.exists() or not base_dir.is_dir():
+                logger.warning(f"skill 路径不存在或不可读，已跳过: {base_dir}")
+                continue
+
+            for skill_root in self._iter_skill_roots(base_dir):
+                skill_md_path = skill_root / "SKILL.md"
+                if not skill_md_path.is_file():
+                    continue
+
+                text = skill_md_path.read_text(encoding="utf-8")
+                parsed_name, parsed_description = _parse_skill_front_matter(text)
+                skill_name = (parsed_name or skill_root.name).strip()
+                skill_description = (
+                    parsed_description
+                    or f"Skill {skill_name}，通过 get_skill 读取后可使用扩展引用与脚本"
+                ).strip()
+
+                markdown_files = [
+                    path.relative_to(skill_root).as_posix()
+                    for path in sorted(skill_root.rglob("*.md"))
+                    if path.is_file()
+                ]
+
+                discovered[skill_name] = SkillEntry(
+                    name=skill_name,
+                    description=skill_description,
+                    root_dir=skill_root,
+                    skill_md_path=skill_md_path,
+                    files=markdown_files,
+                )
+
+        self.apply_discovered_skills(discovered)
+        logger.info(f"skill_manager 已刷新 skill 索引，数量: {len(self.skills)}")
+
+    def _resolve_skill_paths(self) -> list[Path]:
+        """将配置中的路径转换为绝对路径列表。"""
+
+        default_paths = ["skill"]
+        if isinstance(self.config, SkillManagerConfig):
+            configured = [
+                item.strip() for item in self.config.manager.paths if item.strip()
+            ]
+            paths = configured or default_paths
+        else:
+            paths = default_paths
+
+        resolved_paths: list[Path] = []
+        for raw_path in paths:
+            expanded_path = Path(os.path.expandvars(os.path.expanduser(raw_path)))
+            if expanded_path.is_absolute():
+                resolved_paths.append(expanded_path)
+                continue
+            resolved_paths.append((self._workspace_root / expanded_path).resolve())
+        return resolved_paths
+
+    @staticmethod
+    def _iter_skill_roots(base_dir: Path) -> list[Path]:
+        """从基目录中解析 skill 根目录集合。"""
+
+        if (base_dir / "SKILL.md").is_file():
+            return [base_dir]
+
+        skill_roots: list[Path] = []
+        for child in sorted(base_dir.iterdir()):
+            if child.is_dir() and (child / "SKILL.md").is_file():
+                skill_roots.append(child)
+        return skill_roots
+
+    def apply_discovered_skills(self, discovered: dict[str, SkillEntry]) -> None:
+        """应用刷新后的 skill 索引并清理运行态缓存。"""
+
+        self.skills = discovered
+        valid_names = set(self.skills.keys())
+        self.skill_contents = {
+            name: content
+            for name, content in self.skill_contents.items()
+            if name in valid_names
+        }
+        self.injected_skills = {
+            name for name in self.injected_skills if name in valid_names
+        }
+        self._sync_system_reminder()
+
+    def _resolve_skill_relative_path(
+        self,
+        *,
+        skill_entry: SkillEntry,
+        relative_path: str,
+        required_suffix: str,
+    ) -> tuple[Path | None, str | None]:
+        """将 skill 内相对路径解析为受限的绝对路径。"""
+
+        normalized_location = relative_path.strip().replace("\\", "/")
+        if not normalized_location:
+            return None, "location 不能为空"
+
+        resolved_target = (skill_entry.root_dir / normalized_location).resolve()
+        if not _is_path_inside(skill_entry.root_dir, resolved_target):
+            return None, f"location 越界: {relative_path}"
+        if not resolved_target.is_file():
+            return None, f"文件不存在: {relative_path}"
+        if resolved_target.suffix.lower() != required_suffix:
+            return None, f"仅支持 {required_suffix} 文件: {relative_path}"
+        return resolved_target, None
+
+    def _sync_system_reminder(self) -> None:
+        """更新 actor/sub_actor 的 skill 清单提示。"""
+
+        from src.core.prompt import get_system_reminder_store
+
+        store = get_system_reminder_store()
+        if not self.skills:
+            store.delete("actor", "skill_manager_catalog")
+            store.delete("sub_actor", "skill_manager_catalog")
+            return
+
+        reminder_lines = [
+            "## SkillManager 可用技能清单",
+            "当任务复杂、上下文长、需要专用流程时，可按需读取 skill。",
+            "先调用 get_skill(name) 注入后，再按需使用 get_reference/get_script 逐步展开。",
+            "",
+        ]
+        for entry in sorted(self.skills.values(), key=lambda item: item.name.lower()):
+            reminder_lines.append(f"- {entry.name}: {entry.description}")
+
+        reminder_text = "\n".join(reminder_lines)
+
+        inject_actor = True
+        inject_sub_actor = True
+        if isinstance(self.config, SkillManagerConfig):
+            inject_actor = self.config.manager.inject_actor_reminder
+            inject_sub_actor = self.config.manager.inject_sub_actor_reminder
+
+        if inject_actor:
+            store.set(
+                "actor",
+                name="skill_manager_catalog",
+                content=reminder_text,
+                insert_type=SystemReminderInsertType.DYNAMIC,
+            )
+        else:
+            store.delete("actor", "skill_manager_catalog")
+
+        if inject_sub_actor:
+            store.set(
+                "sub_actor",
+                name="skill_manager_catalog",
+                content=reminder_text,
+                insert_type=SystemReminderInsertType.DYNAMIC,
+            )
+        else:
+            store.delete("sub_actor", "skill_manager_catalog")

--- a/plugins/skill_manager/tools.py
+++ b/plugins/skill_manager/tools.py
@@ -1,0 +1,181 @@
+"""SkillManager 对外工具组件。"""
+
+from __future__ import annotations
+
+import io
+import runpy
+import shlex
+import sys
+from contextlib import redirect_stderr, redirect_stdout
+from typing import Annotated
+
+from src.core.components import BaseTool
+from src.kernel.logger import get_logger
+
+
+logger = get_logger("skill_manager.tool")
+
+
+class SkillGetTool(BaseTool):
+    """读取并注入 skill 主文档。"""
+
+    tool_name: str = "get_skill"
+    tool_description: str = "按 skill 名称读取 SKILL.md 原文，并标记为已注入。"
+
+    async def execute(
+        self,
+        name: Annotated[str, "skill 名称（来自 skill 列表）"],
+    ) -> tuple[bool, str | dict]:
+        """返回 SKILL.md 全文。"""
+
+        resolved_name = name.strip()
+        if not resolved_name:
+            return False, "name 不能为空"
+
+        plugin = self.plugin
+        entry = plugin.skills.get(resolved_name)
+        if entry is None:
+            return False, f"未找到 skill: {resolved_name}"
+
+        content = plugin.skill_contents.get(resolved_name)
+        if content is None:
+            content = entry.skill_md_path.read_text(encoding="utf-8")
+            plugin.skill_contents[resolved_name] = content
+
+        plugin.injected_skills.add(resolved_name)
+        return True, content
+
+
+class SkillGetReferenceTool(BaseTool):
+    """读取 skill 下的引用 markdown 文件。"""
+
+    tool_name: str = "get_reference"
+    tool_description: str = (
+        "在已通过 get_skill(name) 注入对应 skill 后，"
+        "按相对路径读取该 skill 目录中的 markdown 引用文件。"
+    )
+
+    async def execute(
+        self,
+        name: Annotated[str, "已注入的 skill 名称"],
+        location: Annotated[str, "该 skill 目录内的 markdown 相对路径，例如 references/callable.md"],
+    ) -> tuple[bool, str | dict]:
+        """返回引用 markdown 原文。"""
+
+        resolved_name = name.strip()
+        if not resolved_name:
+            return False, "name 不能为空"
+
+        plugin = self.plugin
+        if resolved_name not in plugin.injected_skills:
+            return False, f"skill '{resolved_name}' 尚未注入，请先调用 get_skill"
+
+        entry = plugin.skills.get(resolved_name)
+        if entry is None:
+            return False, f"未找到 skill: {resolved_name}"
+
+        resolved_path, error = plugin._resolve_skill_relative_path(
+            skill_entry=entry,
+            relative_path=location,
+            required_suffix=".md",
+        )
+        if resolved_path is None:
+            return False, error or "引用文件路径无效"
+
+        return True, resolved_path.read_text(encoding="utf-8")
+
+
+class SkillGetScriptTool(BaseTool):
+    """直接执行 skill 下 python 脚本。"""
+
+    tool_name: str = "get_script"
+    tool_description: str = (
+        "在已通过 get_skill(name) 注入对应 skill 后，"
+        "按相对路径直接执行该 skill 目录下 python 脚本（等价 python xxx.py）。"
+        "可选通过 script_args 传入命令行参数。"
+    )
+
+    async def execute(
+        self,
+        name: Annotated[str, "已注入的 skill 名称"],
+        location: Annotated[str, "该 skill 目录内 python 文件相对路径，例如 scripts/toolbox.py"],
+        script_args: Annotated[
+            list[str] | str,
+            "可选脚本参数；支持字符串（如 '--check 60 --bonus 1'）或字符串列表（如 ['--check', '60']）",
+        ] | None = None,
+    ) -> tuple[bool, str | dict]:
+        """返回脚本执行结果。"""
+
+        resolved_name = name.strip()
+        if not resolved_name:
+            return False, "name 不能为空"
+
+        plugin = self.plugin
+        if resolved_name not in plugin.injected_skills:
+            return False, f"skill '{resolved_name}' 尚未注入，请先调用 get_skill"
+
+        entry = plugin.skills.get(resolved_name)
+        if entry is None:
+            return False, f"未找到 skill: {resolved_name}"
+
+        script_path, error = plugin._resolve_skill_relative_path(
+            skill_entry=entry,
+            relative_path=location,
+            required_suffix=".py",
+        )
+        if script_path is None:
+            return False, error or "脚本路径无效"
+
+        normalized_args: list[str] = []
+        if isinstance(script_args, str):
+            normalized_args = shlex.split(script_args)
+        elif isinstance(script_args, list):
+            if not all(isinstance(item, str) for item in script_args):
+                return False, "script_args 列表元素必须为字符串"
+            normalized_args = script_args
+        elif script_args is not None:
+            return False, "script_args 必须是字符串或字符串列表"
+
+        old_argv = sys.argv[:]
+        stdout_buffer = io.StringIO()
+        stderr_buffer = io.StringIO()
+        try:
+            sys.argv = [str(script_path), *normalized_args]
+            with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
+                runpy.run_path(str(script_path), run_name="__main__")
+
+            captured_output = _compose_captured_output(stdout_buffer, stderr_buffer)
+            if captured_output:
+                return True, f"脚本已执行: {script_path.name}\n\n{captured_output}"
+            return True, f"脚本已执行: {script_path.name}"
+        except SystemExit as error:
+            captured_output = _compose_captured_output(stdout_buffer, stderr_buffer)
+            exit_code = error.code
+            if exit_code in (None, 0):
+                if captured_output:
+                    return True, f"脚本已执行: {script_path.name}\n\n{captured_output}"
+                return True, f"脚本已执行: {script_path.name}"
+            if captured_output:
+                return False, f"脚本执行退出码: {exit_code}\n\n{captured_output}"
+            return False, f"脚本执行退出码: {exit_code}"
+        except Exception as error:
+            logger.exception("执行 skill 脚本失败")
+            captured_output = _compose_captured_output(stdout_buffer, stderr_buffer)
+            if captured_output:
+                return False, f"执行脚本失败: {error}\n\n{captured_output}"
+            return False, f"执行脚本失败: {error}"
+        finally:
+            sys.argv = old_argv
+
+
+def _compose_captured_output(stdout_buffer: io.StringIO, stderr_buffer: io.StringIO) -> str:
+    """拼接脚本执行期间捕获的标准输出与标准错误。"""
+
+    stdout_text = stdout_buffer.getvalue().strip()
+    stderr_text = stderr_buffer.getvalue().strip()
+    output_sections: list[str] = []
+    if stdout_text:
+        output_sections.append(f"[stdout]\n{stdout_text}")
+    if stderr_text:
+        output_sections.append(f"[stderr]\n{stderr_text}")
+    return "\n\n".join(output_sections)


### PR DESCRIPTION
## Summary by Sourcery

Add a SkillManager plugin that indexes local skill directories and exposes tools to load skill content and scripts.

New Features:
- Introduce SkillManager plugin with configuration for enabling, paths, and system reminder injection behavior.
- Add event handler to refresh the skill catalog after all plugins are loaded and keep system reminders in sync with available skills.
- Provide tools to load SKILL.md content, read referenced markdown files, and execute skill-local Python scripts with captured output.