### PR TITLE
fix(onebot_adapter): 修复 OneBot 适配器无法在配置中禁用的问题

### DIFF
--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -355,13 +355,20 @@ class OneBotAdapterPlugin(BasePlugin):
     plugin_version = "2.0.0"
     plugin_author = "MoFox Team"
     plugin_description = "OneBot 11 适配器（基于 Neo-MoFox 重写）"
-    configs = [OneBotAdapterConfig]
+    configs: list[type] = [OneBotAdapterConfig]
 
 
     def get_components(self) -> list[type]:
         """获取插件内所有组件类
 
+        若配置中 plugin.enabled 为 False，则返回空列表以跳过加载。
+
         Returns:
             list[type]: 插件内所有组件类的列表
         """
+        if self.config:
+            config = cast(OneBotAdapterConfig, self.config)
+            if not config.plugin.enabled:
+                logger.info("OneBot 适配器已在配置中禁用，跳过加载")
+                return []
         return [OneBotAdapter]


### PR DESCRIPTION
## 描述 / Description

修复了 `onebot_adapter` 在配置 `plugin.enabled = False` 时仍被加载的问题。

在此之前，`get_components` 方法没有检查插件的 `enabled` 状态，即使在配置文件中将 `plugin.enabled` 设置为 `False`，该适配器组件仍然会被系统加载并尝试运行，这可能会导致未预期的行为或资源浪费。

## 解决方案 / Solution

在 `plugins/onebot_adapter/plugin.py` 的 `get_components` 中添加了检查逻辑：如果检测到 `plugin.enabled` 为 `False`，则直接返回空列表并打印 info 日志，从而跳过组件的加载。

## 测试 / Testing

已确保该文件逻辑与最新的插件编写规范一致，能够被系统识别和正确跳过加载。

## Summary by Sourcery

Bug Fixes:
- Prevent OneBot adapter from being loaded when its plugin.enabled configuration is set to False.