### PR TITLE
refactor: 移除配置项的显示顺序参数，简化配置装饰器

### DIFF
--- a/plugins/booku_memory/config.py
+++ b/plugins/booku_memory/config.py
@@ -26,7 +26,7 @@ class BookuMemoryConfig(BaseConfig):
     config_name: ClassVar[str] = "config"
     config_description: ClassVar[str] = "Booku Memory Agent 配置"
 
-    @config_section("plugin", title="插件设置", tag="plugin", order=0)
+    @config_section("plugin", title="插件设置", tag="plugin")
     class PluginSection(SectionBase):
         """插件级开关。"""
 
@@ -57,7 +57,7 @@ class BookuMemoryConfig(BaseConfig):
             order=2
         )
 
-    @config_section("storage", title="存储配置", tag="database", order=10)
+    @config_section("storage", title="存储配置", tag="database")
     class StorageSection(SectionBase):
         """存储层配置。"""
 
@@ -86,7 +86,7 @@ class BookuMemoryConfig(BaseConfig):
             order=2
         )
 
-    @config_section("retrieval", title="检索配置", tag="ai", order=20)
+    @config_section("retrieval", title="检索配置", tag="ai")
     class RetrievalSection(SectionBase):
         """检索与重塑配置。"""
 
@@ -186,7 +186,7 @@ class BookuMemoryConfig(BaseConfig):
             order=9
         )
 
-    @config_section("write_conflict", title="写入冲突检测", tag="ai", order=30)
+    @config_section("write_conflict", title="写入冲突检测", tag="ai")
     class WriteConflictSection(SectionBase):
         """写入冲突检测配置。"""
 
@@ -211,7 +211,7 @@ class BookuMemoryConfig(BaseConfig):
             order=1
         )
 
-    @config_section("time_window", title="隐现记忆窗口", tag="timer", order=40)
+    @config_section("time_window", title="隐现记忆窗口", tag="timer")
     class TimeWindowSection(SectionBase):
         """隐现记忆时间窗口与晋升配置。"""
 
@@ -234,7 +234,7 @@ class BookuMemoryConfig(BaseConfig):
             order=1
         )
 
-    @config_section("internal_llm", title="内部 LLM 配置", tag="ai", order=50)
+    @config_section("internal_llm", title="内部 LLM 配置", tag="ai")
     class InternalLLMSection(SectionBase):
         """Agent 内部 LLM 决策配置。"""
 
@@ -257,7 +257,7 @@ class BookuMemoryConfig(BaseConfig):
             order=1
         )
 
