### PR TITLE
fix(llm-stats): get_by_time_range 补齐 success_rate/success_count/error…

### DIFF
--- a/src/kernel/llm/stats/collector.py
+++ b/src/kernel/llm/stats/collector.py
@@ -643,12 +643,15 @@ class LLMStatsCollector:
         sql = """
             SELECT
                 COUNT(*) as total_requests,
+                SUM(CASE WHEN success THEN 1 ELSE 0 END) as success_count,
+                SUM(CASE WHEN success THEN 0 ELSE 1 END) as error_count,
                 COALESCE(SUM(prompt_tokens), 0) as total_prompt_tokens,
                 COALESCE(SUM(completion_tokens), 0) as total_completion_tokens,
                 COALESCE(SUM(total_tokens), 0) as total_tokens,
                 COALESCE(SUM(cache_hit_tokens), 0) as total_cache_hit_tokens,
                 COALESCE(SUM(cache_miss_tokens), 0) as total_cache_miss_tokens,
-                COALESCE(SUM(cost), 0.0) as total_cost
+                COALESCE(SUM(cost), 0.0) as total_cost,
+                COALESCE(AVG(latency), 0.0) as avg_latency
             FROM llm_requests
             WHERE timestamp >= ? AND timestamp <= ?
         """
@@ -660,6 +663,9 @@ class LLMStatsCollector:
         cache_total = (row["total_cache_hit_tokens"] or 0) + (row["total_cache_miss_tokens"] or 0)
         return {
             "total_requests": total,
+            "success_count": row["success_count"] or 0,
+            "error_count": row["error_count"] or 0,
+            "success_rate": (row["success_count"] / total) if total > 0 else 0.0,
             "total_prompt_tokens": row["total_prompt_tokens"] or 0,
             "total_completion_tokens": row["total_completion_tokens"] or 0,
             "total_tokens": row["total_tokens"] or 0,
@@ -667,6 +673,7 @@ class LLMStatsCollector:
             "total_cache_miss_tokens": row["total_cache_miss_tokens"] or 0,
             "cache_hit_rate": (row["total_cache_hit_tokens"] / cache_total) if cache_total > 0 else 0.0,
             "total_cost": round(row["total_cost"] or 0.0, 6),
+            "avg_latency": round(row["avg_latency"] or 0.0, 4),
         }
 
     # ------------------------------------------------------------------

--- a/test/kernel/llm/stats/test_collector_window.py
+++ b/test/kernel/llm/stats/test_collector_window.py
@@ -185,3 +185,41 @@ async def test_request_name_window_summary_orders_by_token_usage() -> None:
     assert item["model_identifier"] == "provider/model-b"
     assert item["base_urls"] == ["https://api.example.com/v1"]
     assert item["success_rate"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_time_range_summary_includes_success_rate() -> None:
+    """get_by_time_range 摘要必须包含 success_rate / success_count / avg_latency 字段。
+
+    回归测试：前端 last-hours 接口依赖该摘要的 success_rate，缺失会导致
+    WebUI 成功率恒为 0。
+    """
+    collector = get_llm_stats_collector()
+    now = time.time()
+    await collector.record(
+        LLMRequestRecord(
+            model_name="ok-model",
+            request_name="ok",
+            success=True,
+            latency=0.3,
+            timestamp=now - 60,
+        )
+    )
+    await collector.record(
+        LLMRequestRecord(
+            model_name="err-model",
+            request_name="err",
+            success=False,
+            error_type="timeout",
+            latency=1.2,
+            timestamp=now - 30,
+        )
+    )
+
+    summary = await collector.get_by_time_range(start_ts=now - 3600, end_ts=now + 60)
+
+    assert summary["total_requests"] == 2
+    assert summary["success_count"] == 1
+    assert summary["error_count"] == 1
+    assert summary["success_rate"] == 0.5
+    assert summary["avg_latency"] > 0

--- a/test/kernel/llm/stats/test_collector_window.py
+++ b/test/kernel/llm/stats/test_collector_window.py
@@ -189,10 +189,8 @@ async def test_request_name_window_summary_orders_by_token_usage() -> None:
 
 @pytest.mark.asyncio
 async def test_time_range_summary_includes_success_rate() -> None:
-    """get_by_time_range 摘要必须包含 success_rate / success_count / avg_latency 字段。
-
-    回归测试：前端 last-hours 接口依赖该摘要的 success_rate，缺失会导致
-    WebUI 成功率恒为 0。
+    """
+    get_by_time_range 摘要必须包含 success_rate / success_count / avg_latency 字段。
     """
     collector = get_llm_stats_collector()
     now = time.time()


### PR DESCRIPTION
LLM 指标页的成功率恒为 0，根因是 get_by_time_range（对应 WebUI
/last-hours 接口）的 SQL 未对 success 列做聚合，返回字典也缺失
success_rate、success_count、error_count、avg_latency 字段。

前端 windowOverview 优先取 last-hours 数据，缺失的 success_rate 经
normalizedNumber 归一化为 0，导致页面始终显示 0.0%。

修复：让 get_by_time_range 的 SQL 与返回结构与 get_summary 对齐，
补充 success_count/error_count/success_rate/avg_latency 计算与字段。

测试：新增 test_time_range_summary_includes_success_rate 覆盖该回归。

## Summary by Sourcery

Align time-range LLM stats aggregation with summary metrics so WebUI can display correct success rate and latency.

Bug Fixes:
- Include success_count, error_count, success_rate, and avg_latency in get_by_time_range LLM stats to fix WebUI success rate always showing 0%.

Tests:
- Add a regression test ensuring time-range summaries contain success_rate, success_count, error_count, and avg_latency fields.