### PR TITLE
fix(dfc,onebot): 修复提示词重复注入与适配器禁用逻辑

### DIFF
--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -830,6 +830,7 @@ class DefaultChatter(BaseChatter):
         history_text: str,
         unread_lines: str,
         extra: str = "",
+        clean_mode: bool = False,
     ) -> str:
         """通过 user prompt 模板构建用户提示词。
 
@@ -838,6 +839,7 @@ class DefaultChatter(BaseChatter):
             history_text: 格式化后的历史消息文本（各行已用统一格式）
             unread_lines: 格式化后的未读消息文本
             extra: 额外信息文本
+            clean_mode: 是否启用净输出模式以跳过 on_prompt_build 注入，用于发送后恢复文本
 
         Returns:
             str: 渲染后的 user 提示词
@@ -847,6 +849,7 @@ class DefaultChatter(BaseChatter):
             history_text,
             unread_lines,
             extra,
+            clean_mode,
         )
 
     @staticmethod

--- a/plugins/default_chatter/prompt_builder.py
+++ b/plugins/default_chatter/prompt_builder.py
@@ -131,6 +131,7 @@ class DefaultChatterPromptBuilder:
         history_text: str,
         unread_lines: str,
         extra: str = "",
+        clean_mode: bool = False,
     ) -> str:
         """通过 user prompt 模板构建用户提示词。"""
         from src.app.plugin_system.api import adapter_api
@@ -149,6 +150,10 @@ class DefaultChatterPromptBuilder:
         stream_name = chat_stream.stream_name
         tmpl = get_prompt_manager().get_template("default_chatter_user_prompt")
         assert tmpl, "缺少 default_chatter_user_prompt 模板，请检查提示词管理器配置"
+
+        if clean_mode:
+            tmpl = tmpl.clone()
+            tmpl.name = "default_chatter_user_prompt_clean"
 
         return await (
             tmpl

--- a/plugins/default_chatter/session.py
+++ b/plugins/default_chatter/session.py
@@ -522,7 +522,26 @@ class DefaultChatterSession:
                             "LLM stream observer disabled because tool_call_compat is enabled."
                         )
 
+                    last_user_payload = None
+                    if state.unread_msgs_to_flush and getattr(state.response, "payloads", None):
+                        if state.response.payloads[-1].role == ROLE.USER:
+                            last_user_payload = state.response.payloads[-1]
+
                     state.response = await state.response.send(stream=use_stream)
+                    
+                    if last_user_payload is not None:
+                        unread_lines = "\n".join(
+                            self.adapters.unread_adapter.format_message_line(msg) for msg in state.unread_msgs_to_flush
+                        )
+                        clean_text = await self.adapters.prompt_adapter._build_user_prompt(
+                            chat_stream,
+                            history_text=history_text if not state.history_merged else "",
+                            unread_lines=unread_lines,
+                            extra="",
+                            clean_mode=True,
+                        )
+                        last_user_payload.content = [Text(clean_text)]
+
                     if use_stream and stream_observer is not None:
                         await state.response.stream_events_with_callback(stream_observer)
                         finalize = getattr(stream_observer, "finalize", None)

--- a/plugins/default_chatter/type_defs.py
+++ b/plugins/default_chatter/type_defs.py
@@ -87,6 +87,7 @@ class PromptAdapter(Protocol):
         history_text: str,
         unread_lines: str,
         extra: str = "",
+        clean_mode: bool = False,
     ) -> str:
         ...
 

--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -355,13 +355,20 @@ class OneBotAdapterPlugin(BasePlugin):
     plugin_version = "2.0.0"
     plugin_author = "MoFox Team"
     plugin_description = "OneBot 11 适配器（基于 Neo-MoFox 重写）"
-    configs = [OneBotAdapterConfig]
+    configs: list[type] = [OneBotAdapterConfig]
 
 
     def get_components(self) -> list[type]:
         """获取插件内所有组件类
 
+        若配置中 plugin.enabled 为 False，则返回空列表以跳过加载。
+
         Returns:
             list[type]: 插件内所有组件类的列表
         """
+        if self.config:
+            config = cast(OneBotAdapterConfig, self.config)
+            if not config.plugin.enabled:
+                logger.info("OneBot 适配器已在配置中禁用，跳过加载")
+                return []
         return [OneBotAdapter]


### PR DESCRIPTION
## 描述 / Description

本 PR 包含了以下两项关键修复，旨在优化 `default_chatter` 的上下文管理以及增强 `onebot_adapter` 的配置灵活性：

1. **Default Chatter 提示词注入净化 (Prompt Injection Sanitization)**：
    - **问题**：在此之前，通过 `on_prompt_build` 事件注入的动态提示词（如系统提醒、情绪设定、长期记忆等）会被永久性地追加到对话历史中（`state.response.payloads`）。这导致在多轮对话中，每一轮都会叠加前一轮所有的注入内容，引发上下文体积爆炸，极大浪费 Token，并可能导致 AI 逻辑混乱。
    - **解决方案**：引入了 **请求后净化 (Post-request Sanitization)** 机制。通过新增的 `clean_mode` 标识，在向 LLM 发送请求后，立即将该轮包含大量注入信息的 User Payload 替换为仅包含纯净对话文本的版本。
    - **结果**：注入的提示词仅对当次请求可见，不会污染后续对话的历史上下文。

2. **OneBot 适配器加载开关修复 (OneBot Adapter Enable Check)**：
    - **问题**：`onebot_adapter` 的组件加载逻辑未检查 `plugin.enabled` 配置项，导致即使在配置中禁用了适配器，它仍会被系统加载。
    - **解决方案**：在 `get_components()` 中添加了配置检查逻辑，当 `plugin.enabled = false` 时跳过组件加载并记录日志。

## 测试 / Testing

- 已通过实际抓包确认 DFC 的注入内容在多轮对话中不再重复累积。
- 已验证 OneBot 适配器在配置禁用时能够正确跳过加载。

## Summary by Sourcery

Refine default chatter prompt handling to avoid persisting injected hints in conversation history and honor the OneBot adapter enable flag when loading components.

Bug Fixes:
- Prevent dynamically injected prompts from accumulating in default chatter conversation history by sanitizing the stored user payload after each request.
- Respect the OneBot adapter plugin.enabled configuration flag so that the adapter is not loaded when disabled in config.