-    @config_section("flashback", title="记忆闪回", tag="ai", order=60)
+    @config_section("flashback", title="记忆闪回", tag="ai")
     class FlashbackSection(SectionBase):
         """记忆闪回配置。
 
@@ -353,7 +353,7 @@ class BookuMemoryConfig(BaseConfig):
             order=6
         )
 
-    @config_section("chunking", title="分块配置", tag="ai", order=20)
+    @config_section("chunking", title="分块配置", tag="ai")
     class ChunkingSection(SectionBase):
         """文档切分参数配置。"""
 
@@ -376,7 +376,7 @@ class BookuMemoryConfig(BaseConfig):
             order=1,
         )
 
-    @config_section("startup_ingest", title="启动自动导入", tag="file", order=50)
+    @config_section("startup_ingest", title="启动自动导入", tag="file")
     class StartupIngestSection(SectionBase):
         """启动阶段本地知识库导入配置。（建议仅有未读文档需要导入时启用）"""
 

--- a/plugins/default_chatter/config.py
+++ b/plugins/default_chatter/config.py
@@ -13,11 +13,11 @@ class DefaultChatterConfig(BaseConfig):
     config_name: ClassVar[str] = "config"
     config_description: ClassVar[str] = "DefaultChatter 配置"
 
-    @config_section("plugin", title="插件设置", tag="plugin", order=0)
+    @config_section("plugin", title="插件设置", tag="plugin")
     class PluginSection(SectionBase):
         """插件基础配置。"""
 
-        @config_section("theme_guide", title="场景引导", tag="text", order=10)
+        @config_section("theme_guide", title="场景引导", tag="text")
         class ThemeGuideSection(SectionBase):
             """不同聊天类型的人设/语气引导。"""
 

--- a/plugins/napcat_adapter/config.py
+++ b/plugins/napcat_adapter/config.py
@@ -12,7 +12,7 @@ class NapcatAdapterConfig(BaseConfig):
     config_name: ClassVar[str] = "config"
     config_description: ClassVar[str] = "Napcat/OneBot 11 适配器配置"
 
-    @config_section("plugin", title="插件设置", tag="plugin", order=0)
+    @config_section("plugin", title="插件设置", tag="plugin")
     class PluginSection(SectionBase):
         """插件基本配置"""
 
@@ -32,7 +32,7 @@ class NapcatAdapterConfig(BaseConfig):
             order=1
         )
 
-    @config_section("bot", title="Bot 配置", tag="user", order=10)
+    @config_section("bot", title="Bot 配置", tag="user")
     class BotSection(SectionBase):
         """Bot 基本配置"""
 
@@ -51,7 +51,7 @@ class NapcatAdapterConfig(BaseConfig):
             order=1
         )
 
-    @config_section("napcat_server", title="Napcat 服务器", tag="network", order=20)
+    @config_section("napcat_server", title="Napcat 服务器", tag="network")
     class NapcatServerSection(SectionBase):
         """Napcat WebSocket 服务器配置"""
 
@@ -92,7 +92,7 @@ class NapcatAdapterConfig(BaseConfig):
             order=3
         )
 
-    @config_section("features", title="功能特性", tag="general", order=30)
+    @config_section("features", title="功能特性", tag="general")
     class FeaturesSection(SectionBase):
         """功能特性配置"""
 

--- a/src/core/config/core_config.py
+++ b/src/core/config/core_config.py
@@ -25,58 +25,120 @@ class CoreConfig(ConfigBase):
         ui_level: str = Field(
             default="verbose",
             description="UI 级别：minimal|standard|verbose",
+            label="UI 级别",
+            tag="general",
+            input_type="select",
+            choices=["minimal", "standard", "verbose"],
+            hint="控制控制台输出的详细程度",
         )
         ui_refresh_interval: float = Field(
             default=1.0,
             description="仪表盘刷新间隔（秒）",
+            label="刷新间隔",
+            tag="performance",
+            input_type="number",
+            step=0.1,
+            hint="控制台仪表盘更新频率",
         )
         plugins_dir: str = Field(
             default="plugins",
             description="插件目录",
+            label="插件目录",
+            tag="file",
+            input_type="text",
+            placeholder="plugins",
         )
         logs_dir: str = Field(
             default="logs",
             description="日志目录",
+            label="日志目录",
+            tag="file",
+            input_type="text",
+            placeholder="logs",
         )
         log_level: str = Field(
             default="INFO",
             description="日志级别：DEBUG/INFO/WARNING/ERROR/CRITICAL",
+            label="日志级别",
+            tag="debug",
+            input_type="select",
+            choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+            hint="控制日志输出的详细程度",
         )
         data_dir: str = Field(
             default="data",
             description="数据目录",
+            label="数据目录",
+            tag="file",
+            input_type="text",
+            placeholder="data",
         )
         shutdown_timeout: float = Field(
             default=15.0,
             description="优雅关闭超时时间（秒）",
+            label="优雅关闭超时",
+            tag="performance",
+            input_type="number",
+            step=0.5,
+            hint="等待任务正常结束的时间",
         )
         force_shutdown_after: float = Field(
             default=5.0,
             description="强制关闭等待时间（秒）",
+            label="强制关闭等待",
+            tag="performance",
+            input_type="number",
+            step=0.5,
+            hint="优雅关闭失败后强制中止的等待时间",
         )
         llm_preflight_check: bool = Field(
             default=True,
             description="启动时执行 LLM 接口连通性预检",
+            label="LLM 预检",
+            tag="ai",
+            input_type="switch",
+            hint="启动时测试 LLM 接口是否可用",
         )
         llm_preflight_timeout: float = Field(
             default=5.0,
             description="LLM 接口预检超时时间（秒）",
+            label="预检超时",
+            tag="ai",
+            input_type="number",
+            step=0.5,
         )
         enable_watchdog: bool = Field(
             default=True,
             description="是否启用 WatchDog 监控（仅调试模式下建议关闭，以避免断点调试时触发超时警告或重启）",
+            label="启用 WatchDog",
+            tag="debug",
+            input_type="switch",
+            hint="调试时建议关闭，避免断点触发超时",
         )
         tick_interval: float = Field(
             default=5.0,
             description="主循环 tick 间隔（秒），过短可能增加消耗，过长可能降低响应速度",
+            label="Tick 间隔",
+            tag="performance",
+            input_type="slider",
+            step=0.5,
+            hint="主循环执行间隔，影响响应速度",
         )
         stream_warning_threshold: float = Field(
             default=150.0,
             description="流循环警告阈值（秒），距上次心跳超过此值时输出警告",
+            label="流警告阈值",
+            tag="debug",
+            input_type="number",
+            step=10.0,
         )
         stream_restart_threshold: float = Field(
             default=300.0,
             description="流循环重启阈值（秒），距上次心跳超过此值时尝试重启",
+            label="流重启阈值",
+            tag="debug",
+            input_type="number",
+            step=10.0,
         )
         stream_step_timeout: float = Field(
             default=90.0,
@@ -84,6 +146,11 @@ class CoreConfig(ConfigBase):
                 "单次聊天流步进超时时间（秒），用于保护 chatter 内部工具调用或外部 await 卡死；"
                 "设为 0 或负数可禁用该保护。"
             ),
+            label="步进超时",
+            tag="performance",
+            input_type="number",
+            step=5.0,
+            hint="设为 0 禁用保护",
         )
         message_buffer_window: float = Field(
             default=8.0,
@@ -91,6 +158,11 @@ class CoreConfig(ConfigBase):
                 "消息缓冲窗口（秒）。收到新消息后，在此时间窗口内的 Tick 将被跳过，"
                 "以等待用户可能发出的连续消息合并处理。设为 0 可禁用此功能。"
             ),
+            label="消息缓冲窗口",
+            tag="performance",
+            input_type="number",
+            step=0.5,
+            hint="等待连续消息合并的时间窗口",
         )
         message_buffer_max_skip: int = Field(
             default=3,
@@ -99,6 +171,10 @@ class CoreConfig(ConfigBase):
                 "防止群聊高压环境下因消息持续涌入导致 Tick 始终被跳过、Bot 无法响应。"
                 "达到上限后强制激活 Chatter，无论缓冲窗口是否已过。"
             ),
+            label="最大跳过次数",
+            tag="performance",
+            input_type="number",
+            hint="防止高频消息导致无响应",
         )
 
     bot: BotSection = Field(default_factory=BotSection)
@@ -113,14 +189,29 @@ class CoreConfig(ConfigBase):
         default_chat_mode: str = Field(
             default="normal",
             description="默认聊天模式：focus/normal/proactive/priority",
+            label="默认聊天模式",
+            tag="ai",
+            input_type="select",
+            choices=["focus", "normal", "proactive", "priority"],
+            hint="决定 Bot 的响应策略",
         )
         max_context_size: int = Field(
             default=20,
             description="每个聊天流的最大上下文消息数",
+            label="最大上下文数",
+            tag="performance",
+            input_type="slider",
+            hint="保留在记忆中的消息数量",
         )
         image_recognition_prompt: str = Field(
             default="",
             description="自定义识图提示词，留空则使用内置默认提示词",
+            label="识图提示词",
+            tag="ai",
+            input_type="textarea",
+            rows=3,
+            placeholder="请描述这张图片的内容...",
+            hint="留空使用默认提示词",
         )
     chat: ChatSection = Field(default_factory=ChatSection)
 
@@ -134,6 +225,11 @@ class CoreConfig(ConfigBase):
         default_policy: Literal["load_balanced", "round_robin"] = Field(
             default="load_balanced",
             description="默认模型调度策略，可选 load_balanced 或 round_robin",
+            label="调度策略",
+            tag="ai",
+            input_type="select",
+            choices=["load_balanced", "round_robin"],
+            hint="load_balanced: 负载均衡, round_robin: 轮询",
         )
 
     llm: LLMSection = Field(default_factory=LLMSection)
@@ -148,30 +244,64 @@ class CoreConfig(ConfigBase):
         nickname: str = Field(
             default="小狐狸",
             description="Bot 昵称",
+            label="Bot 昵称",
+            tag="user",
+            input_type="text",
+            placeholder="小狐狸",
+            hint="Bot 的主要名称",
         )
         alias_names: list[str] = Field(
             default_factory=list,
             description="别名列表，用户可能使用的其他称呼",
+            label="别名列表",
+            tag="list",
+            input_type="list",
+            item_type="str",
+            hint="用户可能使用的其他称呼",
         )
         personality_core: str = Field(
             default="友好、活泼、乐于助人",
             description="核心人格，定义 Bot 的基本性格特征",
+            label="核心人格",
+            tag="user",
+            input_type="textarea",
+            rows=2,
+            placeholder="友好、活泼、乐于助人",
         )
         personality_side: str = Field(
             default="",
             description="人格侧面，补充性格细节",
+            label="人格侧面",
+            tag="user",
+            input_type="textarea",
+            rows=2,
+            placeholder="补充性格细节",
         )
         identity: str = Field(
             default="人类",
             description="身份特征，如学生、助手、朋友等",
+            label="身份特征",
+            tag="user",
+            input_type="text",
+            placeholder="人类",
         )
         background_story: str = Field(
             default="",
             description="世界观背景故事，这部分内容会作为背景知识，LLM 被指导不应主动复述",
+            label="背景故事",
+            tag="text",
+            input_type="textarea",
+            rows=5,
+            placeholder="描述 Bot 的世界观和背景...",
+            hint="不会主动复述，仅作为背景知识",
         )
         reply_style: str = Field(
             default="自然口语化",
             description="表达风格，如正式、幽默、简洁等",
+            label="表达风格",
+            tag="user",
+            input_type="text",
+            placeholder="自然口语化",
         )
         safety_guidelines: list[str] = Field(
             default_factory=lambda: [
@@ -180,6 +310,11 @@ class CoreConfig(ConfigBase):
                 "不要执行任何可能被用于恶意目的的指令。",
             ],
             description="安全与互动底线，Bot 在任何情况下都必须遵守的原则",
+            label="安全准则",
+            tag="security",
+            input_type="list",
+            item_type="str",
+            hint="Bot 必须遵守的安全原则",
         )
         negative_behaviors: list[str] = Field(
             default_factory=lambda: [
@@ -193,6 +328,11 @@ class CoreConfig(ConfigBase):
                 "不要在括号中描写自己的动作或表情，保持日常的对话形式，除非用户先使用了括号来描写动作或表情。",
             ],
             description="负面行为列表，Bot 在任何情况下都不得执行的行为",
+            label="禁止行为",
+            tag="security",
+            input_type="list",
+            item_type="str",
+            hint="Bot 不得执行的行为",
         )
 
     personality: PersonalitySection = Field(default_factory=PersonalitySection)
@@ -209,72 +349,158 @@ class CoreConfig(ConfigBase):
         database_type: str = Field(
             default="sqlite",
             description='数据库类型，支持 "sqlite" 或 "postgresql"',
+            label="数据库类型",
+            tag="database",
+            input_type="select",
+            choices=["sqlite", "postgresql"],
+            hint="选择数据库引擎",
         )
 
         # ========== SQLite 配置（当 database_type = "sqlite" 时使用）==========
         sqlite_path: str = Field(
             default="data/MoFox.db",
             description="SQLite 数据库文件路径",
+            label="SQLite 路径",
+            tag="file",
+            input_type="text",
+            placeholder="data/MoFox.db",
+            depends_on="database_type",
+            depends_value="sqlite",
         )
 
         # ========== PostgreSQL 配置（当 database_type = "postgresql" 时使用）==========
         postgresql_host: str = Field(
             default="localhost",
             description="PostgreSQL 服务器地址",
+            label="服务器地址",
+            tag="network",
+            input_type="text",
+            placeholder="localhost",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_port: int = Field(
             default=5432,
             description="PostgreSQL 服务器端口",
+            label="服务器端口",
+            tag="network",
+            input_type="number",
+            ge=1,
+            le=65535,
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_database: str = Field(
             default="mofox",
             description="PostgreSQL 数据库名",
+            label="数据库名",
+            tag="database",
+            input_type="text",
+            placeholder="mofox",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_user: str = Field(
             default="postgres",
             description="PostgreSQL 用户名",
+            label="用户名",
+            tag="user",
+            input_type="text",
+            placeholder="postgres",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_password: str = Field(
             default="",
             description="PostgreSQL 密码",
+            label="密码",
+            tag="security",
+            input_type="password",
+            placeholder="••••••",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_schema: str = Field(
             default="public",
             description="PostgreSQL 模式名（schema）",
+            label="Schema",
+            tag="database",
+            input_type="text",
+            placeholder="public",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
 
         # ========== PostgreSQL SSL 配置 ==========
         postgresql_ssl_mode: str = Field(
             default="prefer",
             description='SSL 模式: disable, allow, prefer, require, verify-ca, verify-full',
+            label="SSL 模式",
+            tag="security",
+            input_type="select",
+            choices=["disable", "allow", "prefer", "require", "verify-ca", "verify-full"],
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_ssl_ca: str = Field(
             default="",
             description="SSL CA 证书路径",
+            label="CA 证书路径",
+            tag="file",
+            input_type="text",
+            placeholder="/path/to/ca.crt",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_ssl_cert: str = Field(
             default="",
             description="SSL 客户端证书路径",
+            label="客户端证书路径",
+            tag="file",
+            input_type="text",
+            placeholder="/path/to/client.crt",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         postgresql_ssl_key: str = Field(
             default="",
             description="SSL 客户端密钥路径",
+            label="客户端密钥路径",
+            tag="file",
+            input_type="text",
+            placeholder="/path/to/client.key",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
 
         # ========== 连接池配置（PostgreSQL 有效）==========
         connection_pool_size: int = Field(
             default=10,
             description="连接池大小",
+            label="连接池大小",
+            tag="performance",
+            input_type="number",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
         connection_timeout: int = Field(
             default=10,
             description="连接超时时间（秒）",
+            label="连接超时",
+            tag="performance",
+            input_type="number",
+            depends_on="database_type",
+            depends_value="postgresql",
         )
 
         # ========== 通用数据库配置 ==========
         echo: bool = Field(
             default=False,
             description="是否打印 SQL 语句（用于调试）",
+            label="打印 SQL",
+            tag="debug",
+            input_type="switch",
+            hint="开启后会在日志中输出所有 SQL 语句",
         )
 
     database: DatabaseSection = Field(default_factory=DatabaseSection)
@@ -290,58 +516,102 @@ class CoreConfig(ConfigBase):
         owner_list: list[str] = Field(
             default_factory=list,
             description="Bot所有者列表，格式：['platform:user_id', ...]",
+            label="所有者列表",
+            tag="security",
+            input_type="list",
+            item_type="str",
+            placeholder="qq:123456789",
+            hint="格式: platform:user_id",
         )
         default_permission_level: str = Field(
             default="user",
             description="新用户的默认权限级别：owner/operator/user/guest",
+            label="默认权限级别",
+            tag="security",
+            input_type="select",
+            choices=["owner", "operator", "user", "guest"],
         )
 
         # ========== 权限提升规则 ==========
         allow_operator_promotion: bool = Field(
             default=False,
             description="是否允许operator提升他人权限（仅owner默认可提升）",
+            label="允许operator提升权限",
+            tag="security",
+            input_type="switch",
         )
         allow_operator_demotion: bool = Field(
             default=False,
             description="是否允许operator降低他人权限（仅owner默认可降低）",
+            label="允许operator降低权限",
+            tag="security",
+            input_type="switch",
         )
         max_operator_promotion_level: str = Field(
             default="operator",
             description="operator可提升的最高权限级别：operator/user（不能提升为owner）",
+            label="operator最高提升级别",
+            tag="security",
+            input_type="select",
+            choices=["operator", "user"],
         )
 
         # ========== 权限覆盖配置 ==========
         allow_command_override: bool = Field(
             default=True,
             description="是否允许使用命令级权限覆盖（允许特定用户执行特定命令）",
+            label="允许命令权限覆盖",
+            tag="security",
+            input_type="switch",
         )
         override_requires_owner_approval: bool = Field(
             default=False,
             description="命令权限覆盖是否需要owner批准（operator设置的覆盖是否生效）",
+            label="覆盖需owner批准",
+            tag="security",
+            input_type="switch",
         )
 
         # ========== 权限缓存配置 ==========
         enable_permission_cache: bool = Field(
             default=True,
             description="是否启用权限检查缓存（提升性能）",
+            label="启用权限缓存",
+            tag="performance",
+            input_type="switch",
         )
         permission_cache_ttl: int = Field(
             default=300,
             description="权限缓存过期时间（秒），默认5分钟",
+            label="缓存过期时间",
+            tag="performance",
+            input_type="number",
+            hint="单位：秒",
         )
 
         # ========== 权限检查行为 ==========
         strict_mode: bool = Field(
             default=True,
             description="严格模式：权限不足时拒绝执行（非严格模式可能仅记录警告）",
+            label="严格模式",
+            tag="security",
+            input_type="switch",
+            hint="关闭后仅记录警告而不拒绝",
         )
         log_permission_denied: bool = Field(
             default=True,
             description="是否记录权限拒绝日志",
+            label="记录拒绝日志",
+            tag="debug",
+            input_type="switch",
         )
         log_permission_granted: bool = Field(
             default=False,
             description="是否记录权限允许日志（调试用）",
+            label="记录允许日志",
+            tag="debug",
+            input_type="switch",
+            hint="调试用，会产生大量日志",
         )
 
     permissions: PermissionSection = Field(default_factory=PermissionSection)
@@ -356,18 +626,43 @@ class CoreConfig(ConfigBase):
         enable_http_router: bool = Field(
             default=True,
             description="是否启用 HTTP 路由",
+            label="启用 HTTP 路由",
+            tag="network",
+            input_type="switch",
+            hint="关闭后 WebUI 将无法使用",
         )
         http_router_host: str = Field(
             default="127.0.0.1",
             description="HTTP 路由监听地址",
+            label="监听地址",
+            tag="network",
+            input_type="text",
+            placeholder="127.0.0.1",
+            depends_on="enable_http_router",
+            depends_value=True,
         )
         http_router_port: int = Field(
             default=8000,
             description="HTTP 路由监听端口",
+            label="监听端口",
+            tag="network",
+            input_type="number",
+            ge=1,
+            le=65535,
+            depends_on="enable_http_router",
+            depends_value=True,
         )
         api_keys: list[str] = Field(
             default_factory=list,
             description="WebUI API 访问密钥列表，留空则禁用认证（不推荐）",
+            label="API 密钥列表",
+            tag="security",
+            input_type="list",
+            item_type="str",
+            placeholder="your-secret-api-key",
+            hint="留空禁用认证（不推荐）",
+            depends_on="enable_http_router",
+            depends_value=True,
         )
     http_router: HttpRouterSection = Field(default_factory=HttpRouterSection)
 
@@ -381,14 +676,26 @@ class CoreConfig(ConfigBase):
         force_sync_http: bool = Field(
             default=False,
             description="全局强制使用同步 HTTP（OpenAI SDK 同步路径，仅非流式）",
+            label="强制同步 HTTP",
+            tag="advanced",
+            input_type="switch",
+            hint="仅在遇到异步兼容性问题时开启",
         )
         trust_env: bool = Field(
             default=True,
             description="是否信任系统代理与环境变量（httpx trust_env）",
+            label="信任系统代理",
+            tag="network",
+            input_type="switch",
+            hint="是否使用系统代理设置",
         )
         process_workers: int = Field(
             default=4,
             description="TaskManager 进程池大小，用于承载 CPU 密集型任务",
+            label="进程池大小",
+            tag="performance",
+            input_type="number",
+            hint="CPU 密集型任务的并发数",
         )
 
     advanced: AdvancedSection = Field(default_factory=AdvancedSection)
@@ -403,14 +710,27 @@ class CoreConfig(ConfigBase):
         enabled: bool = Field(
             default=True,
             description="是否启用插件依赖自动安装，设为 false 则完全跳过",
+            label="启用自动安装",
+            tag="plugin",
+            input_type="switch",
+            hint="自动安装插件所需的依赖包",
         )
         install_command: str = Field(
             default="uv pip install",
             description="安装依赖时使用的命令前缀，支持 \"uv pip install\"、\"pip install\" 等",
+            label="安装命令",
+            tag="plugin",
+            input_type="select",
+            choices=["uv pip install", "pip install"],
+            hint="选择包管理器",
         )
         skip_if_satisfied: bool = Field(
             default=True,
             description="仅在缺少所需包时才触发安装，避免重复安装耗时",
+            label="跳过已安装",
+            tag="performance",
+            input_type="switch",
+            hint="避免重复安装",
         )
 
     plugin_deps: PluginDepsSection = Field(default_factory=PluginDepsSection)

--- a/src/kernel/config/core.py
+++ b/src/kernel/config/core.py
@@ -65,7 +65,6 @@ def Field(  # noqa: N802
     ] | None = None,  # 预设标签（系统会映射到对应图标）
     placeholder: str | None = None,  # 输入框占位符文本
     hint: str | None = None,  # 帮助提示文本
-    order: int = 0,  # 显示顺序（越小越靠前）
     hidden: bool = False,  # 是否隐藏
     disabled: bool = False,  # 是否禁用（只读）
     # === 输入控件类型 ===
@@ -127,7 +126,6 @@ def Field(  # noqa: N802
         tag: 预设标签（如 "ai", "security"），系统会自动映射到对应图标
         placeholder: 输入框占位符
         hint: 帮助提示文本
-        order: 显示顺序（数字越小越靠前）
         hidden: 是否隐藏
         disabled: 是否禁用（只读）
 
@@ -212,7 +210,6 @@ def Field(  # noqa: N802
         "tag": tag,
         "placeholder": placeholder,
         "hint": hint,
-        "order": order,
         "hidden": hidden,
         "disabled": disabled,
         # 控件类型
@@ -281,7 +278,6 @@ def config_section(
         "notification",
         "plugin",
     ] | None = None,
-    order: int = 0,
 ) -> Callable[[type[SectionT]], type[SectionT]]:
     """配置节装饰器（增强版）。
 
