### PR TITLE
feat(default-chatter): support flexible inline at mentions

### DIFF
--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -255,9 +255,25 @@ class SendTextAction(BaseAction):
     """发送文本消息"""
 
     action_name = "send_text"
-    action_description = "发送一段文本消息给用户。这是你唯一发送文本消息的方式。你可以一次调用多个 send_text 来分多段回复，但每次调用必须提供你想说的话的文本内容，不要添加任何标记或格式，只写纯文本即可。content 参数只能包含发送给用户的正文，严禁将行为理由、内心独白或格式说明混入 content。你也可以选择引用或回复之前某条消息作为背景，使用 reply_to 参数指定；若不引用消息，可用 at 参数指定要@的对象。注意：本工具无法发送表情包等非文本内容。所有@对象都应该通过at参数而不是直接写在文本里，以确保正确解析和发送。"
+    base_action_description = "发送一段文本消息给用户。这是你唯一发送文本消息的方式。你可以一次调用多个 send_text 来分多段回复，但每次调用必须提供你想说的话的文本内容。content 参数只能包含发送给用户的正文，严禁将行为理由、内心独白或格式说明混入 content。你也可以选择引用或回复之前某条消息作为背景，使用 reply_to 参数指定。注意：本工具无法发送表情包等非文本内容。"
+    action_description = base_action_description
+    group_action_description = base_action_description + "群聊中如需 @ 用户，必须发送真实 @ 段：只能在 content 中写 <at:用户ID>，系统会按原位置发送真实 @ 段。严禁在 content 中写 @昵称、@用户ID、@某人 之类的文本假 @，这些不会被当作真实 @；也不要把 @ 目标放到其他参数中。"
 
     chatter_allow: list[str] = ["default_chatter"]
+
+    @classmethod
+    def _description_for_chat_type(cls, chat_type: str) -> str:
+        """根据聊天类型返回 send_text 工具描述。"""
+        if str(chat_type).lower() == ChatType.GROUP.value:
+            return cls.group_action_description
+        return cls.base_action_description
+
+    async def go_activate(self) -> bool:
+        """激活时按当前聊天类型更新工具描述。"""
+        self.__class__.action_description = self._description_for_chat_type(
+            self.chat_stream.chat_type
+        )
+        return True
 
     def _is_programmatic_controller_enabled(self) -> bool:
         """读取程序化控制器开关。"""
@@ -285,189 +301,144 @@ class SendTextAction(BaseAction):
         if delay > 0:
             await asyncio.sleep(delay)
 
+    @staticmethod
+    def _append_text_segment(
+        segments: list[dict[str, str]],
+        text: str,
+    ) -> None:
+        """向消息段列表追加文本段，并合并相邻文本。"""
+        if not text:
+            return
+        if segments and segments[-1].get("type") == "text":
+            segments[-1]["data"] += text
+            return
+        segments.append({"type": "text", "data": text})
+
+    async def _resolve_at_user_id(self, platform: str, hint: str) -> str | None:
+        """校验 @ 参数或占位符中的平台用户 ID。"""
+        _ = platform
+        normalized_hint = hint.strip().lstrip("@").strip()
+        if not normalized_hint:
+            return None
+        if normalized_hint.isdigit():
+            return normalized_hint
+        return None
+
+    async def _build_group_content_segments(
+        self,
+        content: str,
+        platform: str,
+    ) -> list[dict[str, str]] | None:
+        """把正文中的 <at:用户ID> 占位符转换为有序消息段。"""
+        import re
+
+        segments: list[dict[str, str]] = []
+        pattern = re.compile(r"<at:(\d+)>")
+        cursor = 0
+        found_inline_at = False
+        for match in pattern.finditer(content):
+            self._append_text_segment(segments, content[cursor:match.start()])
+            hint = match.group(1) or ""
+            at_user_id = await self._resolve_at_user_id(platform, hint)
+            if at_user_id:
+                segments.append({"type": "at", "data": at_user_id})
+                found_inline_at = True
+            else:
+                logger.info(f"at 占位符不是用户 ID: {hint}，保留为普通文本")
+                self._append_text_segment(segments, match.group(0))
+            cursor = match.end()
+        self._append_text_segment(segments, content[cursor:])
+
+        if not found_inline_at:
+            return None
+        return segments
+
     async def execute(
         self,
         content: str,
         reply_to: str | None = None,
-        at: str | None = None,
     ) -> AsyncGenerator[tuple[bool, str] | None, None]:
         """执行发送文本消息的逻辑
 
         Args:
-            content: 要发送的文本内容，不用添加标记，只写你想说的话即可
+            content: 要发送的文本内容；如需真实 @，只能写 <at:用户ID>
             reply_to: 可选，要引用回复的目标消息 ID。若指定此参数，发送的消息将作为对该消息的回复
-            at: 可选，不使用 reply_to 时指定要 @ 的对象（用户 ID）
         """
         import re
