### PR TITLE
fix(dfc): 修复 default_chatter 提示词重复注入导致的上下文污染

### DIFF
--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -830,6 +830,7 @@ class DefaultChatter(BaseChatter):
         history_text: str,
         unread_lines: str,
         extra: str = "",
+        clean_mode: bool = False,
     ) -> str:
         """通过 user prompt 模板构建用户提示词。
 
@@ -838,6 +839,7 @@ class DefaultChatter(BaseChatter):
             history_text: 格式化后的历史消息文本（各行已用统一格式）
             unread_lines: 格式化后的未读消息文本
             extra: 额外信息文本
+            clean_mode: 是否启用净输出模式以跳过 on_prompt_build 注入，用于发送后恢复文本
 
         Returns:
             str: 渲染后的 user 提示词
@@ -847,6 +849,7 @@ class DefaultChatter(BaseChatter):
             history_text,
             unread_lines,
             extra,
+            clean_mode,
         )
 
     @staticmethod

--- a/plugins/default_chatter/prompt_builder.py
+++ b/plugins/default_chatter/prompt_builder.py
@@ -131,6 +131,7 @@ class DefaultChatterPromptBuilder:
         history_text: str,
         unread_lines: str,
         extra: str = "",
+        clean_mode: bool = False,
     ) -> str:
         """通过 user prompt 模板构建用户提示词。"""
         from src.app.plugin_system.api import adapter_api
@@ -149,6 +150,10 @@ class DefaultChatterPromptBuilder:
         stream_name = chat_stream.stream_name
         tmpl = get_prompt_manager().get_template("default_chatter_user_prompt")
         assert tmpl, "缺少 default_chatter_user_prompt 模板，请检查提示词管理器配置"
+
+        if clean_mode:
+            tmpl = tmpl.clone()
+            tmpl.name = "default_chatter_user_prompt_clean"
 
         return await (
             tmpl

--- a/plugins/default_chatter/session.py
+++ b/plugins/default_chatter/session.py
@@ -522,7 +522,26 @@ class DefaultChatterSession:
                             "LLM stream observer disabled because tool_call_compat is enabled."
                         )
 
+                    last_user_payload = None
+                    if state.unread_msgs_to_flush and getattr(state.response, "payloads", None):
+                        if state.response.payloads[-1].role == ROLE.USER:
+                            last_user_payload = state.response.payloads[-1]
+
                     state.response = await state.response.send(stream=use_stream)
+                    
+                    if last_user_payload is not None:
+                        unread_lines = "\n".join(
+                            self.adapters.unread_adapter.format_message_line(msg) for msg in state.unread_msgs_to_flush
+                        )
+                        clean_text = await self.adapters.prompt_adapter._build_user_prompt(
+                            chat_stream,
+                            history_text=history_text if not state.history_merged else "",
+                            unread_lines=unread_lines,
+                            extra="",
+                            clean_mode=True,
+                        )
+                        last_user_payload.content = [Text(clean_text)]
+
                     if use_stream and stream_observer is not None:
                         await state.response.stream_events_with_callback(stream_observer)
                         finalize = getattr(stream_observer, "finalize", None)

--- a/plugins/default_chatter/type_defs.py
+++ b/plugins/default_chatter/type_defs.py
@@ -87,6 +87,7 @@ class PromptAdapter(Protocol):
         history_text: str,
         unread_lines: str,
         extra: str = "",
+        clean_mode: bool = False,
     ) -> str:
         ...
 


### PR DESCRIPTION
## 描述 / Description

修复了 `default_chatter` 中因提示词重复注入导致的严重上下文污染问题。

在此之前，各种插件（如 `booku_memory`、`feeling` 等）通过 `on_prompt_build` 注入的 `system_reminder`，会随着完整的 user prompt 被持久化写入对话历史（保存在 `state.response.payloads` 中）。这导致在多轮对话中，每一轮都会叠加前一轮所有的动态注入内容，引发上下文体积爆炸，浪费大量 Token，并导致 LLM 逻辑降级或对旧设定的过度反应。

## 解决方案 / Solution

引入了 **请求后净化 (Post-request Sanitization)** 机制，不改变底层架构而优雅地解决问题：

1. **新增清理模式**：在 PromptAdapter 的 `_build_user_prompt` 方法中新增了 `clean_mode` 标识。
2. **绕过事件注入**：在 `prompt_builder.py` 中，当 `clean_mode` 为 `True` 时，通过克隆模板并重命名为 `default_chatter_user_prompt_clean`，成功绕过所有的 `on_prompt_build` 事件订阅者，生成了一份仅包含纯净对话文本的 Prompt。
3. **延迟历史替换**：在 `session.py` 的处理流中，带有完整注入信息的 Payload 正常被发送给 LLM。**而在发送请求返回后**，立即调用 `clean_mode` 生成纯净文本，并覆盖刚才发送出去的那个 Payload 的内容。

这就使得那些动态注入的 Prompt 仅作为“瞬态载荷（Transient Payload）”在本次请求中对 LLM 可见，但绝对不会被作为历史记忆进入下一轮。

## 测试 / Testing

已通过实际抓包确认：
- 第一轮请求发送时，尾部的 User Payload 成功携带了所有需要的 `<system_reminder>` 信息。
- 第二轮请求发送时，第一轮的那条 User Payload 被完美替换为无注入的纯净文本，且本次请求的末尾也只包含当次新增的注入内容。没有发生任何重复叠加现象。

## Summary by Sourcery

Prevent prompt injection reminders from polluting persisted conversation history in default_chatter.

Bug Fixes:
- Ensure dynamically injected system_reminder content is treated as transient and not persisted into future conversation turns.

Enhancements:
- Add a clean_mode to user prompt construction to generate a version of the user prompt without plugin on_prompt_build injections for history storage.