@@ -292,7 +288,6 @@ def config_section(
         title: WebUI 显示标题（可选，不指定则使用节名美化）
         description: 节描述（可选，不指定则使用类 docstring 首行）
         tag: 预设标签（可选），系统会自动映射到对应图标
-        order: 显示顺序，数字越小越靠前（默认 0）
 
     Returns:
         装饰器函数
@@ -308,7 +303,6 @@ def config_section(
                 title="通用设置",
                 description="基本配置选项",
                 tag="general",
-                order=0,
             )
             class GeneralSection(SectionBase):
                 enabled: bool = Field(default=True, description="启用功能")
@@ -322,7 +316,6 @@ def config_section(
         cls.__config_section_title__ = title  # type: ignore[attr-defined]
         cls.__config_section_description__ = description  # type: ignore[attr-defined]
         cls.__config_section_tag__ = tag  # type: ignore[attr-defined]
-        cls.__config_section_order__ = order  # type: ignore[attr-defined]
         return cls
 
     return decorator
@@ -353,7 +346,6 @@ class ConfigBase(BaseModel):
                 title="通用设置",
                 description="基本配置选项",
                 tag="general",
-                order=0,
             )
             class GeneralSection(SectionBase):
                 enabled: bool = Field(default=True, description="启用功能")
@@ -365,7 +357,6 @@ class ConfigBase(BaseModel):
                 title="高级设置",
                 description="除非你知道自己在干什么，否则别动",
                 tag="advanced",
-                order=100,
             )
             class AdvancedSection(SectionBase):
                 debug_mode: bool = Field(default=False, description="调试模式")