+        from uuid import uuid4
+
+        from src.core.managers.adapter_manager import get_adapter_manager
         from src.core.models.message import Message
+        from src.core.transport.message_send import get_message_sender
 
-        # 清洗 LLM 可能侧漏的 reason 字段
         if content:
-            # 匹配 ,reason: 或 reason: 及其后的所有内容
             content = re.split(r'[,，]?\s*reason[:：]', content, flags=re.IGNORECASE)[0].strip()
-
-        # 解析 content 开头的 @对象，并从正文中移除。
-        # 示例: "@小明 你好" -> at_prefix_hint="小明", content="你好"
-        at_prefix_hint: str | None = None
-        if content:
-            at_match = re.match(r"^\s*@([^\s]+)\s*", content)
-            if at_match:
-                at_prefix_hint = at_match.group(1).strip()
-                content = content[at_match.end():].lstrip()
-
-        if not (content or at_prefix_hint):
-            yield True, "内容为空，跳过发送"
-            return
 
         if not content:
             yield True, "内容为空，跳过发送"
             return
-        
-        # 如果需要引用消息，创建带reply_to的Message对象
-        if reply_to:
-            target_stream_id = self.chat_stream.stream_id
-            platform = self.chat_stream.platform
-            chat_type = self.chat_stream.chat_type
-            context = self.chat_stream.context
-            
-            from src.core.managers.adapter_manager import get_adapter_manager
-            from uuid import uuid4
-            
-            bot_info = await get_adapter_manager().get_bot_info_by_platform(platform)
-            
-            target_user_id = None
-            target_group_id = None
-            target_user_name = None
-            target_group_name = None
-            
-            target_msg = self._get_context_message_for_target(reply_to)
-            
-            if chat_type == "group":
-                if target_msg:
-                    target_group_id = target_msg.extra.get("group_id")
-                    target_group_name = target_msg.extra.get("group_name")
-            else:
-                if target_msg:
-                    target_user_id = target_msg.sender_id
-                    target_user_name = target_msg.sender_name
-                if not target_user_id:
-                    target_user_id = context.triggering_user_id
-            
-            extra: dict[str, str] = {}
-            if target_user_id:
-                extra["target_user_id"] = target_user_id
-            if target_user_name:
-                extra["target_user_name"] = target_user_name
-            if target_group_id:
-                extra["target_group_id"] = target_group_id
-            if target_group_name:
-                extra["target_group_name"] = target_group_name
-            
-            message = Message(
-                message_id=f"action_{self.action_name}_{uuid4().hex}",
-                content=content,
-                processed_plain_text=content,
-                message_type=MessageType.TEXT,
-                sender_id=bot_info.get("bot_id", "") if bot_info else "",
-                sender_name=bot_info.get("bot_name", "Bot") if bot_info else "Bot",
-                platform=platform,
-                chat_type=chat_type,
-                stream_id=target_stream_id,
-                reply_to=reply_to,
-            )
-            message.extra.update(extra)
-            
-            from src.core.transport.message_send import get_message_sender
-            sender = get_message_sender()
-            yield None
-            await self._sleep_for_typing_delay(content)
-            success = await sender.send_message(message)
-            self._mark_sub_agent_bonus_on_success(success)
-            yield success, f"已发送消息:{content}"
-            return
+
+        target_stream_id = self.chat_stream.stream_id
+        platform = self.chat_stream.platform
+        chat_type = self.chat_stream.chat_type
+        context = self.chat_stream.context
+        bot_info = await get_adapter_manager().get_bot_info_by_platform(platform)
+
+        target_user_id = None
+        target_group_id = None
+        target_user_name = None
+        target_group_name = None
+        target_msg = self._get_context_message_for_target(reply_to) if reply_to else None
+
+        if chat_type == "group":
+            group_source_msg = target_msg or self._get_context_message_for_target()
+            if group_source_msg:
+                target_group_id = group_source_msg.extra.get("group_id")
+                target_group_name = group_source_msg.extra.get("group_name")
         else:
-            # 非引用回复时可使用显式 at 参数；reply_to 存在时已在上分支处理并忽略 at。
-            at_hint = (at or at_prefix_hint or "").strip().lstrip("@").strip()
+            if target_msg:
+                target_user_id = target_msg.sender_id
+                target_user_name = target_msg.sender_name
+            if not target_user_id:
+                target_user_id = context.triggering_user_id
 
-            if not at_hint:
-                yield None
-                await self._sleep_for_typing_delay(content)
-                success = await self._send_to_stream(content)
-                self._mark_sub_agent_bonus_on_success(success)
-                yield success, f"已发送消息:{content}"
-                return
+        extra: dict[str, str] = {}
+        if target_user_id:
+            extra["target_user_id"] = target_user_id
+        if target_user_name:
+            extra["target_user_name"] = target_user_name
+        if target_group_id:
+            extra["target_group_id"] = target_group_id
+        if target_group_name:
+            extra["target_group_name"] = target_group_name
 
-            target_stream_id = self.chat_stream.stream_id
-            platform = self.chat_stream.platform
-            chat_type = self.chat_stream.chat_type
-            context = self.chat_stream.context
+        message_content: str | list[dict[str, str]] = content
+        if chat_type == "group":
+            segments = await self._build_group_content_segments(content, platform)
+            if segments:
+                message_content = segments
 
-            if chat_type != "group":
-                # 私聊场景不需要显式 @，按普通发送处理。
-                yield None
-                await self._sleep_for_typing_delay(content)
-                success = await self._send_to_stream(content)
-                self._mark_sub_agent_bonus_on_success(success)
-                yield success, f"已发送消息:{content}"
-                return
+        message = Message(
+            message_id=f"action_{self.action_name}_{uuid4().hex}",
+            content=message_content,
+            processed_plain_text=content,
+            message_type=MessageType.TEXT,
+            sender_id=bot_info.get("bot_id", "") if bot_info else "",
+            sender_name=bot_info.get("bot_name", "Bot") if bot_info else "Bot",
+            platform=platform,
+            chat_type=chat_type,
+            stream_id=target_stream_id,
+            reply_to=reply_to,
+        )
+        message.extra.update(extra)
 
-            from src.core.managers.adapter_manager import get_adapter_manager
-            from src.core.utils.user_query_helper import get_user_query_helper
-            from uuid import uuid4
-
-            bot_info = await get_adapter_manager().get_bot_info_by_platform(platform)
-
-            if at_hint.isdigit():
-                at_user_id = at_hint
-            else:
-                at_user_id = await get_user_query_helper().resolve_user_id(platform, at_hint)
-
-            if not at_user_id:
-                logger.info(f"无法定位 at 目标: {at_hint}，降级为普通回复")
-                yield None
-                await self._sleep_for_typing_delay(content)
-                success = await self._send_to_stream(content)
-                self._mark_sub_agent_bonus_on_success(success)
-                yield success, f"已发送消息:{content}"
-                return
-
-            target_group_id = None
-            target_group_name = None
-            last_msg = self._get_context_message_for_target()
-            if last_msg:
-                target_group_id = last_msg.extra.get("group_id")
-                target_group_name = last_msg.extra.get("group_name")
-
-            extra: dict[str, str] = {
-                "at_user_id": str(at_user_id),
-            }
-            if target_group_id:
-                extra["target_group_id"] = target_group_id
-            if target_group_name:
-                extra["target_group_name"] = target_group_name
-
-            message = Message(
-                message_id=f"action_{self.action_name}_{uuid4().hex}",
-                content=content,
-                processed_plain_text=content,
-                message_type=MessageType.TEXT,
-                sender_id=bot_info.get("bot_id", "") if bot_info else "",
-                sender_name=bot_info.get("bot_name", "Bot") if bot_info else "Bot",
-                platform=platform,
-                chat_type=chat_type,
-                stream_id=target_stream_id,
-            )
-            message.extra.update(extra)
-
-            from src.core.transport.message_send import get_message_sender
-
-            sender = get_message_sender()
-            yield None
-            await self._sleep_for_typing_delay(content)
-            success = await sender.send_message(message)
-            self._mark_sub_agent_bonus_on_success(success)
-            yield success, f"已发送消息:{content}"
-            return
+        sender = get_message_sender()
+        yield None
+        await self._sleep_for_typing_delay(content)
+        success = await sender.send_message(message)
+        self._mark_sub_agent_bonus_on_success(success)
+        yield success, f"已发送消息:{content}"
+        return
 
 
 class PassAndWaitAction(BaseAction):

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -229,11 +229,20 @@ class MessageConverter:
                 })
         else:
             # 文本 / 混合消息
