### PR TITLE
Revert "fix(onebot_adapter): 修复 OneBot 适配器无法在配置中禁用的问题"

### DIFF
--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -355,20 +355,13 @@ class OneBotAdapterPlugin(BasePlugin):
     plugin_version = "2.0.0"
     plugin_author = "MoFox Team"
     plugin_description = "OneBot 11 适配器（基于 Neo-MoFox 重写）"
-    configs: list[type] = [OneBotAdapterConfig]
+    configs = [OneBotAdapterConfig]
 
 
     def get_components(self) -> list[type]:
         """获取插件内所有组件类
 
-        若配置中 plugin.enabled 为 False，则返回空列表以跳过加载。
-
         Returns:
             list[type]: 插件内所有组件类的列表
         """
-        if self.config:
-            config = cast(OneBotAdapterConfig, self.config)
-            if not config.plugin.enabled:
-                logger.info("OneBot 适配器已在配置中禁用，跳过加载")
-                return []
         return [OneBotAdapter]


### PR DESCRIPTION
Reverts MoFox-Studio/Neo-MoFox#75

## Summary by Sourcery

Enhancements:
- Restore always-on loading of the OneBot adapter components regardless of configuration flags and simplify the plugin config declaration.