### PR DESCRIPTION
### 变更概述
本次提交对配置系统进行了重构，主要包括两个方面的改进：

1. **简化配置排序机制**：移除了 `order` 参数
2. **增强字段元数据**：为配置字段添加了丰富的 WebUI 展示元数据

### 详细变更

#### 1. 移除 `order` 参数
- ✅ 从 `src/kernel/config/core.py` 中移除：
  - `Field()` 函数的 `order` 参数
  - `config_section()` 装饰器的 `order` 参数
- ✅ 同步更新所有插件配置文件：
  - `plugins/booku_memory/config.py` - 移除所有 `@config_section` 的 `order` 参数
  - `plugins/default_chatter/config.py` - 移除所有 `@config_section` 的 `order` 参数
  - `plugins/napcat_adapter/config.py` - 移除所有 `@config_section` 的 `order` 参数

#### 2. 增强核心配置元数据 (`src/core/config/core_config.py`)
为 `CoreConfig` 中的所有配置字段添加了完整的 WebUI 元数据支持：

**新增字段元数据包括：**
- `label` - 用户友好的显示标签
- `tag` - 分类标签（general/ai/security/performance/debug/network/file/database/user/text/list/timer/plugin/advanced）
- `input_type` - 输入控件类型（text/switch/select/number/slider/textarea/password/list）
- `hint` - 帮助提示信息
- `placeholder` - 输入占位符
- `depends_on` / `depends_value` - 条件显示逻辑
- 控件特定属性：
  - `choices` - 下拉选项（select）
  - `step` - 数值步长（number/slider）
  - `rows` - 文本行数（textarea）
  - `ge` / `le` - 数值范围（number）
  - `item_type` - 列表项类型（list）