-            text = message.processed_plain_text or (
-                message.content if isinstance(message.content, str) else ""
-            )
-            if text:
-                seg_list.append({"type": "text", "data": text})
+            if isinstance(message.content, list):
+                for segment in message.content:
+                    if not isinstance(segment, dict):
+                        continue
+                    segment_type = segment.get("type")
+                    if not isinstance(segment_type, str) or not segment_type:
+                        continue
+                    seg_list.append(segment)  # type: ignore[arg-type]
+            else:
+                text = message.processed_plain_text or (
+                    message.content if isinstance(message.content, str) else ""
+                )
+                if text:
+                    seg_list.append({"type": "text", "data": text})
 
         # 构建额外媒体段（来自 extra["media"]）
         media_list: list[dict[str, Any]] = message.extra.get("media", [])

--- a/test/core/transport/test_message_converter_private_target.py
+++ b/test/core/transport/test_message_converter_private_target.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -65,3 +66,82 @@ async def test_message_to_envelope_private_target_prefers_stream_person(monkeypa
     assert user_info.get("user_nickname") == "NeoBot"
     fake_stream_manager.get_stream_info.assert_awaited_once_with("stream-private-1")
     helper.person_crud.get_by.assert_awaited_once_with(person_id="hash_person_888")
+
+
+@pytest.mark.asyncio
+async def test_message_to_envelope_preserves_ordered_content_segments(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """发送结构化段列表时应保留 text/at/text 的原始顺序。"""
+    converter = MessageConverter()
+    fake_stream_manager = SimpleNamespace(
+        get_stream_info=AsyncMock(return_value={
+            "group_id": "group-1",
+            "group_name": "测试群",
+        })
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+    ordered_segments: list[dict[str, Any]] = [
+        {"type": "text", "data": "你好 "},
+        {"type": "at", "data": "user-123"},
+        {"type": "text", "data": " 吃了吗"},
+    ]
+    message = Message(
+        message_id="m-segments",
+        content=ordered_segments,
+        processed_plain_text="你好 @user-123 吃了吗",
+        message_type=MessageType.TEXT,
+        sender_id="bot-001",
+        sender_name="NeoBot",
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-group-1",
+        group_id="group-1",
+        group_name="测试群",
+    )
+
+    envelope = await converter.message_to_envelope(message)
+
+    assert envelope.get("message_segment") == ordered_segments
+
+
+@pytest.mark.asyncio
+async def test_message_to_envelope_keeps_string_content_with_at_user_id(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """at_user_id 旧路径应保留字符串正文并前置 at 段。"""
+    converter = MessageConverter()
+    fake_stream_manager = SimpleNamespace(
+        get_stream_info=AsyncMock(return_value={
+            "group_id": "group-1",
+            "group_name": "测试群",
+        })
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+    message = Message(
+        message_id="m-at-string",
+        content="hello world",
+        processed_plain_text="hello world",
+        message_type=MessageType.TEXT,
+        sender_id="bot-001",
+        sender_name="NeoBot",
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-group-1",
+        group_id="group-1",
+        group_name="测试群",
+        at_user_id="user-123",
+    )
+
+    envelope = await converter.message_to_envelope(message)
+
+    assert envelope.get("message_segment") == [
+        {"type": "at", "data": "user-123"},
+        {"type": "text", "data": "hello world"},
+    ]


### PR DESCRIPTION
## 摘要

## Summary by Sourcery

Support structured inline @ mentions in group text sending and extend message conversion to handle ordered segments while keeping backwards compatibility.

New Features:
- Allow send_text to embed real group @ mentions via <at:用户ID> placeholders that are converted into ordered message segments.
- Dynamically tailor the send_text tool description based on chat type to clarify group @ mention usage.

Enhancements:
- Unify reply and target resolution in SendTextAction, passing group @ information via structured content instead of a separate at parameter.
- Extend message_to_envelope to accept pre-structured message segment lists while preserving their original order.
- Preserve legacy behavior when at_user_id is provided by constructing an at segment followed by the text content.

Tests:
- Add tests ensuring message_to_envelope preserves the order of provided text/at segments and correctly handles the legacy at_user_id path.