### PR TITLE
feat: implement native multimodal for default_chatter and granular VLM skipping

### DIFF
--- a/plugins/default_chatter/config.py
+++ b/plugins/default_chatter/config.py
@@ -86,6 +86,28 @@ class DefaultChatterConfig(BaseConfig):
             tag="performance",
             hint="有效范围为 0.0 到 1.0。"
         )
+        native_multimodal: bool = Field(
+            default=False,
+            description=(
+                "原生多模态模式。启用后，图片直接以 base64 形式打包进 LLM payload，"
+                "由主模型在对话上下文中理解图片内容，跳过框架的 VLM 文字识别环节，"
+                "避免空转浪费 token；表情包仍走 VLM 识别以利用哈希缓存。"
+                "需确保 actor 任务对应的模型支持多模态输入。"
+            ),
+            label="原生多模态",
+            tag="ai",
+            hint="启用前请确认 actor 模型支持图片输入"
+        )
+        max_images_per_payload: int = Field(
+            default=4,
+            description=(
+                "原生多模态模式下的总图片配额（单次 payload 中所有来源的图片上限）。"
+                "配额由 bot 已发图片、用户新消息图片、历史图片三者共同占用，"
+                "优先级依次为：bot 已发 > 用户新消息 > 历史补充。"
+            ),
+            label="单次最大图片数",
+            tag="ai"
+        )
         theme_guide: ThemeGuideSection = Field(
             default_factory=ThemeGuideSection,
             description="按聊天类型区分的额外提示词",

--- a/plugins/default_chatter/decision_agent.py
+++ b/plugins/default_chatter/decision_agent.py
@@ -110,11 +110,12 @@ async def decide_should_respond(
         return {"should_respond": True, "reason": "未找到 sub_actor 配置，默认响应"}
 
     nickname = get_core_config().personality.nickname
+    bot_id = chat_stream.bot_id or ""
     tmpl = get_prompt_manager().get_template("default_chatter_sub_agent_prompt")
     if tmpl:
-        sub_prompt = await tmpl.set("nickname", nickname).build()
+        sub_prompt = await tmpl.set("nickname", nickname).set("bot_id", bot_id).build()
     else:
-        sub_prompt = fallback_prompt.format(nickname=nickname)
+        sub_prompt = fallback_prompt.format(nickname=nickname, bot_id=bot_id)
 
     request.add_payload(LLMPayload(ROLE.SYSTEM, Text(sub_prompt)))
 

--- a/plugins/default_chatter/decision_agent.py
+++ b/plugins/default_chatter/decision_agent.py
@@ -111,9 +111,16 @@ async def decide_should_respond(
 
     nickname = get_core_config().personality.nickname
     bot_id = chat_stream.bot_id or ""
+    bot_id_section = f"它的 QQ 号是 {bot_id}。\n" if bot_id else ""
     tmpl = get_prompt_manager().get_template("default_chatter_sub_agent_prompt")
     if tmpl:
-        sub_prompt = await tmpl.set("nickname", nickname).set("bot_id", bot_id).build()
+        sub_prompt = (
+            await tmpl
+            .set("nickname", nickname)
+            .set("bot_id", bot_id)
+            .set("bot_id_section", bot_id_section)
+            .build()
+        )
     else:
         sub_prompt = fallback_prompt.format(nickname=nickname, bot_id=bot_id)
 

--- a/plugins/default_chatter/multimodal.py
+++ b/plugins/default_chatter/multimodal.py
@@ -1,0 +1,159 @@
+"""DefaultChatter 原生多模态辅助模块。
+
+提供与 KFC 多模态相同语义的图片提取与 LLM 内容拼装能力，但默认仅
+处理 ``image`` 类型；表情包仍交由框架的 VLM 走文字描述路径，以利用
+其哈希缓存。
+
+模块保持纯函数 / 数据类形态，不依赖运行时单例，便于单测覆盖。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from src.core.models.message import Message
+from src.kernel.llm import Content, Image, Text
+from src.kernel.llm.payload.tooling import LLMUsable
+
+
+@dataclass
+class MediaItem:
+    """从消息中提取的媒体条目（DFC 仅使用 image 类型）。"""
+
+    media_type: str  # 当前固定为 "image"
+    base64_data: str  # 原始 base64 数据（"base64|..." 格式）
+    source_message_id: str  # 来源消息 ID
+
+
+class ImageBudget:
+    """跨 payload 的图片预算追踪器。
+
+    在 enhanced 工作流开始时创建一次实例，bot 已发图片、用户新消息图片、
+    历史图片三者共享同一总配额，避免重复占用。
+    """
+
+    def __init__(self, total_max: int = 4) -> None:
+        """初始化图片预算。
+
+        Args:
+            total_max: 单次 payload 中允许出现的最大图片数量
+        """
+        self._total_max = total_max
+        self._used = 0
+
+    @property
+    def remaining(self) -> int:
+        """剩余可用图片配额。"""
+        return max(0, self._total_max - self._used)
+
+    def consume(self, count: int) -> None:
+        """消耗图片配额。"""
+        self._used += count
+
+    def is_exhausted(self) -> bool:
+        """配额是否已用尽。"""
+        return self._used >= self._total_max
+
+
+def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
+    """从 ``Message`` 中提取仅包含 ``image`` 类型的媒体列表。
+
+    DFC 多模态模式下，表情包继续走 VLM 文字描述（受益于哈希缓存），
+    因此这里显式过滤掉 ``emoji`` / ``voice`` 等非图片类型。
+
+    Args:
+        msg: 消息对象
+
+    Returns:
+        仅含 ``{"type": "image", "data": ...}`` 的字典列表；无图片返回空
+    """
+    media = _read_raw_media(msg)
+    return [item for item in media if item.get("type") == "image" and item.get("data")]
+
+
+def extract_images_from_messages(
+    messages: list[Message],
+    max_items: int,
+) -> list[MediaItem]:
+    """按顺序从消息列表中提取图片，最多 ``max_items`` 张。
+
+    Args:
+        messages: 待扫描的消息（可为未读消息或历史消息子集）
+        max_items: 提取上限，调用方需保证 >= 0
+
+    Returns:
+        提取到的 ``MediaItem`` 列表，按消息顺序截断至 ``max_items``
+    """
+    items: list[MediaItem] = []
+    if max_items <= 0:
+        return items
+
+    for msg in messages:
+        if len(items) >= max_items:
+            break
+        msg_id = msg.message_id or ""
+        for media in get_image_media_list(msg):
+            if len(items) >= max_items:
+                break
+            items.append(
+                MediaItem(
+                    media_type="image",
+                    base64_data=str(media["data"]),
+                    source_message_id=msg_id,
+                )
+            )
+    return items
+
+
+def build_multimodal_content(
+    text: str,
+    media_items: list[MediaItem],
+) -> list[Content | LLMUsable]:
+    """将文本与图片打包为 LLMPayload 可接受的 content 列表。
+
+    Args:
+        text: 文本主体
+        media_items: 按消息时序排列的图片条目列表
+
+    Returns:
+        ``[Text(text), Image(data1), Image(data2), ...]`` 格式的内容列表
+    """
+    content_list: list[Content | LLMUsable] = [Text(text)]
+    for item in media_items:
+        content_list.append(Image(item.base64_data))
+    return content_list
+
+
+# ──────────────────────────────────────────
+# 内部辅助
+# ──────────────────────────────────────────
+
+
+def _read_raw_media(msg: Message) -> list[dict[str, Any]]:
+    """读取消息中尚未被剥离 base64 的原始 media 列表。
+
+    与 KFC 一致地按多个候选位置查找；任一位置只要含 ``data`` 字段即视为
+    有效来源。stream_manager 持久化时会剔除超大 ``data``，此处仅在
+    Chatter 运行期内使用，因此能拿到完整字节。
+    """
+    content = msg.content
+
+    if isinstance(content, dict):
+        media = content.get("media")
+        if isinstance(media, list) and any(
+            isinstance(item, dict) and item.get("data") for item in media
+        ):
+            return [item for item in media if isinstance(item, dict)]
+
+    extra = msg.extra
+    if isinstance(extra, dict):
+        media = extra.get("media")
+        if isinstance(media, list) and media:
+            return [item for item in media if isinstance(item, dict)]
+
+    direct_media = getattr(msg, "media", None)
+    if isinstance(direct_media, list) and direct_media:
+        return [item for item in direct_media if isinstance(item, dict)]
+
+    return []

--- a/plugins/default_chatter/multimodal.py
+++ b/plugins/default_chatter/multimodal.py
@@ -113,8 +113,4 @@ def _read_raw_media(msg: Message) -> list[dict[str, Any]]:
         if items:
             return items
 
-    items = _extract_dict_list(getattr(msg, "media", None))
-    if items:
-        return items
-
     return []

--- a/plugins/default_chatter/multimodal.py
+++ b/plugins/default_chatter/multimodal.py
@@ -4,56 +4,16 @@
 处理 ``image`` 类型；表情包仍交由框架的 VLM 走文字描述路径，以利用
 其哈希缓存。
 
-模块保持纯函数 / 数据类形态，不依赖运行时单例，便于单测覆盖。
+模块保持纯函数形态，不依赖运行时单例，便于单测覆盖。
 """
 
 from __future__ import annotations
 
-from dataclasses import dataclass
 from typing import Any
 
 from src.core.models.message import Message
 from src.kernel.llm import Content, Image, Text
 from src.kernel.llm.payload.tooling import LLMUsable
-
-
-@dataclass
-class MediaItem:
-    """从消息中提取的媒体条目（DFC 仅使用 image 类型）。"""
-
-    media_type: str  # 当前固定为 "image"
-    base64_data: str  # 原始 base64 数据（"base64|..." 格式）
-    source_message_id: str  # 来源消息 ID
-
-
-class ImageBudget:
-    """跨 payload 的图片预算追踪器。
-
-    在 enhanced 工作流开始时创建一次实例，bot 已发图片、用户新消息图片、
-    历史图片三者共享同一总配额，避免重复占用。
-    """
-
-    def __init__(self, total_max: int = 4) -> None:
-        """初始化图片预算。
-
-        Args:
-            total_max: 单次 payload 中允许出现的最大图片数量
-        """
-        self._total_max = total_max
-        self._used = 0
-
-    @property
-    def remaining(self) -> int:
-        """剩余可用图片配额。"""
-        return max(0, self._total_max - self._used)
-
-    def consume(self, count: int) -> None:
-        """消耗图片配额。"""
-        self._used += count
-
-    def is_exhausted(self) -> bool:
-        """配额是否已用尽。"""
-        return self._used >= self._total_max
 
 
 def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
@@ -75,7 +35,7 @@ def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
 def extract_images_from_messages(
     messages: list[Message],
     max_items: int,
-) -> list[MediaItem]:
+) -> list[dict[str, Any]]:
     """按顺序从消息列表中提取图片，最多 ``max_items`` 张。
 
     Args:
@@ -83,45 +43,38 @@ def extract_images_from_messages(
         max_items: 提取上限，调用方需保证 >= 0
 
     Returns:
-        提取到的 ``MediaItem`` 列表，按消息顺序截断至 ``max_items``
+        提取到的媒体字典列表，按消息顺序截断至 ``max_items``
     """
-    items: list[MediaItem] = []
+    items: list[dict[str, Any]] = []
     if max_items <= 0:
         return items
 
     for msg in messages:
         if len(items) >= max_items:
             break
-        msg_id = msg.message_id or ""
         for media in get_image_media_list(msg):
             if len(items) >= max_items:
                 break
-            items.append(
-                MediaItem(
-                    media_type="image",
-                    base64_data=str(media["data"]),
-                    source_message_id=msg_id,
-                )
-            )
+            items.append(media)
     return items
 
 
 def build_multimodal_content(
     text: str,
-    media_items: list[MediaItem],
+    media_items: list[dict[str, Any]],
 ) -> list[Content | LLMUsable]:
     """将文本与图片打包为 LLMPayload 可接受的 content 列表。
 
     Args:
         text: 文本主体
-        media_items: 按消息时序排列的图片条目列表
+        media_items: 按消息时序排列的图片媒体字典列表
 
     Returns:
         ``[Text(text), Image(data1), Image(data2), ...]`` 格式的内容列表
     """
     content_list: list[Content | LLMUsable] = [Text(text)]
     for item in media_items:
-        content_list.append(Image(item.base64_data))
+        content_list.append(Image(str(item["data"])))
     return content_list
 
 
@@ -130,30 +83,38 @@ def build_multimodal_content(
 # ──────────────────────────────────────────
 
 
+def _extract_dict_list(raw: Any) -> list[dict[str, Any]] | None:
+    """将原始值转换为仅含 dict 元素的列表；非列表或空列表返回 None。"""
+    if isinstance(raw, list) and raw:
+        return [item for item in raw if isinstance(item, dict)]
+    return None
+
+
 def _read_raw_media(msg: Message) -> list[dict[str, Any]]:
     """读取消息中尚未被剥离 base64 的原始 media 列表。
 
-    与 KFC 一致地按多个候选位置查找；任一位置只要含 ``data`` 字段即视为
-    有效来源。stream_manager 持久化时会剔除超大 ``data``，此处仅在
-    Chatter 运行期内使用，因此能拿到完整字节。
+    按优先级依次检查三个候选位置：
+    1. ``msg.content["media"]`` — 要求至少一项含 ``data`` 字段（完整媒体）
+    2. ``msg.extra["media"]`` — 非空列表即可
+    3. ``msg.media`` 属性 — 非空列表即可
+
+    stream_manager 持久化时会剔除超大 ``data``，此处仅在 Chatter 运行期
+    内使用，因此能拿到完整字节。
     """
     content = msg.content
-
     if isinstance(content, dict):
-        media = content.get("media")
-        if isinstance(media, list) and any(
-            isinstance(item, dict) and item.get("data") for item in media
-        ):
-            return [item for item in media if isinstance(item, dict)]
+        items = _extract_dict_list(content.get("media"))
+        if items and any(item.get("data") for item in items):
+            return items
 
     extra = msg.extra
     if isinstance(extra, dict):
-        media = extra.get("media")
-        if isinstance(media, list) and media:
-            return [item for item in media if isinstance(item, dict)]
+        items = _extract_dict_list(extra.get("media"))
+        if items:
+            return items
 
-    direct_media = getattr(msg, "media", None)
-    if isinstance(direct_media, list) and direct_media:
-        return [item for item in direct_media if isinstance(item, dict)]
+    items = _extract_dict_list(getattr(msg, "media", None))
+    if items:
+        return items
 
     return []

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -217,19 +217,23 @@ sub_agent_system_prompt = """你是一个聊天意图识别助手。
 
 # 关于主机器人
 主机器人的名字是 {nickname}。
+它的 QQ 号是 {bot_id}。
 {personality_core_section}{personality_side_section}
 # 判定准则
 你应该在以下情况判定为 "需要回复" (should_respond = true)：
-1. 明确提及：消息中明确提到了机器人的名字({nickname})或代称。
+1. 明确提及：
+   - 消息中明确提到了机器人的名字({nickname})或代称。
+   - 消息中存在艾特(@)行为，且艾特的 QQ 号必须是 {bot_id}。**注意：如果艾特的 QQ 号不是 {bot_id}，则绝对不是在叫它，即使艾特的昵称看起来像。**
 2. 话题相关：消息内容与当前正在进行的话题高度相关，需要机器人进一步说明、回答或参与。
 3. 话语完整：对方的话已经说完，或者是一个完整的问题/指令。
 4. 情感互动：对方在表达某种需要回应的情绪（如问候、告别、称赞、抱怨等）。
 
 你应该在以下情况判定为 "不需要回复" (should_respond = false)：
 1. 话题无关：消息是群聊中的闲聊，且机器人并非话题参与者。
-2. 话未说完：明显是一连串消息中的中间部分，可以继续等待后续。
-3. 机器博弈：检测到是其他 Bot 的自动回复或无意义的刷屏消息。
-4. 纯粹表情：只有单个表情且不携带任何需要回复的语义。
+2. 艾特他人：消息艾特了其他人（QQ 号不是 {bot_id}）。
+3. 话未说完：明显是一连串消息中的中间部分，可以继续等待后续。
+4. 机器博弈：检测到是其他 Bot 的自动回复或无意义的刷屏消息。
+5. 纯粹表情：只有单个表情且不携带任何需要回复的语义。
 
 # 输出格式
 请务必返回 JSON 格式，如下所示：
@@ -703,20 +707,15 @@ class DefaultChatter(BaseChatter):
         formatted_text: str,
     ) -> None:
         """在未发送前合并未读消息到最后一个 USER payload。"""
-        if response.payloads:
+        if response.payloads and response.payloads[-1].role == ROLE.USER:
             last_payload = response.payloads[-1]
-            if last_payload.role == ROLE.USER:
-                if last_payload.content and isinstance(last_payload.content[-1], Text):
-                    existing_text = last_payload.content[-1].text
-                    separator = "\n" if existing_text else ""
-                    last_payload.content[-1] = Text(
-                        f"{existing_text}{separator}{formatted_text}"
-                    )
-                else:
-                    last_payload.content.append(Text(formatted_text))
-                return
-
-        response.add_payload(LLMPayload(ROLE.USER, Text(formatted_text)))
+            if last_payload.content and isinstance(last_payload.content[-1], Text):
+                existing_text = last_payload.content[-1].text
+                last_payload.content[-1] = Text(f"{existing_text}\n{formatted_text}")
+            else:
+                last_payload.content.append(Text(formatted_text))
+        else:
+            response.add_payload(LLMPayload(ROLE.USER, Text(formatted_text)))
 
     async def sub_agent(
         self,
@@ -797,11 +796,15 @@ class DefaultChatter(BaseChatter):
     ) -> AsyncGenerator[Wait | Success | Failure | Stop, WaitResumeEvent | None]:
         """执行 DefaultChatter 对话流程。"""
         plugin_config = getattr(self.plugin, "config", None)
-        enable_cooldown = (
-            plugin_config.plugin.enable_cooldown
-            if isinstance(plugin_config, DefaultChatterConfig)
-            else False
-        )
+        if isinstance(plugin_config, DefaultChatterConfig):
+            enable_cooldown = plugin_config.plugin.enable_cooldown
+            native_multimodal = plugin_config.plugin.native_multimodal
+            max_images_per_payload = plugin_config.plugin.max_images_per_payload
+        else:
+            enable_cooldown = False
+            native_multimodal = False
+            max_images_per_payload = 4
+
         runner = run_enhanced(
             chatter=self,
             chat_stream=chat_stream,
@@ -811,6 +814,8 @@ class DefaultChatter(BaseChatter):
             suspend_text=_SUSPEND_TEXT,
             enable_action_suspend=self._is_action_suspend_enabled(),
             enable_cooldown=enable_cooldown,
+            native_multimodal=native_multimodal,
+            max_images_per_payload=max_images_per_payload,
         )
         resume_event: WaitResumeEvent | None = None
 
@@ -892,6 +897,7 @@ class DefaultChatterPlugin(BasePlugin):
             template=sub_agent_system_prompt,
             policies={
                 "nickname": optional(personality.nickname),
+                "bot_id": optional(""),
                 "personality_core_section": optional(personality.personality_core)
                 .then(wrap("它的核心人格是：", "\n")),
                 "personality_side_section": optional(personality.personality_side)

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -217,8 +217,7 @@ sub_agent_system_prompt = """你是一个聊天意图识别助手。
 
 # 关于主机器人
 主机器人的名字是 {nickname}。
-它的 QQ 号是 {bot_id}。
-{personality_core_section}{personality_side_section}
+{bot_id_section}{personality_core_section}{personality_side_section}
 # 判定准则
 你应该在以下情况判定为 "需要回复" (should_respond = true)：
 1. 明确提及：
@@ -898,6 +897,7 @@ class DefaultChatterPlugin(BasePlugin):
             policies={
                 "nickname": optional(personality.nickname),
                 "bot_id": optional(""),
+                "bot_id_section": optional(""),
                 "personality_core_section": optional(personality.personality_core)
                 .then(wrap("它的核心人格是：", "\n")),
                 "personality_side_section": optional(personality.personality_side)

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -33,9 +33,13 @@ from src.core.config import get_core_config
 from src.core.prompt import get_prompt_manager
 from src.core.models.message import Message
 from src.kernel.llm import LLMPayload, ROLE, Text
+from src.kernel.llm.payload.content import Content
+from src.kernel.llm.payload.tooling import LLMUsable
+from src.kernel.logger import Logger
 
 from .config import DefaultChatterConfig
 from .decision_agent import decide_should_respond
+from .multimodal import build_multimodal_content, extract_images_from_messages
 from .prompt_builder import DefaultChatterPromptBuilder
 from .runners import run_enhanced
 from .type_defs import LLMConversationState, LLMResponseLike, SubAgentDecision
@@ -704,17 +708,37 @@ class DefaultChatter(BaseChatter):
     def _upsert_pending_unread_payload(
         response: LLMConversationState,
         formatted_text: str,
+        unread_msgs: list[Message] | None = None,
+        native_multimodal: bool = False,
+        max_images: int = 0,
+        logger_override: Logger | None = None,
     ) -> None:
         """在未发送前合并未读消息到最后一个 USER payload。"""
+        content_list: list[Content | LLMUsable]
+        if native_multimodal and unread_msgs and max_images > 0:
+            images = extract_images_from_messages(unread_msgs, max_images)
+            content_list = build_multimodal_content(formatted_text, images)
+            if images:
+                (logger_override or logger).debug(f"已提取 {len(images)} 张图片")
+        else:
+            content_list = [Text(formatted_text)]
+
         if response.payloads and response.payloads[-1].role == ROLE.USER:
             last_payload = response.payloads[-1]
-            if last_payload.content and isinstance(last_payload.content[-1], Text):
+            if (
+                last_payload.content
+                and isinstance(last_payload.content[-1], Text)
+                and isinstance(content_list[0], Text)
+            ):
                 existing_text = last_payload.content[-1].text
-                last_payload.content[-1] = Text(f"{existing_text}\n{formatted_text}")
+                last_payload.content[-1] = Text(
+                    f"{existing_text}\n{content_list[0].text}"
+                )
+                last_payload.content.extend(content_list[1:])
             else:
-                last_payload.content.append(Text(formatted_text))
+                last_payload.content.extend(content_list)
         else:
-            response.add_payload(LLMPayload(ROLE.USER, Text(formatted_text)))
+            response.add_payload(LLMPayload(ROLE.USER, content_list))
 
     async def sub_agent(
         self,

--- a/plugins/default_chatter/runners.py
+++ b/plugins/default_chatter/runners.py
@@ -10,10 +10,11 @@ from src.core.components.base import Wait, WaitResumeEvent, Success, Failure, St
 from src.core.models.message import Message
 from src.core.models.stream import ChatStream
 from src.kernel.logger import Logger
-from src.kernel.llm import LLMPayload, ROLE, Text
+from src.kernel.llm import LLMPayload, ROLE, Text, Content, LLMUsable
 
 from .type_defs import DefaultChatterRuntime, LLMConversationState, LLMResponseLike
 from .tool_flow import append_suspend_payload_if_action_only, process_tool_calls
+from .multimodal import ImageBudget, build_multimodal_content, extract_images_from_messages
 
 # LLM 返回纯文本（非 tool call）时的最大重试次数
 _MAX_PLAIN_TEXT_RETRIES = 0
@@ -186,6 +187,42 @@ def _transition(
     rt.phase = to_phase
 
 
+def _append_unread_user_payload(
+    response: LLMConversationState,
+    chatter: DefaultChatterRuntime,
+    formatted_text: str,
+    unread_msgs: list[Message],
+    native_multimodal: bool,
+    image_budget: ImageBudget,
+    logger: Logger,
+) -> None:
+    """将未读消息 payload 追加到 response。"""
+    content_list: list[Content | LLMUsable]
+    if native_multimodal and not image_budget.is_exhausted():
+        images = extract_images_from_messages(unread_msgs, image_budget.remaining)
+        content_list = build_multimodal_content(formatted_text, images)
+        image_budget.consume(len(images))
+        if images:
+            logger.debug(f"已提取 {len(images)} 张图片, 剩余图片配额 {image_budget.remaining}")
+    else:
+        content_list = [Text(formatted_text)]
+
+    # 尝试合并到最后一个 USER payload
+    if response.payloads and response.payloads[-1].role == ROLE.USER:
+        last_payload = response.payloads[-1]
+        if last_payload.content and isinstance(last_payload.content[-1], Text) and isinstance(content_list[0], Text):
+            # 两个文本可以合并
+            existing_text = last_payload.content[-1].text
+            last_payload.content[-1] = Text(f"{existing_text}\n{content_list[0].text}")
+            last_payload.content.extend(content_list[1:])
+        else:
+            # 直接追加
+            last_payload.content.extend(content_list)
+    else:
+        # 创建新 USER payload
+        response.add_payload(LLMPayload(ROLE.USER, content_list))
+
+
 async def run_enhanced(
     chatter: DefaultChatterRuntime,
     chat_stream: ChatStream,
@@ -195,8 +232,23 @@ async def run_enhanced(
     suspend_text: str,
     enable_action_suspend: bool = True,
     enable_cooldown: bool = False,
+    native_multimodal: bool = False,
+    max_images_per_payload: int = 4,
 ) -> AsyncGenerator[Wait | Success | Failure | Stop, WaitResumeEvent | None]:
-    """enhanced 模式执行流程。"""
+    """enhanced 模式执行流程。
+
+    Args:
+        native_multimodal: 启用后将 image 媒体以 base64 直接打包进 USER payload，
+            同时为当前 stream 持久注册 "image" 类型的 VLM 跳过（表情包 emoji 仍由框架
+            VLM 生成描述，受益于哈希缓存）。注册后**不会在执行结束后取消**，
+            防止该 stream 下一条图片在执行间隙被 VLM 处理。
+        max_images_per_payload: 单次 payload 的总图片配额。
+    """
+    if native_multimodal:
+        from src.core.managers.media_manager import get_media_manager
+        get_media_manager().skip_vlm_for_stream(chat_stream.stream_id, ["image"])
+        logger.debug(f"已为 stream {chat_stream.stream_id[:8]} 注册跳过 image 类型的 VLM 识别")
+
     try:
         request = chatter.create_request("actor", with_reminder="actor")
     except (ValueError, KeyError) as error:
@@ -209,6 +261,8 @@ async def run_enhanced(
 
     history_text = chatter._build_enhanced_history_text(chat_stream)
     usable_map = await chatter.inject_usables(request)
+
+    image_budget = ImageBudget(total_max=max_images_per_payload)
 
     rt = _EnhancedWorkflowRuntime(
         response=request,
@@ -289,9 +343,14 @@ async def run_enhanced(
                 resume_event = yield Wait()
                 continue
 
-            chatter._upsert_pending_unread_payload(
+            _append_unread_user_payload(
                 response=rt.response,
+                chatter=chatter,
                 formatted_text=unread_user_prompt,
+                unread_msgs=unread_msgs,
+                native_multimodal=native_multimodal,
+                image_budget=image_budget,
+                logger=logger,
             )
             _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.MODEL_TURN, logger=logger, reason="accepted unread batch")
 

--- a/plugins/default_chatter/runners.py
+++ b/plugins/default_chatter/runners.py
@@ -14,7 +14,7 @@ from src.kernel.llm import LLMPayload, ROLE, Text, Content, LLMUsable
 
 from .type_defs import DefaultChatterRuntime, LLMConversationState, LLMResponseLike
 from .tool_flow import append_suspend_payload_if_action_only, process_tool_calls
-from .multimodal import ImageBudget, build_multimodal_content, extract_images_from_messages
+from .multimodal import build_multimodal_content, extract_images_from_messages
 
 # LLM 返回纯文本（非 tool call）时的最大重试次数
 _MAX_PLAIN_TEXT_RETRIES = 0
@@ -193,17 +193,22 @@ def _append_unread_user_payload(
     formatted_text: str,
     unread_msgs: list[Message],
     native_multimodal: bool,
-    image_budget: ImageBudget,
+    max_images: int,
     logger: Logger,
 ) -> None:
-    """将未读消息 payload 追加到 response。"""
+    """将未读消息 payload 追加到 response。
+
+    Args:
+        native_multimodal: 启用时从未读消息中提取图片并打包进 payload。
+            历史消息不传图片。
+        max_images: 本次 payload 允许携带的最大图片数量。
+    """
     content_list: list[Content | LLMUsable]
-    if native_multimodal and not image_budget.is_exhausted():
-        images = extract_images_from_messages(unread_msgs, image_budget.remaining)
+    if native_multimodal and max_images > 0:
+        images = extract_images_from_messages(unread_msgs, max_images)
         content_list = build_multimodal_content(formatted_text, images)
-        image_budget.consume(len(images))
         if images:
-            logger.debug(f"已提取 {len(images)} 张图片, 剩余图片配额 {image_budget.remaining}")
+            logger.debug(f"已提取 {len(images)} 张图片")
     else:
         content_list = [Text(formatted_text)]
 
@@ -239,10 +244,10 @@ async def run_enhanced(
 
     Args:
         native_multimodal: 启用后将 image 媒体以 base64 直接打包进 USER payload，
-            同时为当前 stream 持久注册 "image" 类型的 VLM 跳过（表情包 emoji 仍由框架
-            VLM 生成描述，受益于哈希缓存）。注册后**不会在执行结束后取消**，
-            防止该 stream 下一条图片在执行间隙被 VLM 处理。
-        max_images_per_payload: 单次 payload 的总图片配额。
+            同时为当前 stream 注册 "image" 类型的 VLM 跳过（表情包 emoji 仍由框架
+            VLM 生成描述，受益于哈希缓存）。执行结束后会自动取消注册，避免残留副作用。
+            历史消息不传图片，仅未读消息携带图片。
+        max_images_per_payload: 单次未读消息 payload 允许携带的最大图片数量。
     """
     if native_multimodal:
         from src.core.managers.media_manager import get_media_manager
@@ -250,210 +255,215 @@ async def run_enhanced(
         logger.debug(f"已为 stream {chat_stream.stream_id[:8]} 注册跳过 image 类型的 VLM 识别")
 
     try:
-        request = chatter.create_request("actor", with_reminder="actor")
-    except (ValueError, KeyError) as error:
-        logger.error(f"获取模型配置失败: {error}")
-        yield Failure(f"模型配置错误: {error}")
-        return
+        try:
+            request = chatter.create_request("actor", with_reminder="actor")
+        except (ValueError, KeyError) as error:
+            logger.error(f"获取模型配置失败: {error}")
+            yield Failure(f"模型配置错误: {error}")
+            return
 
-    system_prompt_text = await chatter._build_system_prompt(chat_stream)
-    request.add_payload(LLMPayload(ROLE.SYSTEM, Text(system_prompt_text)))
+        system_prompt_text = await chatter._build_system_prompt(chat_stream)
+        request.add_payload(LLMPayload(ROLE.SYSTEM, Text(system_prompt_text)))
 
-    history_text = chatter._build_enhanced_history_text(chat_stream)
-    usable_map = await chatter.inject_usables(request)
+        history_text = chatter._build_enhanced_history_text(chat_stream)
+        usable_map = await chatter.inject_usables(request)
 
-    image_budget = ImageBudget(total_max=max_images_per_payload)
+        rt = _EnhancedWorkflowRuntime(
+            response=request,
+            phase=_ToolCallWorkflowPhase.FOLLOW_UP if request.payloads and request.payloads[-1].role == ROLE.TOOL_RESULT else _ToolCallWorkflowPhase.WAIT_USER,
+            history_merged=False,
+            unreads=[],
+            cross_round_seen_signatures=set(),
+            unread_msgs_to_flush=[],
+        )
 
-    rt = _EnhancedWorkflowRuntime(
-        response=request,
-        phase=_ToolCallWorkflowPhase.FOLLOW_UP if request.payloads and request.payloads[-1].role == ROLE.TOOL_RESULT else _ToolCallWorkflowPhase.WAIT_USER,
-        history_merged=False,
-        unreads=[],
-        cross_round_seen_signatures=set(),
-        unread_msgs_to_flush=[],
-    )
+        resume_event: WaitResumeEvent | None = None
 
-    resume_event: WaitResumeEvent | None = None
+        while True:
+            current_resume_event = resume_event
+            resume_event = None
+            _, unread_msgs = await chatter.fetch_unreads()
 
-    while True:
-        current_resume_event = resume_event
-        resume_event = None
-        _, unread_msgs = await chatter.fetch_unreads()
-
-        # 安全兜底：若上下文尾部为 TOOL_RESULT，必须进入 FOLLOW_UP
-        if rt.phase == _ToolCallWorkflowPhase.WAIT_USER and rt.has_tool_result_tail():
-            _transition(
-                rt=rt,
-                to_phase=_ToolCallWorkflowPhase.FOLLOW_UP,
-                logger=logger,
-                reason="context tail is TOOL_RESULT; must follow-up before new USER",
-            )
-
-        # FSM 驱动：每次循环只推进一个相位（或 yield）
-        if rt.phase == _ToolCallWorkflowPhase.WAIT_USER:
-            if _is_timer_resume_event(current_resume_event):
-                assert current_resume_event is not None
-                rt.cross_round_seen_signatures.clear()
-                rt.plain_text_retry_count = 0
-                rt.unreads = []
-                rt.unread_msgs_to_flush = []
-                chatter._upsert_pending_unread_payload(
-                    response=rt.response,
-                    formatted_text=_build_wait_timeout_prompt(current_resume_event),
-                )
+            # 安全兜底：若上下文尾部为 TOOL_RESULT，必须进入 FOLLOW_UP
+            if rt.phase == _ToolCallWorkflowPhase.WAIT_USER and rt.has_tool_result_tail():
                 _transition(
                     rt=rt,
-                    to_phase=_ToolCallWorkflowPhase.MODEL_TURN,
+                    to_phase=_ToolCallWorkflowPhase.FOLLOW_UP,
                     logger=logger,
-                    reason="wait timer elapsed",
+                    reason="context tail is TOOL_RESULT; must follow-up before new USER",
                 )
-                continue
 
-            if not unread_msgs:
-                resume_event = yield Wait()
-                continue
-
-            # 仅在采纳新未读消息时清空跨轮去重状态；FOLLOW_UP 阶段不应清空。
-            rt.cross_round_seen_signatures.clear()
-            rt.plain_text_retry_count = 0
-            rt.unreads = unread_msgs
-
-            unread_lines = "\n".join(
-                chatter.format_message_line(msg) for msg in unread_msgs
-            )
-            unread_user_prompt = await chatter._build_user_prompt(
-                chat_stream,
-                history_text=history_text if not rt.history_merged else "",
-                unread_lines=unread_lines,
-                extra=chatter._build_negative_behaviors_extra(),
-            )
-            rt.history_merged = True
-
-            decision = await chatter.sub_agent(
-                unread_lines,
-                unread_msgs,
-                chat_stream,
-            )
-            logger.info(
-                f"Sub-agent 决策: {decision['reason']} (响应: {decision['should_respond']})"
-            )
-
-            if not decision["should_respond"]:
-                logger.info("Sub-agent 决定不响应，继续等待...")
-                resume_event = yield Wait()
-                continue
-
-            _append_unread_user_payload(
-                response=rt.response,
-                chatter=chatter,
-                formatted_text=unread_user_prompt,
-                unread_msgs=unread_msgs,
-                native_multimodal=native_multimodal,
-                image_budget=image_budget,
-                logger=logger,
-            )
-            _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.MODEL_TURN, logger=logger, reason="accepted unread batch")
-
-            # MODEL_TURN 阶段发送后才 flush 本轮采纳的 unread
-            rt.unread_msgs_to_flush = unread_msgs
-            continue
-
-        if rt.phase in (_ToolCallWorkflowPhase.MODEL_TURN, _ToolCallWorkflowPhase.FOLLOW_UP):
-            # FOLLOW_UP 阶段严禁 flush 新未读；MODEL_TURN 才 flush 本轮采纳的 unread。
-            try:
-                rt.response = await rt.response.send(stream=False)
-                await rt.response
-                if rt.phase == _ToolCallWorkflowPhase.MODEL_TURN:
-                    if rt.unread_msgs_to_flush:
-                        await chatter.flush_unreads(rt.unread_msgs_to_flush)
+            # FSM 驱动：每次循环只推进一个相位（或 yield）
+            if rt.phase == _ToolCallWorkflowPhase.WAIT_USER:
+                if _is_timer_resume_event(current_resume_event):
+                    assert current_resume_event is not None
+                    rt.cross_round_seen_signatures.clear()
+                    rt.plain_text_retry_count = 0
+                    rt.unreads = []
                     rt.unread_msgs_to_flush = []
-            except Exception as error:
-                logger.error(f"LLM 请求失败: {error}", exc_info=True)
-                yield Failure("LLM 请求失败", error)
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="request failed")
-                continue
-
-            _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.TOOL_EXEC, logger=logger, reason="model responded")
-            continue
-
-        if rt.phase == _ToolCallWorkflowPhase.TOOL_EXEC:
-            llm_response = _require_response(rt.response)
-            current_calls = llm_response.call_list or []
-
-            _print_actor_decision_panel(chat_stream, llm_response, logger)
-
-            if not llm_response.call_list:
-                if _is_suspend_message(llm_response.message, suspend_text):
-                    resume_event = yield Wait()
-                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="model returned suspend")
-                    continue
-                if llm_response.message and llm_response.message.strip():
-                    logger.warning(
-                        f"LLM 返回了纯文本而非 tool call: "
-                        f"{llm_response.message[:100]}"
+                    chatter._upsert_pending_unread_payload(
+                        response=rt.response,
+                        formatted_text=_build_wait_timeout_prompt(current_resume_event),
                     )
-                    yield Stop(0)
-                    return
-                resume_event = yield Wait()
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="no call_list")
-                continue
-
-            logger.info(f"本轮调用列表：{[call.name for call in current_calls]}")
-            for call in current_calls:
-                args = call.args if isinstance(call.args, dict) else {}
-                reason = args.pop("reason", "未提供原因")
-                logger.info(f"LLM 调用 {call.name}，原因: {reason}，参数: {args}")
-
-            call_outcome = await process_tool_calls(
-                stream_id=chat_stream.stream_id,
-                calls=current_calls,
-                response=llm_response,
-                run_tool_call=chatter.run_tool_call,
-                usable_map=usable_map,
-                trigger_msg=rt.unreads[-1] if rt.unreads else None,
-                pass_call_name=pass_call_name,
-                stop_call_name=stop_call_name,
-                cross_round_seen_signatures=rt.cross_round_seen_signatures,
-            )
-
-            if call_outcome.should_stop:
-                cooldown_seconds = call_outcome.stop_minutes * 60 if enable_cooldown else 0
-                logger.info(f"对话已结束，冷却 {call_outcome.stop_minutes} 分钟（{'已启用' if enable_cooldown else '已禁用，实际不冷却'}）")
-                yield Stop(cooldown_seconds)
-                return
-
-            if call_outcome.has_pending_tool_results:
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="pending tool results")
-                continue
-
-            action_only_round = bool(current_calls) and all(
-                call.name.startswith("action-") for call in current_calls
-            )
-            append_suspend_payload_if_action_only(
-                calls=current_calls,
-                response=llm_response,
-                suspend_text=suspend_text,
-                enable_action_suspend=enable_action_suspend,
-                logger=logger,
-            )
-
-            # 工具链已闭合，可以进入等待或接受新 user。
-            if action_only_round and not call_outcome.should_wait:
-                if enable_action_suspend:
-                    resume_event = yield Wait()
-                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="action-only round suspended")
+                    _transition(
+                        rt=rt,
+                        to_phase=_ToolCallWorkflowPhase.MODEL_TURN,
+                        logger=logger,
+                        reason="wait timer elapsed",
+                    )
                     continue
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="action-only round continues follow-up")
+
+                if not unread_msgs:
+                    resume_event = yield Wait()
+                    continue
+
+                # 仅在采纳新未读消息时清空跨轮去重状态；FOLLOW_UP 阶段不应清空。
+                rt.cross_round_seen_signatures.clear()
+                rt.plain_text_retry_count = 0
+                rt.unreads = unread_msgs
+
+                unread_lines = "\n".join(
+                    chatter.format_message_line(msg) for msg in unread_msgs
+                )
+                unread_user_prompt = await chatter._build_user_prompt(
+                    chat_stream,
+                    history_text=history_text if not rt.history_merged else "",
+                    unread_lines=unread_lines,
+                    extra=chatter._build_negative_behaviors_extra(),
+                )
+                rt.history_merged = True
+
+                decision = await chatter.sub_agent(
+                    unread_lines,
+                    unread_msgs,
+                    chat_stream,
+                )
+                logger.info(
+                    f"Sub-agent 决策: {decision['reason']} (响应: {decision['should_respond']})"
+                )
+
+                if not decision["should_respond"]:
+                    logger.info("Sub-agent 决定不响应，继续等待...")
+                    resume_event = yield Wait()
+                    continue
+
+                _append_unread_user_payload(
+                    response=rt.response,
+                    chatter=chatter,
+                    formatted_text=unread_user_prompt,
+                    unread_msgs=unread_msgs,
+                    native_multimodal=native_multimodal,
+                    max_images=max_images_per_payload,
+                    logger=logger,
+                )
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.MODEL_TURN, logger=logger, reason="accepted unread batch")
+
+                # MODEL_TURN 阶段发送后才 flush 本轮采纳的 unread
+                rt.unread_msgs_to_flush = unread_msgs
                 continue
 
-            if call_outcome.should_wait:
-                _append_suspend_payload_if_tool_result_tail(
+            if rt.phase in (_ToolCallWorkflowPhase.MODEL_TURN, _ToolCallWorkflowPhase.FOLLOW_UP):
+                # FOLLOW_UP 阶段严禁 flush 新未读；MODEL_TURN 才 flush 本轮采纳的 unread。
+                try:
+                    rt.response = await rt.response.send(stream=False)
+                    await rt.response
+                    if rt.phase == _ToolCallWorkflowPhase.MODEL_TURN:
+                        if rt.unread_msgs_to_flush:
+                            await chatter.flush_unreads(rt.unread_msgs_to_flush)
+                        rt.unread_msgs_to_flush = []
+                except Exception as error:
+                    logger.error(f"LLM 请求失败: {error}", exc_info=True)
+                    yield Failure("LLM 请求失败", error)
+                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="request failed")
+                    continue
+
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.TOOL_EXEC, logger=logger, reason="model responded")
+                continue
+
+            if rt.phase == _ToolCallWorkflowPhase.TOOL_EXEC:
+                llm_response = _require_response(rt.response)
+                current_calls = llm_response.call_list or []
+
+                _print_actor_decision_panel(chat_stream, llm_response, logger)
+
+                if not llm_response.call_list:
+                    if _is_suspend_message(llm_response.message, suspend_text):
+                        resume_event = yield Wait()
+                        _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="model returned suspend")
+                        continue
+                    if llm_response.message and llm_response.message.strip():
+                        logger.warning(
+                            f"LLM 返回了纯文本而非 tool call: "
+                            f"{llm_response.message[:100]}"
+                        )
+                        yield Stop(0)
+                        return
+                    resume_event = yield Wait()
+                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="no call_list")
+                    continue
+
+                logger.info(f"本轮调用列表：{[call.name for call in current_calls]}")
+                for call in current_calls:
+                    args = call.args if isinstance(call.args, dict) else {}
+                    reason = args.pop("reason", "未提供原因")
+                    logger.info(f"LLM 调用 {call.name}，原因: {reason}，参数: {args}")
+
+                call_outcome = await process_tool_calls(
+                    stream_id=chat_stream.stream_id,
+                    calls=current_calls,
+                    response=llm_response,
+                    run_tool_call=chatter.run_tool_call,
+                    usable_map=usable_map,
+                    trigger_msg=rt.unreads[-1] if rt.unreads else None,
+                    pass_call_name=pass_call_name,
+                    stop_call_name=stop_call_name,
+                    cross_round_seen_signatures=rt.cross_round_seen_signatures,
+                )
+
+                if call_outcome.should_stop:
+                    cooldown_seconds = call_outcome.stop_minutes * 60 if enable_cooldown else 0
+                    logger.info(f"对话已结束，冷却 {call_outcome.stop_minutes} 分钟（{'已启用' if enable_cooldown else '已禁用，实际不冷却'}）")
+                    yield Stop(cooldown_seconds)
+                    return
+
+                if call_outcome.has_pending_tool_results:
+                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="pending tool results")
+                    continue
+
+                action_only_round = bool(current_calls) and all(
+                    call.name.startswith("action-") for call in current_calls
+                )
+                append_suspend_payload_if_action_only(
+                    calls=current_calls,
                     response=llm_response,
                     suspend_text=suspend_text,
+                    enable_action_suspend=enable_action_suspend,
                     logger=logger,
                 )
-                resume_event = yield Wait(
-                    time=getattr(call_outcome, "wait_seconds", None)
-                )
-            _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="tool exec done")
-            continue
+
+                # 工具链已闭合，可以进入等待或接受新 user。
+                if action_only_round and not call_outcome.should_wait:
+                    if enable_action_suspend:
+                        resume_event = yield Wait()
+                        _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="action-only round suspended")
+                        continue
+                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="action-only round continues follow-up")
+                    continue
+
+                if call_outcome.should_wait:
+                    _append_suspend_payload_if_tool_result_tail(
+                        response=llm_response,
+                        suspend_text=suspend_text,
+                        logger=logger,
+                    )
+                    resume_event = yield Wait(
+                        time=getattr(call_outcome, "wait_seconds", None)
+                    )
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="tool exec done")
+                continue
+
+    finally:
+        if native_multimodal:
+            from src.core.managers.media_manager import get_media_manager
+            get_media_manager().unskip_vlm_for_stream(chat_stream.stream_id)
+            logger.debug(f"已取消 stream {chat_stream.stream_id[:8]} 的 VLM 跳过注册")

--- a/plugins/default_chatter/runners.py
+++ b/plugins/default_chatter/runners.py
@@ -10,11 +10,10 @@ from src.core.components.base import Wait, WaitResumeEvent, Success, Failure, St
 from src.core.models.message import Message
 from src.core.models.stream import ChatStream
 from src.kernel.logger import Logger
-from src.kernel.llm import LLMPayload, ROLE, Text, Content, LLMUsable
+from src.kernel.llm import LLMPayload, ROLE, Text
 
 from .type_defs import DefaultChatterRuntime, LLMConversationState, LLMResponseLike
 from .tool_flow import append_suspend_payload_if_action_only, process_tool_calls
-from .multimodal import build_multimodal_content, extract_images_from_messages
 
 # LLM 返回纯文本（非 tool call）时的最大重试次数
 _MAX_PLAIN_TEXT_RETRIES = 0
@@ -187,47 +186,6 @@ def _transition(
     rt.phase = to_phase
 
 
-def _append_unread_user_payload(
-    response: LLMConversationState,
-    chatter: DefaultChatterRuntime,
-    formatted_text: str,
-    unread_msgs: list[Message],
-    native_multimodal: bool,
-    max_images: int,
-    logger: Logger,
-) -> None:
-    """将未读消息 payload 追加到 response。
-
-    Args:
-        native_multimodal: 启用时从未读消息中提取图片并打包进 payload。
-            历史消息不传图片。
-        max_images: 本次 payload 允许携带的最大图片数量。
-    """
-    content_list: list[Content | LLMUsable]
-    if native_multimodal and max_images > 0:
-        images = extract_images_from_messages(unread_msgs, max_images)
-        content_list = build_multimodal_content(formatted_text, images)
-        if images:
-            logger.debug(f"已提取 {len(images)} 张图片")
-    else:
-        content_list = [Text(formatted_text)]
-
-    # 尝试合并到最后一个 USER payload
-    if response.payloads and response.payloads[-1].role == ROLE.USER:
-        last_payload = response.payloads[-1]
-        if last_payload.content and isinstance(last_payload.content[-1], Text) and isinstance(content_list[0], Text):
-            # 两个文本可以合并
-            existing_text = last_payload.content[-1].text
-            last_payload.content[-1] = Text(f"{existing_text}\n{content_list[0].text}")
-            last_payload.content.extend(content_list[1:])
-        else:
-            # 直接追加
-            last_payload.content.extend(content_list)
-    else:
-        # 创建新 USER payload
-        response.add_payload(LLMPayload(ROLE.USER, content_list))
-
-
 async def run_enhanced(
     chatter: DefaultChatterRuntime,
     chat_stream: ChatStream,
@@ -255,215 +213,207 @@ async def run_enhanced(
         logger.debug(f"已为 stream {chat_stream.stream_id[:8]} 注册跳过 image 类型的 VLM 识别")
 
     try:
-        try:
-            request = chatter.create_request("actor", with_reminder="actor")
-        except (ValueError, KeyError) as error:
-            logger.error(f"获取模型配置失败: {error}")
-            yield Failure(f"模型配置错误: {error}")
-            return
+        request = chatter.create_request("actor", with_reminder="actor")
+    except (ValueError, KeyError) as error:
+        logger.error(f"获取模型配置失败: {error}")
+        yield Failure(f"模型配置错误: {error}")
+        return
 
-        system_prompt_text = await chatter._build_system_prompt(chat_stream)
-        request.add_payload(LLMPayload(ROLE.SYSTEM, Text(system_prompt_text)))
+    system_prompt_text = await chatter._build_system_prompt(chat_stream)
+    request.add_payload(LLMPayload(ROLE.SYSTEM, Text(system_prompt_text)))
 
-        history_text = chatter._build_enhanced_history_text(chat_stream)
-        usable_map = await chatter.inject_usables(request)
+    history_text = chatter._build_enhanced_history_text(chat_stream)
+    usable_map = await chatter.inject_usables(request)
 
-        rt = _EnhancedWorkflowRuntime(
-            response=request,
-            phase=_ToolCallWorkflowPhase.FOLLOW_UP if request.payloads and request.payloads[-1].role == ROLE.TOOL_RESULT else _ToolCallWorkflowPhase.WAIT_USER,
-            history_merged=False,
-            unreads=[],
-            cross_round_seen_signatures=set(),
-            unread_msgs_to_flush=[],
-        )
+    rt = _EnhancedWorkflowRuntime(
+        response=request,
+        phase=_ToolCallWorkflowPhase.FOLLOW_UP if request.payloads and request.payloads[-1].role == ROLE.TOOL_RESULT else _ToolCallWorkflowPhase.WAIT_USER,
+        history_merged=False,
+        unreads=[],
+        cross_round_seen_signatures=set(),
+        unread_msgs_to_flush=[],
+    )
 
-        resume_event: WaitResumeEvent | None = None
+    resume_event: WaitResumeEvent | None = None
 
-        while True:
-            current_resume_event = resume_event
-            resume_event = None
-            _, unread_msgs = await chatter.fetch_unreads()
+    while True:
+        current_resume_event = resume_event
+        resume_event = None
+        _, unread_msgs = await chatter.fetch_unreads()
 
-            # 安全兜底：若上下文尾部为 TOOL_RESULT，必须进入 FOLLOW_UP
-            if rt.phase == _ToolCallWorkflowPhase.WAIT_USER and rt.has_tool_result_tail():
-                _transition(
-                    rt=rt,
-                    to_phase=_ToolCallWorkflowPhase.FOLLOW_UP,
-                    logger=logger,
-                    reason="context tail is TOOL_RESULT; must follow-up before new USER",
-                )
+        # 安全兜底：若上下文尾部为 TOOL_RESULT，必须进入 FOLLOW_UP
+        if rt.phase == _ToolCallWorkflowPhase.WAIT_USER and rt.has_tool_result_tail():
+            _transition(
+                rt=rt,
+                to_phase=_ToolCallWorkflowPhase.FOLLOW_UP,
+                logger=logger,
+                reason="context tail is TOOL_RESULT; must follow-up before new USER",
+            )
 
-            # FSM 驱动：每次循环只推进一个相位（或 yield）
-            if rt.phase == _ToolCallWorkflowPhase.WAIT_USER:
-                if _is_timer_resume_event(current_resume_event):
-                    assert current_resume_event is not None
-                    rt.cross_round_seen_signatures.clear()
-                    rt.plain_text_retry_count = 0
-                    rt.unreads = []
-                    rt.unread_msgs_to_flush = []
-                    chatter._upsert_pending_unread_payload(
-                        response=rt.response,
-                        formatted_text=_build_wait_timeout_prompt(current_resume_event),
-                    )
-                    _transition(
-                        rt=rt,
-                        to_phase=_ToolCallWorkflowPhase.MODEL_TURN,
-                        logger=logger,
-                        reason="wait timer elapsed",
-                    )
-                    continue
-
-                if not unread_msgs:
-                    resume_event = yield Wait()
-                    continue
-
-                # 仅在采纳新未读消息时清空跨轮去重状态；FOLLOW_UP 阶段不应清空。
+        # FSM 驱动：每次循环只推进一个相位（或 yield）
+        if rt.phase == _ToolCallWorkflowPhase.WAIT_USER:
+            if _is_timer_resume_event(current_resume_event):
+                assert current_resume_event is not None
                 rt.cross_round_seen_signatures.clear()
                 rt.plain_text_retry_count = 0
-                rt.unreads = unread_msgs
-
-                unread_lines = "\n".join(
-                    chatter.format_message_line(msg) for msg in unread_msgs
-                )
-                unread_user_prompt = await chatter._build_user_prompt(
-                    chat_stream,
-                    history_text=history_text if not rt.history_merged else "",
-                    unread_lines=unread_lines,
-                    extra=chatter._build_negative_behaviors_extra(),
-                )
-                rt.history_merged = True
-
-                decision = await chatter.sub_agent(
-                    unread_lines,
-                    unread_msgs,
-                    chat_stream,
-                )
-                logger.info(
-                    f"Sub-agent 决策: {decision['reason']} (响应: {decision['should_respond']})"
-                )
-
-                if not decision["should_respond"]:
-                    logger.info("Sub-agent 决定不响应，继续等待...")
-                    resume_event = yield Wait()
-                    continue
-
-                _append_unread_user_payload(
+                rt.unreads = []
+                rt.unread_msgs_to_flush = []
+                chatter._upsert_pending_unread_payload(
                     response=rt.response,
-                    chatter=chatter,
-                    formatted_text=unread_user_prompt,
-                    unread_msgs=unread_msgs,
-                    native_multimodal=native_multimodal,
-                    max_images=max_images_per_payload,
+                    formatted_text=_build_wait_timeout_prompt(current_resume_event),
+                )
+                _transition(
+                    rt=rt,
+                    to_phase=_ToolCallWorkflowPhase.MODEL_TURN,
                     logger=logger,
+                    reason="wait timer elapsed",
                 )
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.MODEL_TURN, logger=logger, reason="accepted unread batch")
-
-                # MODEL_TURN 阶段发送后才 flush 本轮采纳的 unread
-                rt.unread_msgs_to_flush = unread_msgs
                 continue
 
-            if rt.phase in (_ToolCallWorkflowPhase.MODEL_TURN, _ToolCallWorkflowPhase.FOLLOW_UP):
-                # FOLLOW_UP 阶段严禁 flush 新未读；MODEL_TURN 才 flush 本轮采纳的 unread。
-                try:
-                    rt.response = await rt.response.send(stream=False)
-                    await rt.response
-                    if rt.phase == _ToolCallWorkflowPhase.MODEL_TURN:
-                        if rt.unread_msgs_to_flush:
-                            await chatter.flush_unreads(rt.unread_msgs_to_flush)
-                        rt.unread_msgs_to_flush = []
-                except Exception as error:
-                    logger.error(f"LLM 请求失败: {error}", exc_info=True)
-                    yield Failure("LLM 请求失败", error)
-                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="request failed")
-                    continue
-
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.TOOL_EXEC, logger=logger, reason="model responded")
+            if not unread_msgs:
+                resume_event = yield Wait()
                 continue
 
-            if rt.phase == _ToolCallWorkflowPhase.TOOL_EXEC:
-                llm_response = _require_response(rt.response)
-                current_calls = llm_response.call_list or []
+            # 仅在采纳新未读消息时清空跨轮去重状态；FOLLOW_UP 阶段不应清空。
+            rt.cross_round_seen_signatures.clear()
+            rt.plain_text_retry_count = 0
+            rt.unreads = unread_msgs
 
-                _print_actor_decision_panel(chat_stream, llm_response, logger)
+            unread_lines = "\n".join(
+                chatter.format_message_line(msg) for msg in unread_msgs
+            )
+            unread_user_prompt = await chatter._build_user_prompt(
+                chat_stream,
+                history_text=history_text if not rt.history_merged else "",
+                unread_lines=unread_lines,
+                extra=chatter._build_negative_behaviors_extra(),
+            )
+            rt.history_merged = True
 
-                if not llm_response.call_list:
-                    if _is_suspend_message(llm_response.message, suspend_text):
-                        resume_event = yield Wait()
-                        _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="model returned suspend")
-                        continue
-                    if llm_response.message and llm_response.message.strip():
-                        logger.warning(
-                            f"LLM 返回了纯文本而非 tool call: "
-                            f"{llm_response.message[:100]}"
-                        )
-                        yield Stop(0)
-                        return
+            decision = await chatter.sub_agent(
+                unread_lines,
+                unread_msgs,
+                chat_stream,
+            )
+            logger.info(
+                f"Sub-agent 决策: {decision['reason']} (响应: {decision['should_respond']})"
+            )
+
+            if not decision["should_respond"]:
+                logger.info("Sub-agent 决定不响应，继续等待...")
+                resume_event = yield Wait()
+                continue
+
+            chatter._upsert_pending_unread_payload(
+                response=rt.response,
+                formatted_text=unread_user_prompt,
+                unread_msgs=unread_msgs,
+                native_multimodal=native_multimodal,
+                max_images=max_images_per_payload,
+                logger_override=logger,
+            )
+            _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.MODEL_TURN, logger=logger, reason="accepted unread batch")
+
+            # MODEL_TURN 阶段发送后才 flush 本轮采纳的 unread
+            rt.unread_msgs_to_flush = unread_msgs
+            continue
+
+        if rt.phase in (_ToolCallWorkflowPhase.MODEL_TURN, _ToolCallWorkflowPhase.FOLLOW_UP):
+            # FOLLOW_UP 阶段严禁 flush 新未读；MODEL_TURN 才 flush 本轮采纳的 unread。
+            try:
+                rt.response = await rt.response.send(stream=False)
+                await rt.response
+                if rt.phase == _ToolCallWorkflowPhase.MODEL_TURN:
+                    if rt.unread_msgs_to_flush:
+                        await chatter.flush_unreads(rt.unread_msgs_to_flush)
+                    rt.unread_msgs_to_flush = []
+            except Exception as error:
+                logger.error(f"LLM 请求失败: {error}", exc_info=True)
+                yield Failure("LLM 请求失败", error)
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="request failed")
+                continue
+
+            _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.TOOL_EXEC, logger=logger, reason="model responded")
+            continue
+
+        if rt.phase == _ToolCallWorkflowPhase.TOOL_EXEC:
+            llm_response = _require_response(rt.response)
+            current_calls = llm_response.call_list or []
+
+            _print_actor_decision_panel(chat_stream, llm_response, logger)
+
+            if not llm_response.call_list:
+                if _is_suspend_message(llm_response.message, suspend_text):
                     resume_event = yield Wait()
-                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="no call_list")
+                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="model returned suspend")
                     continue
-
-                logger.info(f"本轮调用列表：{[call.name for call in current_calls]}")
-                for call in current_calls:
-                    args = call.args if isinstance(call.args, dict) else {}
-                    reason = args.pop("reason", "未提供原因")
-                    logger.info(f"LLM 调用 {call.name}，原因: {reason}，参数: {args}")
-
-                call_outcome = await process_tool_calls(
-                    stream_id=chat_stream.stream_id,
-                    calls=current_calls,
-                    response=llm_response,
-                    run_tool_call=chatter.run_tool_call,
-                    usable_map=usable_map,
-                    trigger_msg=rt.unreads[-1] if rt.unreads else None,
-                    pass_call_name=pass_call_name,
-                    stop_call_name=stop_call_name,
-                    cross_round_seen_signatures=rt.cross_round_seen_signatures,
-                )
-
-                if call_outcome.should_stop:
-                    cooldown_seconds = call_outcome.stop_minutes * 60 if enable_cooldown else 0
-                    logger.info(f"对话已结束，冷却 {call_outcome.stop_minutes} 分钟（{'已启用' if enable_cooldown else '已禁用，实际不冷却'}）")
-                    yield Stop(cooldown_seconds)
+                if llm_response.message and llm_response.message.strip():
+                    logger.warning(
+                        f"LLM 返回了纯文本而非 tool call: "
+                        f"{llm_response.message[:100]}"
+                    )
+                    yield Stop(0)
                     return
+                resume_event = yield Wait()
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="no call_list")
+                continue
 
-                if call_outcome.has_pending_tool_results:
-                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="pending tool results")
+            logger.info(f"本轮调用列表：{[call.name for call in current_calls]}")
+            for call in current_calls:
+                args = call.args if isinstance(call.args, dict) else {}
+                reason = args.pop("reason", "未提供原因")
+                logger.info(f"LLM 调用 {call.name}，原因: {reason}，参数: {args}")
+
+            call_outcome = await process_tool_calls(
+                stream_id=chat_stream.stream_id,
+                calls=current_calls,
+                response=llm_response,
+                run_tool_call=chatter.run_tool_call,
+                usable_map=usable_map,
+                trigger_msg=rt.unreads[-1] if rt.unreads else None,
+                pass_call_name=pass_call_name,
+                stop_call_name=stop_call_name,
+                cross_round_seen_signatures=rt.cross_round_seen_signatures,
+            )
+
+            if call_outcome.should_stop:
+                cooldown_seconds = call_outcome.stop_minutes * 60 if enable_cooldown else 0
+                logger.info(f"对话已结束，冷却 {call_outcome.stop_minutes} 分钟（{'已启用' if enable_cooldown else '已禁用，实际不冷却'}）")
+                yield Stop(cooldown_seconds)
+                return
+
+            if call_outcome.has_pending_tool_results:
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="pending tool results")
+                continue
+
+            action_only_round = bool(current_calls) and all(
+                call.name.startswith("action-") for call in current_calls
+            )
+            append_suspend_payload_if_action_only(
+                calls=current_calls,
+                response=llm_response,
+                suspend_text=suspend_text,
+                enable_action_suspend=enable_action_suspend,
+                logger=logger,
+            )
+
+            # 工具链已闭合，可以进入等待或接受新 user。
+            if action_only_round and not call_outcome.should_wait:
+                if enable_action_suspend:
+                    resume_event = yield Wait()
+                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="action-only round suspended")
                     continue
+                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="action-only round continues follow-up")
+                continue
 
-                action_only_round = bool(current_calls) and all(
-                    call.name.startswith("action-") for call in current_calls
-                )
-                append_suspend_payload_if_action_only(
-                    calls=current_calls,
+            if call_outcome.should_wait:
+                _append_suspend_payload_if_tool_result_tail(
                     response=llm_response,
                     suspend_text=suspend_text,
-                    enable_action_suspend=enable_action_suspend,
                     logger=logger,
                 )
-
-                # 工具链已闭合，可以进入等待或接受新 user。
-                if action_only_round and not call_outcome.should_wait:
-                    if enable_action_suspend:
-                        resume_event = yield Wait()
-                        _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="action-only round suspended")
-                        continue
-                    _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.FOLLOW_UP, logger=logger, reason="action-only round continues follow-up")
-                    continue
-
-                if call_outcome.should_wait:
-                    _append_suspend_payload_if_tool_result_tail(
-                        response=llm_response,
-                        suspend_text=suspend_text,
-                        logger=logger,
-                    )
-                    resume_event = yield Wait(
-                        time=getattr(call_outcome, "wait_seconds", None)
-                    )
-                _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="tool exec done")
-                continue
-
-    finally:
-        if native_multimodal:
-            from src.core.managers.media_manager import get_media_manager
-            get_media_manager().unskip_vlm_for_stream(chat_stream.stream_id)
-            logger.debug(f"已取消 stream {chat_stream.stream_id[:8]} 的 VLM 跳过注册")
+                resume_event = yield Wait(
+                    time=getattr(call_outcome, "wait_seconds", None)
+                )
+            _transition(rt=rt, to_phase=_ToolCallWorkflowPhase.WAIT_USER, logger=logger, reason="tool exec done")
+            continue

--- a/plugins/default_chatter/type_defs.py
+++ b/plugins/default_chatter/type_defs.py
@@ -8,6 +8,7 @@ from typing import Protocol, TypedDict, TypeAlias
 from src.core.models.message import Message
 from src.core.models.stream import ChatStream
 from src.kernel.llm import LLMPayload, LLMRequest, ToolCall, ToolRegistry
+from src.kernel.logger import Logger
 
 
 class SubAgentDecision(TypedDict):
@@ -116,6 +117,10 @@ class DefaultChatterRuntime(Protocol):
         self,
         response: LLMConversationState,
         formatted_text: str,
+        unread_msgs: list[Message] | None = None,
+        native_multimodal: bool = False,
+        max_images: int = 0,
+        logger_override: Logger | None = None,
     ) -> None:
         """将未读消息写入待发送上下文。"""
         ...

--- a/src/core/managers/media_manager.py
+++ b/src/core/managers/media_manager.py
@@ -21,6 +21,7 @@ import asyncio
 import hashlib
 import time
 from pathlib import Path
+from collections.abc import Iterable
 from typing import Any
 from sqlalchemy import select
 
@@ -62,7 +63,8 @@ class MediaManager:
     def __init__(self):
         """初始化媒体管理器。"""
         self._vlm_model_set = None
-        self._skip_vlm_stream_ids: set[str] = set()  # 已注册跳过 VLM 识别的聊天流 ID
+        # stream_id -> 跳过的媒体类型集合；值为 None 表示跳过所有类型
+        self._skip_vlm_streams: dict[str, frozenset[str] | None] = {}
         self._initialize_vlm()
         self._initialize_asr()
         self._register_prompts()
@@ -206,7 +208,11 @@ class MediaManager:
     # 公共 API：VLM 识别控制
     # ──────────────────────────────────────────
 
-    def skip_vlm_for_stream(self, stream_id: str) -> None:
+    def skip_vlm_for_stream(
+        self,
+        stream_id: str,
+        media_types: Iterable[str] | None = None,
+    ) -> None:
         """注册指定聊天流跳过 VLM 识别。
 
         调用后，该 stream_id 的消息在 MessageConverter 中将不再触发
@@ -215,9 +221,18 @@ class MediaManager:
 
         Args:
             stream_id: 要跳过 VLM 识别的聊天流 ID
+            media_types: 要跳过的媒体类型集合（如 ``("image",)``）。为 ``None``
+                时表示跳过所有类型，保持与旧调用兼容。
         """
-        self._skip_vlm_stream_ids.add(stream_id)
-        logger.debug(f"已注册跳过 VLM 识别: stream_id={stream_id[:8]}")
+        if media_types is None:
+            self._skip_vlm_streams[stream_id] = None
+            logger.debug(f"已注册跳过 VLM 识别: stream_id={stream_id[:8]} (全部类型)")
+            return
+        types = frozenset(media_types)
+        self._skip_vlm_streams[stream_id] = types
+        logger.debug(
+            f"已注册跳过 VLM 识别: stream_id={stream_id[:8]} (类型={sorted(types)})"
+        )
 
     def unskip_vlm_for_stream(self, stream_id: str) -> None:
         """取消指定聊天流的 VLM 识别跳过。
@@ -225,19 +240,32 @@ class MediaManager:
         Args:
             stream_id: 要恢复 VLM 识别的聊天流 ID
         """
-        self._skip_vlm_stream_ids.discard(stream_id)
+        self._skip_vlm_streams.pop(stream_id, None)
         logger.debug(f"已取消跳过 VLM 识别: stream_id={stream_id[:8]}")
 
-    def should_skip_vlm(self, stream_id: str) -> bool:
+    def should_skip_vlm(
+        self,
+        stream_id: str,
+        media_type: str | None = None,
+    ) -> bool:
         """查询指定聊天流是否应跳过 VLM 识别。
 
         Args:
             stream_id: 聊天流 ID
+            media_type: 待识别媒体的类型；省略时表示
+                ""该流是否对任意类型注册了跳过""，用于保留旧的整流粒度语义。
 
         Returns:
-            True 表示该聊天流已注册跳过 VLM 识别
+            True 表示该聊天流（针对给定媒体类型）应跳过 VLM 识别
         """
-        return stream_id in self._skip_vlm_stream_ids
+        if stream_id not in self._skip_vlm_streams:
+            return False
+        types = self._skip_vlm_streams[stream_id]
+        if types is None:
+            return True
+        if media_type is None:
+            return True
+        return media_type in types
 
     # ──────────────────────────────────────────
     # 公共 API：媒体识别

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -132,12 +132,9 @@ class MessageConverter:
         
         # 如果解析过程中发现有媒体资源，则后续需要考虑是否运行视觉语言模型识别
         if result.media:
-            # 提前提取 stream_id 用于判断是否跳过 VLM
+            # 提前提取 stream_id 以供逐项过滤 VLM
             stream_id = extract_stream_id(message_info)
-            if self._should_skip_vlm_for_stream(stream_id):
-                logger.debug(f"聊天流 {stream_id[:8]} 已注册跳过 VLM 识别，保留原始媒体数据")
-            else:
-                result = await self._recognize_media_with_manager(result)
+            result = await self._recognize_media_with_manager(result, stream_id)
 
         # 确定消息类型
         # 根据最终解析结果决定消息类型，比如 TEXT/IMAGE 等
@@ -586,28 +583,38 @@ class MessageConverter:
 
         return type_mapping.get(first_media_type, MessageType.UNKNOWN)
 
-    async def _recognize_media_with_manager(self, result: _ParseResult) -> _ParseResult:
+    async def _recognize_media_with_manager(
+        self,
+        result: _ParseResult,
+        stream_id: str,
+    ) -> _ParseResult:
         """使用 MediaManager 识别媒体内容（图片、表情包、语音）并更新文本描述。
-        
+
         Args:
             result: 解析结果
-            
+            stream_id: 聊天流 ID，用于逐项查询 ``should_skip_vlm`` 跳过选定类型的 VLM 识别
+
         Returns:
             更新后的解析结果
         """
         try:
             # 延迟导入避免循环依赖
             from src.core.managers.media_manager import get_media_manager
-            
+
             manager = get_media_manager()
-            
-            # 收集需要识别的媒体（图片、表情包、语音）
+
+            # 收集需要识别的媒体（图片、表情包、语音），逐项过滤已注册跳过的类型
             media_to_recognize = []
             voice_to_recognize = []
             for i, media in enumerate(result.media):
-                if media["type"] in ("image", "emoji"):
+                media_type = media["type"]
+                if media_type in ("image", "emoji"):
+                    if manager.should_skip_vlm(stream_id, media_type):
+                        continue
                     media_to_recognize.append((i, media))
-                elif media["type"] == "voice":
+                elif media_type == "voice":
+                    if manager.should_skip_vlm(stream_id, media_type):
+                        continue
                     voice_to_recognize.append((i, media))
             
             # 早退策略：没有待识别媒体就直接返回原结果
@@ -674,23 +681,6 @@ class MessageConverter:
             logger.error(f"MediaManager 识别失败: {e}", exc_info=True)
         
         return result
-    
-    @staticmethod
-    def _should_skip_vlm_for_stream(stream_id: str) -> bool:
-        """检查指定聊天流是否已注册跳过 VLM 识别。
-
-        Args:
-            stream_id: 聊天流 ID
-
-        Returns:
-            True 表示应跳过 VLM 识别
-        """
-        # 如果查询发生异常则安全起见返回 False
-        try:
-            from src.core.managers.media_manager import get_media_manager
-            return get_media_manager().should_skip_vlm(stream_id)
-        except Exception:
-            return False
 
     @staticmethod
     def _build_content(result: _ParseResult, message_type: MessageType) -> str | Any:

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -613,8 +613,6 @@ class MessageConverter:
                         continue
                     media_to_recognize.append((i, media))
                 elif media_type == "voice":
-                    if manager.should_skip_vlm(stream_id, media_type):
-                        continue
                     voice_to_recognize.append((i, media))
             
             # 早退策略：没有待识别媒体就直接返回原结果

--- a/test/core/managers/test_media_manager.py
+++ b/test/core/managers/test_media_manager.py
@@ -100,6 +100,43 @@ class TestMediaManagerSkipVLM:
             
             assert manager.should_skip_vlm("stream_456") is False
 
+    def test_skip_vlm_for_stream_with_media_types(self) -> None:
+        """指定 media_types 时只对该类型生效，其余类型仍走 VLM。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.skip_vlm_for_stream("stream_dfc", media_types=("image",))
+
+            # 整流粒度查询：只要注册过任意类型，都视为跳过
+            assert manager.should_skip_vlm("stream_dfc") is True
+            # 类型粒度查询
+            assert manager.should_skip_vlm("stream_dfc", "image") is True
+            assert manager.should_skip_vlm("stream_dfc", "emoji") is False
+            assert manager.should_skip_vlm("stream_dfc", "voice") is False
+
+    def test_skip_vlm_for_stream_default_skips_all_types(self) -> None:
+        """不指定 media_types 时跳过所有媒体类型，保持向后兼容。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.skip_vlm_for_stream("stream_kfc")
+
+            assert manager.should_skip_vlm("stream_kfc") is True
+            assert manager.should_skip_vlm("stream_kfc", "image") is True
+            assert manager.should_skip_vlm("stream_kfc", "emoji") is True
+            assert manager.should_skip_vlm("stream_kfc", "voice") is True
+
+    def test_unskip_vlm_clears_typed_skip(self) -> None:
+        """unskip 必须同时清掉按类型注册的跳过。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.skip_vlm_for_stream("stream_dfc", media_types=("image",))
+            manager.unskip_vlm_for_stream("stream_dfc")
+
+            assert manager.should_skip_vlm("stream_dfc") is False
+            assert manager.should_skip_vlm("stream_dfc", "image") is False
+
 
 class TestMediaManagerRecognizeMedia:
     """测试媒体识别功能。"""

--- a/test/plugins/default_chatter/__init__.py
+++ b/test/plugins/default_chatter/__init__.py
@@ -1,0 +1,1 @@
+"""DefaultChatter 测试包。"""

--- a/test/plugins/default_chatter/test_multimodal.py
+++ b/test/plugins/default_chatter/test_multimodal.py
@@ -1,0 +1,175 @@
+"""DefaultChatter 原生多模态辅助模块单元测试。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from src.core.models.message import Message, MessageType
+from src.kernel.llm import Image, Text
+
+from plugins.default_chatter.multimodal import (
+    ImageBudget,
+    MediaItem,
+    build_multimodal_content,
+    extract_images_from_messages,
+    get_image_media_list,
+)
+
+# 一个最小可解码的合法 base64 字符串（Image 构造时会做 b64decode 校验）
+_VALID_B64 = "aGVsbG8="  # b"hello"
+
+
+def _make_msg(
+    *,
+    message_id: str = "msg_1",
+    media: list[dict[str, Any]] | None = None,
+    via: str = "content",
+) -> Message:
+    """构造带 media 的 Message。
+
+    via:
+        - "content": media 写入 content dict（converter 默认路径）
+        - "extra":   media 仅写入 extra（兼容路径）
+    """
+    if media is None:
+        media = []
+    if via == "content":
+        return Message(
+            message_id=message_id,
+            content={"text": "", "media": media},
+            message_type=MessageType.IMAGE,
+        )
+    return Message(
+        message_id=message_id,
+        content="",
+        message_type=MessageType.TEXT,
+        media=media,
+    )
+
+
+class TestImageBudget:
+    def test_initial_remaining(self) -> None:
+        b = ImageBudget(4)
+        assert b.remaining == 4
+        assert not b.is_exhausted()
+
+    def test_consume_and_exhaust(self) -> None:
+        b = ImageBudget(2)
+        b.consume(1)
+        assert b.remaining == 1
+        b.consume(1)
+        assert b.remaining == 0
+        assert b.is_exhausted()
+
+    def test_consume_overflow_clamps_remaining(self) -> None:
+        b = ImageBudget(2)
+        b.consume(5)
+        assert b.remaining == 0
+        assert b.is_exhausted()
+
+
+class TestGetImageMediaList:
+    def test_only_images_are_returned(self) -> None:
+        msg = _make_msg(
+            media=[
+                {"type": "image", "data": "base64|aaa"},
+                {"type": "emoji", "data": "base64|bbb"},
+                {"type": "voice", "data": "base64|ccc"},
+            ]
+        )
+        result = get_image_media_list(msg)
+        assert len(result) == 1
+        assert result[0]["type"] == "image"
+
+    def test_image_without_data_is_skipped(self) -> None:
+        msg = _make_msg(media=[{"type": "image"}, {"type": "image", "data": ""}])
+        assert get_image_media_list(msg) == []
+
+    def test_extra_path_is_used_when_content_lacks_media(self) -> None:
+        msg = _make_msg(
+            via="extra",
+            media=[{"type": "image", "data": "base64|x"}],
+        )
+        result = get_image_media_list(msg)
+        assert len(result) == 1
+
+
+class TestExtractImagesFromMessages:
+    def test_respects_max_items(self) -> None:
+        m1 = _make_msg(message_id="m1", media=[{"type": "image", "data": "1"}])
+        m2 = _make_msg(message_id="m2", media=[{"type": "image", "data": "2"}])
+        m3 = _make_msg(message_id="m3", media=[{"type": "image", "data": "3"}])
+
+        items = extract_images_from_messages([m1, m2, m3], max_items=2)
+        assert len(items) == 2
+        assert items[0].source_message_id == "m1"
+        assert items[1].source_message_id == "m2"
+
+    def test_zero_max_returns_empty(self) -> None:
+        m = _make_msg(media=[{"type": "image", "data": "1"}])
+        assert extract_images_from_messages([m], max_items=0) == []
+
+    def test_skips_emoji_and_voice(self) -> None:
+        m = _make_msg(
+            media=[
+                {"type": "emoji", "data": "e"},
+                {"type": "voice", "data": "v"},
+                {"type": "image", "data": "i"},
+            ]
+        )
+        items = extract_images_from_messages([m], max_items=10)
+        assert len(items) == 1
+        assert items[0].media_type == "image"
+        assert items[0].base64_data == "i"
+
+
+class TestBuildMultimodalContent:
+    def test_text_only_when_no_media(self) -> None:
+        content = build_multimodal_content("hello", [])
+        assert len(content) == 1
+        assert isinstance(content[0], Text)
+
+    def test_interleave_at_placeholder(self) -> None:
+        items = [
+            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1"),
+            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m2"),
+        ]
+        # text 中两个 [图片] 占位符正好对应两张图片
+        content = build_multimodal_content("前 [图片] 中 [图片] 后", items)
+        # 期望：Text("前 ") Image(A) Text(" 中 ") Image(B) Text(" 后")
+        assert [type(c).__name__ for c in content] == [
+            "Text",
+            "Image",
+            "Text",
+            "Image",
+            "Text",
+        ]
+
+    def test_more_placeholders_than_images_keeps_extras(self) -> None:
+        items = [MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1")]
+        content = build_multimodal_content("a [图片] b [图片] c", items)
+        # 1 图 + 2 占位符 → 第二个占位符保留
+        assert any(
+            isinstance(c, Text) and "[图片]" in c.text  # type: ignore[attr-defined]
+            for c in content
+        )
+
+    def test_more_images_than_placeholders_appends_remaining(self) -> None:
+        items = [
+            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1"),
+            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m2"),
+        ]
+        content = build_multimodal_content("hi", items)
+        # 没有占位符：所有图片追加到末尾
+        types = [type(c).__name__ for c in content]
+        assert types == ["Text", "Image", "Image"]
+
+    def test_text_followed_by_images_when_no_placeholder(self) -> None:
+        items = [
+            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1"),
+        ]
+        content = build_multimodal_content("hi", items)
+        assert isinstance(content[0], Text)
+        assert isinstance(content[1], Image)

--- a/test/plugins/default_chatter/test_multimodal.py
+++ b/test/plugins/default_chatter/test_multimodal.py
@@ -7,15 +7,13 @@ from typing import Any
 import pytest
 
 from src.core.models.message import Message, MessageType
-from src.kernel.llm import Image, Text
 
 from plugins.default_chatter.multimodal import (
-    ImageBudget,
-    MediaItem,
     build_multimodal_content,
     extract_images_from_messages,
     get_image_media_list,
 )
+from src.kernel.llm import Image, Text
 
 # 一个最小可解码的合法 base64 字符串（Image 构造时会做 b64decode 校验）
 _VALID_B64 = "aGVsbG8="  # b"hello"
@@ -47,27 +45,6 @@ def _make_msg(
         message_type=MessageType.TEXT,
         media=media,
     )
-
-
-class TestImageBudget:
-    def test_initial_remaining(self) -> None:
-        b = ImageBudget(4)
-        assert b.remaining == 4
-        assert not b.is_exhausted()
-
-    def test_consume_and_exhaust(self) -> None:
-        b = ImageBudget(2)
-        b.consume(1)
-        assert b.remaining == 1
-        b.consume(1)
-        assert b.remaining == 0
-        assert b.is_exhausted()
-
-    def test_consume_overflow_clamps_remaining(self) -> None:
-        b = ImageBudget(2)
-        b.consume(5)
-        assert b.remaining == 0
-        assert b.is_exhausted()
 
 
 class TestGetImageMediaList:
@@ -104,8 +81,8 @@ class TestExtractImagesFromMessages:
 
         items = extract_images_from_messages([m1, m2, m3], max_items=2)
         assert len(items) == 2
-        assert items[0].source_message_id == "m1"
-        assert items[1].source_message_id == "m2"
+        assert items[0]["data"] == "1"
+        assert items[1]["data"] == "2"
 
     def test_zero_max_returns_empty(self) -> None:
         m = _make_msg(media=[{"type": "image", "data": "1"}])
@@ -121,8 +98,8 @@ class TestExtractImagesFromMessages:
         )
         items = extract_images_from_messages([m], max_items=10)
         assert len(items) == 1
-        assert items[0].media_type == "image"
-        assert items[0].base64_data == "i"
+        assert items[0]["type"] == "image"
+        assert items[0]["data"] == "i"
 
 
 class TestBuildMultimodalContent:
@@ -131,45 +108,16 @@ class TestBuildMultimodalContent:
         assert len(content) == 1
         assert isinstance(content[0], Text)
 
-    def test_interleave_at_placeholder(self) -> None:
+    def test_images_appended_after_text(self) -> None:
         items = [
-            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1"),
-            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m2"),
-        ]
-        # text 中两个 [图片] 占位符正好对应两张图片
-        content = build_multimodal_content("前 [图片] 中 [图片] 后", items)
-        # 期望：Text("前 ") Image(A) Text(" 中 ") Image(B) Text(" 后")
-        assert [type(c).__name__ for c in content] == [
-            "Text",
-            "Image",
-            "Text",
-            "Image",
-            "Text",
-        ]
-
-    def test_more_placeholders_than_images_keeps_extras(self) -> None:
-        items = [MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1")]
-        content = build_multimodal_content("a [图片] b [图片] c", items)
-        # 1 图 + 2 占位符 → 第二个占位符保留
-        assert any(
-            isinstance(c, Text) and "[图片]" in c.text  # type: ignore[attr-defined]
-            for c in content
-        )
-
-    def test_more_images_than_placeholders_appends_remaining(self) -> None:
-        items = [
-            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1"),
-            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m2"),
+            {"type": "image", "data": _VALID_B64},
+            {"type": "image", "data": _VALID_B64},
         ]
         content = build_multimodal_content("hi", items)
-        # 没有占位符：所有图片追加到末尾
-        types = [type(c).__name__ for c in content]
-        assert types == ["Text", "Image", "Image"]
+        assert [type(c).__name__ for c in content] == ["Text", "Image", "Image"]
 
     def test_text_followed_by_images_when_no_placeholder(self) -> None:
-        items = [
-            MediaItem(media_type="image", base64_data=_VALID_B64, source_message_id="m1"),
-        ]
+        items = [{"type": "image", "data": _VALID_B64}]
         content = build_multimodal_content("hi", items)
         assert isinstance(content[0], Text)
         assert isinstance(content[1], Image)

--- a/test/plugins/test_default_chatter_decision_agent.py
+++ b/test/plugins/test_default_chatter_decision_agent.py
@@ -105,7 +105,7 @@ async def test_decide_should_respond_requests_sub_actor_reminder(
         chatter=_FakeChatter(),
         logger=SimpleNamespace(info=lambda *_a, **_k: None, warning=lambda *_a, **_k: None, debug=lambda *_a, **_k: None, error=lambda *_a, **_k: None),
         unreads_text="hello",
-        chat_stream=SimpleNamespace(stream_id="s1"),
+        chat_stream=SimpleNamespace(stream_id="s1", bot_id=""),
         fallback_prompt="hello {nickname}",
     )
 

--- a/test/plugins/test_default_chatter_runners.py
+++ b/test/plugins/test_default_chatter_runners.py
@@ -172,8 +172,21 @@ class _FakeChatterAllowUser(_FakeChatter):
     """允许 enhanced 正常注入 USER payload 的 chatter 替身。"""
 
     @staticmethod
-    def _upsert_pending_unread_payload(response: Any, formatted_text: str) -> None:
-        _ = formatted_text
+    def _upsert_pending_unread_payload(
+        response: Any,
+        formatted_text: str,
+        unread_msgs: list[Any] | None = None,
+        native_multimodal: bool = False,
+        max_images: int = 0,
+        logger_override: Any = None,
+    ) -> None:
+        _ = (
+            formatted_text,
+            unread_msgs,
+            native_multimodal,
+            max_images,
+            logger_override,
+        )
         response.add_payload(SimpleNamespace(role=ROLE.USER))
 
     async def flush_unreads(self, _unread_messages: list[Any]) -> int:


### PR DESCRIPTION
# 变更描述

## 主要更改

- **框架部分**: 更新了 `MediaManager` 的 `skip_vlm` 逻辑，支持按类型（如仅针对 image）精准跳过 VLM 识别。
- **Default_Chatter 部分**: 新增 `native_multimodal` 支持逻辑（配置及运行实现），并移除了旧版的不兼容属性。
- **decision_agent.py**: 更新补充 `bot_id` 支持。

## 相关测试

- 更新并补全 `MediaManager` 以及 `default_chatter` 关于 multimodal 的相关单元测试，确保类型粒度跳过有效、图片处理工作正常。

## Summary by Sourcery

Add native multimodal image handling to DefaultChatter and make VLM skipping configurable per media type.

New Features:
- Introduce native multimodal mode in DefaultChatter to send images as base64 directly in USER payloads with configurable per-payload image limits.
- Allow decision agent prompts to incorporate the bot_id so sub-agents can distinguish mentions by explicit @ IDs.

Enhancements:
- Refine MediaManager to support VLM skipping per media type per stream while keeping backward compatibility with stream-level skipping.
- Adjust DefaultChatter enhanced runner to reuse unread message payload assembly and support multimodal content alongside text.
- Tighten DefaultChatter sub-agent prompt rules around @ mentions to avoid responding to messages that mention other users.

Tests:
- Add unit tests for DefaultChatter multimodal helper utilities, including image budgeting and content building.
- Extend MediaManager tests to cover per-type VLM skipping behavior and unskip semantics.