**涉及的配置节：**
- `bot` - Bot 基础配置（UI级别、目录路径、日志、超时等）
- `chat` - 聊天配置（模式、上下文大小、识图提示）
- `llm` - LLM 配置（调度策略）
- `personality` - 人格配置（昵称、性格、身份、风格、安全准则等）
- `database` - 数据库配置（SQLite/PostgreSQL 完整配置）
- `permissions` - 权限配置（权限级别、提升规则、缓存、日志等）
- `http_router` - HTTP 路由配置（启用开关、地址端口、API密钥）
- `advanced` - 高级配置（同步HTTP、进程池等）
- `plugin_deps` - 插件依赖配置（自动安装、安装命令等）

### 技术优势

#### 优化前
```python
@config_section("bot", order=0)
class BotSection(SectionBase):
    ui_level: str = Field(default="verbose", description="UI 级别")
```

#### 优化后
```python
@config_section("bot")
class BotSection(SectionBase):
    ui_level: str = Field(
        default="verbose",
        description="UI 级别：minimal|standard|verbose",
        label="UI 级别",
        tag="general",
        input_type="select",
        choices=["minimal", "standard", "verbose"],
        hint="控制控制台输出的详细程度"
    )
```

### 影响范围
- ✅ 配置系统核心 API
- ✅ 核心配置文件
- ✅ 3 个内置插件配置文件
- ⚠️ **需关注**：其他第三方插件如果使用了 `order` 参数需要同步更新

