### PR TITLE
feat: 暴露 Chatter 显式绑定与恢复默认相关的公开 API

### DIFF
--- a/src/app/plugin_system/api/chat_api.py
+++ b/src/app/plugin_system/api/chat_api.py
@@ -135,6 +135,35 @@ def unregister_active_chatter(stream_id: str) -> bool:
     return _get_chatter_manager().unregister_active_chatter(stream_id)
 
 
+def bind_chatter_for_stream(stream_id: str, chatter: "BaseChatter") -> None:
+    """显式绑定 chatter 到指定 stream。
+
+    Args:
+        stream_id: 聊天流 ID
+        chatter: Chatter 实例
+
+    Returns:
+        None
+    """
+    _validate_non_empty(stream_id, "stream_id")
+    if chatter is None:
+        raise ValueError("chatter 不能为空")
+    _get_chatter_manager().bind_chatter_for_stream(stream_id, chatter)
+
+
+def restore_stream_to_default(stream_id: str) -> bool:
+    """移除 stream 的显式 chatter 绑定。
+
+    Args:
+        stream_id: 聊天流 ID
+
+    Returns:
+        是否成功注销/移除绑定
+    """
+    _validate_non_empty(stream_id, "stream_id")
+    return _get_chatter_manager().restore_stream_to_default(stream_id)
+
+
 def get_chatter_by_stream(stream_id: str) -> "BaseChatter | None":
     """获取指定聊天流的活跃 Chatter 实例。
 
@@ -179,6 +208,8 @@ __all__ = [
     "get_active_chatters",
     "register_active_chatter",
     "unregister_active_chatter",
+    "bind_chatter_for_stream",
+    "restore_stream_to_default",
     "get_chatter_by_stream",
     "get_or_create_chatter_for_stream",
 ]

--- a/test/app/plugin_system/api/test_chat_api.py
+++ b/test/app/plugin_system/api/test_chat_api.py
@@ -237,3 +237,53 @@ def test_get_chatter_by_stream_delegates(monkeypatch: pytest.MonkeyPatch) -> Non
     result = chat_api.get_chatter_by_stream("stream_1")
 
     assert result is not None
+
+
+def test_bind_chatter_for_stream_requires_stream_id() -> None:
+    """stream_id 为空时应抛出 ValueError。"""
+    with pytest.raises(ValueError, match="stream_id 不能为空"):
+        chat_api.bind_chatter_for_stream("", cast(BaseChatter, object()))
+
+
+def test_bind_chatter_for_stream_requires_chatter() -> None:
+    """chatter 为空时应抛出 ValueError。"""
+    with pytest.raises(ValueError, match="chatter 不能为空"):
+        chat_api.bind_chatter_for_stream("stream_1", cast(BaseChatter, None))
+
+
+def test_bind_chatter_for_stream_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """bind_chatter_for_stream 应委托给 ChatterManager。"""
+    captured: dict[str, object] = {}
+    chatter = cast(BaseChatter, object())
+
+    class _FakeManager:
+        def bind_chatter_for_stream(self, stream_id: str, chatter_obj: object) -> None:
+            captured["stream_id"] = stream_id
+            captured["chatter"] = chatter_obj
+
+    monkeypatch.setattr(chat_api, "_get_chatter_manager", lambda: _FakeManager())
+
+    chat_api.bind_chatter_for_stream("stream_1", chatter)
+
+    assert captured["stream_id"] == "stream_1"
+    assert captured["chatter"] is chatter
+
+
+def test_restore_stream_to_default_requires_stream_id() -> None:
+    """stream_id 为空时应抛出 ValueError。"""
+    with pytest.raises(ValueError, match="stream_id 不能为空"):
+        chat_api.restore_stream_to_default("")
+
+
+def test_restore_stream_to_default_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """restore_stream_to_default 应委托给 ChatterManager。"""
+
+    class _FakeManager:
+        def restore_stream_to_default(self, stream_id: str) -> bool:
+            return stream_id == "stream_1"
+
+    monkeypatch.setattr(chat_api, "_get_chatter_manager", lambda: _FakeManager())
+
+    result = chat_api.restore_stream_to_default("stream_1")
+
+    assert result is True


### PR DESCRIPTION
在插件公开 API 层 chat_api.py 中暴露 bind_chatter_for_stream 与 restore_stream_to_default，并补全单元测试，以便后续在 anima_chatter 插件中规范化调用。

## Summary by Sourcery

Expose new chatter binding and reset APIs on the chat plugin public interface and validate their inputs.

New Features:
- Add bind_chatter_for_stream and restore_stream_to_default to the chat_api public API for explicit chatter binding and restoration to defaults.

Tests:
- Add unit tests covering validation and ChatterManager delegation for bind_chatter_for_stream and restore_stream_to_default.