### PR TITLE
Feat/plugin query enhancement

### DIFF
--- a/src/app/plugin_system/api/plugin_api.py
+++ b/src/app/plugin_system/api/plugin_api.py
@@ -154,6 +154,48 @@ def is_plugin_loaded(plugin_name: str) -> bool:
     return _get_plugin_manager().is_plugin_loaded(plugin_name)
 
 
+def get_plugin_path(plugin_name: str) -> str | None:
+    """获取插件路径。
+
+    Args:
+        plugin_name: 插件名称
+
+    Returns:
+        插件路径，未找到则返回 None
+    """
+    _validate_non_empty(plugin_name, "plugin_name")
+    return _get_plugin_manager().get_plugin_path(plugin_name)
+
+
+async def list_unloaded_plugins() -> dict[str, dict]:
+    """列出plugins目录下所有未加载的插件。
+
+    返回所有未加载插件的详细信息，包括未主动加载的插件和加载失败的插件。
+
+    Returns:
+        dict[str, dict]: 插件名到插件信息的字典，格式为：
+            {
+                "plugin_name": {
+                    "name": str,
+                    "version": str,
+                    "description": str,
+                    "author": str,
+                    "path": str,
+                    "status": "not_loaded" | "failed",
+                    "reason": str | None,  # 失败原因（仅status为failed时）
+                }
+            }
+
+    Examples:
+        >>> unloaded = await list_unloaded_plugins("plugins")
+        >>> for name, info in unloaded.items():
+        ...     print(f"{name}: {info['status']}")
+        ...     if info['reason']:
+        ...         print(f"  原因: {info['reason']}")
+    """
+    return await _get_plugin_manager().get_unloaded_plugins_info()
+
+
 __all__ = [
     "load_plugin_from_manifest",
     "load_plugin",
@@ -164,4 +206,6 @@ __all__ = [
     "list_loaded_plugins",
     "get_manifest",
     "is_plugin_loaded",
+    "get_plugin_path",
+    "list_unloaded_plugins",
 ]

--- a/src/core/managers/plugin_manager.py
+++ b/src/core/managers/plugin_manager.py
@@ -441,6 +441,98 @@ class PluginManager:
         """
         return plugin_name in self._loaded_plugins
 
+    def get_plugin_path(self, plugin_name: str) -> str | None:
+        """获取插件路径。
+
+        Args:
+            plugin_name: 插件名称
+
+        Returns:
+            str | None: 插件路径，如果未找到则返回 None
+
+        Examples:
+            >>> path = manager.get_plugin_path("my_plugin")
+            >>> print(path)
+            'plugins/my_plugin'
+        """
+        return self._plugin_paths.get(plugin_name)
+
+    async def get_unloaded_plugins_info(
+        self
+    ) -> dict[str, dict[str, Any]]:
+        """获取所有未加载插件的信息。
+
+        扫描插件目录，返回所有未加载插件的详细信息，包括未主动加载的插件和加载失败的插件。
+
+        Args:
+            plugins_dir: 插件目录路径
+
+        Returns:
+            dict[str, dict[str, Any]]: 插件名到插件信息的字典，格式为：
+                {
+                    "plugin_name": {
+                        "name": str,
+                        "version": str,
+                        "description": str,
+                        "author": str,
+                        "path": str,
+                        "status": "not_loaded" | "failed",
+                        "reason": str | None,  # 失败原因
+                    }
+                }
+
+        Examples:
+            >>> unloaded = await manager.get_unloaded_plugins_info("plugins")
+            >>> for name, info in unloaded.items():
+            ...     print(f"{name}: {info['status']} - {info.get('reason', 'N/A')}")
+        """
+        from src.core.components.loader import PluginLoader, load_manifest
+
+        loader = PluginLoader()
+
+        # 发现所有插件
+        discovered_paths = await loader.discover_plugins(str("plugins"))
+
+        unloaded_info: dict[str, dict[str, Any]] = {}
+
+        for plugin_path in discovered_paths:
+            manifest = await load_manifest(plugin_path)
+            if not manifest:
+                # manifest 加载失败的插件
+                unloaded_info[plugin_path] = {
+                    "name": Path(plugin_path).stem,
+                    "version": "unknown",
+                    "description": "无法读取插件信息",
+                    "author": "unknown",
+                    "path": plugin_path,
+                    "status": "failed",
+                    "reason": "无法加载 manifest.json",
+                }
+                continue
+
+            plugin_name = manifest.name
+
+            # 跳过已加载的插件
+            if plugin_name in self._loaded_plugins:
+                continue
+
+            # 构建插件信息
+            status = "failed" if plugin_name in self._failed_plugins else "not_loaded"
+            reason = self._failed_plugins.get(plugin_name, None)
+
+            unloaded_info[plugin_name] = {
+                "name": manifest.name,
+                "version": manifest.version,
+                "description": manifest.description,
+                "author": manifest.author,
+                "path": plugin_path,
+                "status": status,
+                "reason": reason,
+            }
+
+        logger.debug(f"发现 {len(unloaded_info)} 个未加载插件")
+        return unloaded_info
+
     # === 私有方法 ===
 
     # manifest 读取 / 版本校验 / 依赖解析：已迁移至 loader.PluginLoader


### PR DESCRIPTION
📝 变更概述
为插件管理系统增加两个查询功能，提升插件管理能力：

查询插件路径
列出所有未加载的插件详细信息
✨ 新增功能
1. get_plugin_path - 插件路径查询
API 层 (plugin_api.py):

新增 get_plugin_path(plugin_name: str) -> str | None
通过插件名称获取其文件系统路径
管理器层 (plugin_manager.py):

实现 get_plugin_path 方法
从 _plugin_paths 字典中查询路径
使用场景:

WebUI 插件管理界面显示插件位置
调试和故障排查
插件配置文件访问
2. list_unloaded_plugins - 未加载插件列表
API 层 (plugin_api.py):

新增 list_unloaded_plugins() -> dict[str, dict]
异步接口，返回结构化的插件信息
管理器层 (plugin_manager.py):

实现 get_unloaded_plugins_info 方法
扫描插件目录，识别未加载和加载失败的插件
返回详细信息：name, version, description, author, path, status, reason
返回格式:

使用场景:
WebUI

🎯 设计亮点
✅ 保持三层架构一致性（API层→Manager层）
✅ 完整的类型注解和文档字符串
✅ 参数校验（_validate_non_empty）
✅ 区分未加载与加载失败两种状态
✅ 提供失败原因追溯（_failed_plugins）
📦 影响范围
新增: 4 个公共函数/方法
修改: __all__ 导出列表
依赖: 复用现有 PluginLoader 和 load_manifest
向后兼容: ✅ 纯新增功能，无破坏性变更


此PR为WebUI插件管理模块提供后端支持，是插件管理功能完善的重要一步。

## Summary by Sourcery

Add backend support to query plugin paths and list detailed information for unloaded plugins in the plugin management system.

New Features:
- Expose a manager-level API to retrieve the filesystem path of a plugin by name.
- Expose an async API to list all unloaded or failed plugins with structured metadata for each.

Enhancements:
- Wire new plugin query capabilities through the public plugin API, including input validation and exports.