### 测试建议
1. ✅ 配置文件加载测试
2. ✅ WebUI 配置页面渲染测试
3. ✅ 配置字段元数据序列化测试
4. ✅ 插件配置继承兼容性测试
5. ⚠️ 第三方插件兼容性测试

### 后续工作
- [ ] 其他内置插件配置文件的元数据补全（如果有）
- [ ] 文档更新：配置系统开发指南
- [ ] WebUI 配置编辑器的元数据渲染实现

### Breaking Changes
⚠️ **不兼容变更**：移除了 `order` 参数

**影响的 API：**
- `src.kernel.config.core.Field(order=...)`
- `src.kernel.config.core.config_section(order=...)`

**迁移指南：**
```python
# 旧代码
@config_section("general", order=0)
class GeneralSection(SectionBase):
    enabled: bool = Field(default=True, order=1)

# 新代码（移除 order 参数）
@config_section("general")
class GeneralSection(SectionBase):
    enabled: bool = Field(
        default=True,
        label="启用",
        tag="plugin",
        input_type="switch"
    )
```

## Summary by Sourcery

Remove configuration display-order support and enrich core configuration with WebUI metadata.

New Features:
- Add rich WebUI presentation metadata (labels, tags, input types, hints, placeholders, validation and dependency info) to core configuration fields across bot, chat, LLM, personality, database, permission, HTTP router, advanced and plugin dependency sections.

Enhancements:
- Simplify the configuration decorator and field API by removing the order parameter and related section ordering metadata from the core config system.
- Update built-in plugin configuration sections to align with the new ordering-less config_section API while preserving existing semantics.