### PR TITLE
feat(system_reminder): 为 SystemReminderStore 增加 stream_id 流隔离支持

### DIFF
--- a/src/app/plugin_system/api/prompt_api.py
+++ b/src/app/plugin_system/api/prompt_api.py
@@ -163,6 +163,7 @@ def add_system_reminder(
     content: str,
     insert_type: str | SystemReminderInsertType = SystemReminderInsertType.FIXED,
     consume: str | SystemReminderConsumeType = SystemReminderConsumeType.FOREVER,
+    stream_id: str | None = None,
 ) -> None:
     """添加（或覆盖）一条 system reminder。
 
@@ -174,6 +175,8 @@ def add_system_reminder(
         name: reminder 名称
         content: reminder 内容
         insert_type: reminder 插入位置类型，支持 fixed 和 dynamic
+        stream_id: 聊天流 ID。为 ``None`` 时写入全局命名空间（所有流共享，
+            向后兼容）；为具体值时仅对该聊天流可见，实现 per-stream 隔离注入。
 
     Returns:
         None
@@ -188,24 +191,32 @@ def add_system_reminder(
         content=content,
         insert_type=insert_type,
         consume=consume,
+        stream_id=stream_id,
     )
 
 
 def get_system_reminder(
     bucket: str | SystemReminderBucket,
     names: list[str] | None = None,
+    stream_id: str | None = None,
 ) -> str:
     """获取指定 bucket 的 system reminder 内容。
 
     Args:
         bucket: bucket 名称
         names: 可选的 name 列表；传入时仅返回这些 name 对应的 reminder（按 names 顺序拼接）。
+        stream_id: 聊天流 ID。为 ``None`` 时从全局命名空间读取；为具体值时从该流
+            的私有命名空间读取。
 
     Returns:
         拼接后的 reminder 字符串；若 bucket 为空或无内容则返回空字符串。
     """
 
-    return _get_system_reminder_store().get(bucket=bucket, names=names)
+    return _get_system_reminder_store().get(
+        bucket=bucket,
+        names=names,
+        stream_id=stream_id,
+    )
 
 
 __all__ = [

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -504,6 +504,7 @@ class BaseChatter(ABC):
                 ReminderSourceSpec(
                     bucket=str(with_reminder),
                     wrap_with_system_tag=True,
+                    stream_id=self.stream_id,
                 )
             ]
 

--- a/src/core/prompt/system_reminder.py
+++ b/src/core/prompt/system_reminder.py
@@ -161,7 +161,7 @@ class SystemReminderStore:
       第三层键为 name。
     - 提供 set 和 get 方法来添加和检索 reminder，支持按 bucket、stream_id
       和 name 进行过滤。
-    - ``stream_id=None`` 时为全局命名空间，所有聊天流共享，保持向后兼容。
+    - ``stream_id=None`` 时为全局命名空间，所有聊天流共享。
     - ``stream_id`` 为具体值时为流私有命名空间，仅对该流可见。
     - 使用 RLock 确保在多线程环境下的安全访问。
     """
@@ -184,12 +184,12 @@ class SystemReminderStore:
 
         Args:
             bucket: reminder所属的 bucket。
-            name: reminder的名称，在 bucket + stream_id 范围内唯一。
+            name: reminder的名称。
             content: reminder的内容文本。
             insert_type: reminder 的插入位置类型。
             consume: reminder 的消费模式。
             stream_id: 聊天流 ID。为 ``None`` 时写入全局命名空间（所有流共享）；
-                为具体值时仅对该流可见。
+                为具体值时仅对该流可见。name 在同一 bucket + stream_id 范围内唯一。
         """
 
         bucket_key = _normalize_bucket(bucket)
@@ -224,7 +224,7 @@ class SystemReminderStore:
         Args:
             bucket: reminder所属的 bucket。
             names: 可选的reminder名称列表。如果提供，则仅返回这些 name 的 reminder。
-            stream_id: 聊天流 ID。为 ``None`` 时从全局命名空间读取（向后兼容）；
+            stream_id: 聊天流 ID。为 ``None`` 时从全局命名空间读取；
                 为具体值时从该流的私有命名空间读取。
 
         Returns:
@@ -282,8 +282,7 @@ class SystemReminderStore:
         Args:
             bucket: reminder所属的 bucket。
             stream_id: 聊天流 ID。为 ``None`` 时清空全局命名空间；
-                为具体值时仅清空该流的私有命名空间。不传或传 ``None``
-                不会影响其他流的私有数据。
+                为具体值时仅清空该流的私有命名空间。
         """
 
         bucket_key = _normalize_bucket(bucket)

--- a/src/core/prompt/system_reminder.py
+++ b/src/core/prompt/system_reminder.py
@@ -6,16 +6,25 @@
 设计目标：
 - 简单易用：提供直观的接口来设置和获取提醒。
 - 灵活性：支持不同的提醒分类（bucket）和命名（name），以适应多样化的使用场景。
+- 流隔离：通过 ``stream_id`` 参数支持按聊天流隔离 reminder，实现 per-stream 注入。
 - 线程安全：在多线程环境下安全地访问和修改提醒。
 - 轻量级：仅在内存中存储，不涉及持久化，以保持高性能和低复杂度。
 
 使用示例:
     from src.core.prompt import get_system_reminder_store
 
-    # 添加提醒
+    # 添加全局提醒（stream_id=None，所有聊天流共享）
     store = get_system_reminder_store()
     store.set(bucket="actor", name="goal", content="完成订单处理")
     store.set(bucket="actor", name="constraint", content="只能使用提供的API")
+
+    # 添加流隔离提醒（仅对指定 stream_id 生效）
+    store.set(
+        bucket="actor",
+        name="group_rule",
+        content="这是技术群，优先解决技术问题。",
+        stream_id="stream_abc123",
+    )
 
     # 获取提醒
     print(store.get("actor"))
@@ -147,14 +156,20 @@ class SystemReminderStore:
     """system reminder存储类，提供线程安全的接口来设置和获取reminder。
 
     设计说明:
-    - 内部使用嵌套字典结构存储reminder，第一层键为 bucket，第二层键为 name。
-    - 提供 set 和 get 方法来添加和检索reminder，支持按 bucket 和 name 进行过滤。
+    - 内部使用三层嵌套字典结构存储 reminder：
+      第一层键为 bucket，第二层键为 stream_id（``None`` 表示全局），
+      第三层键为 name。
+    - 提供 set 和 get 方法来添加和检索 reminder，支持按 bucket、stream_id
+      和 name 进行过滤。
+    - ``stream_id=None`` 时为全局命名空间，所有聊天流共享，保持向后兼容。
+    - ``stream_id`` 为具体值时为流私有命名空间，仅对该流可见。
     - 使用 RLock 确保在多线程环境下的安全访问。
     """
 
     def __init__(self) -> None:
         self._lock = RLock()
-        self._data: dict[str, dict[str, SystemReminderItem]] = {}
+        # bucket -> stream_id(None=全局) -> name -> item
+        self._data: dict[str, dict[str | None, dict[str, SystemReminderItem]]] = {}
 
     def set(
         self,
@@ -163,15 +178,18 @@ class SystemReminderStore:
         content: str,
         insert_type: InsertTypeLike = SystemReminderInsertType.FIXED,
         consume: ConsumeTypeLike = SystemReminderConsumeType.FOREVER,
+        stream_id: str | None = None,
     ) -> None:
         """设置一个reminder。
 
         Args:
             bucket: reminder所属的 bucket。
-            name: reminder的名称，在 bucket 内唯一。
+            name: reminder的名称，在 bucket + stream_id 范围内唯一。
             content: reminder的内容文本。
             insert_type: reminder 的插入位置类型。
             consume: reminder 的消费模式。
+            stream_id: 聊天流 ID。为 ``None`` 时写入全局命名空间（所有流共享）；
+                为具体值时仅对该流可见。
         """
 
         bucket_key = _normalize_bucket(bucket)
@@ -186,7 +204,9 @@ class SystemReminderStore:
         )
 
         with self._lock:
-            self._data.setdefault(bucket_key, {})[normalized_name] = SystemReminderItem(
+            stream_map = self._data.setdefault(bucket_key, {})
+            name_map = stream_map.setdefault(stream_id, {})
+            name_map[normalized_name] = SystemReminderItem(
                 name=normalized_name,
                 content=content,
                 insert_type=normalized_insert_type,
@@ -197,13 +217,25 @@ class SystemReminderStore:
         self,
         bucket: BucketLike,
         names: Sequence[str] | None = None,
+        stream_id: str | None = None,
     ) -> list[SystemReminderItem]:
-        """获取 bucket 下的 reminder 记录列表。"""
+        """获取 bucket 下的 reminder 记录列表。
+
+        Args:
+            bucket: reminder所属的 bucket。
+            names: 可选的reminder名称列表。如果提供，则仅返回这些 name 的 reminder。
+            stream_id: 聊天流 ID。为 ``None`` 时从全局命名空间读取（向后兼容）；
+                为具体值时从该流的私有命名空间读取。
+
+        Returns:
+            bucket + stream_id 范围内的 reminder 记录列表。
+        """
 
         bucket_key = _normalize_bucket(bucket)
 
         with self._lock:
-            bucket_map = dict(self._data.get(bucket_key, {}))
+            stream_map = dict(self._data.get(bucket_key, {}))
+            bucket_map = dict(stream_map.get(stream_id, {}))
 
         if names is None:
             return list(bucket_map.values())
@@ -217,36 +249,64 @@ class SystemReminderStore:
                 selected_items.append(bucket_map[normalized_name])
         return selected_items
 
-    def get(self, bucket: BucketLike, names: Sequence[str] | None = None) -> str:
+    def get(
+        self,
+        bucket: BucketLike,
+        names: Sequence[str] | None = None,
+        stream_id: str | None = None,
+    ) -> str:
         """获取 bucket 下的reminder文本。
 
         Args:
             bucket: reminder所属的 bucket。
             names: 可选的reminder名称列表。如果提供，则仅返回这些 name 的 reminder，且按 names 顺序拼接；如果为 None，则返回 bucket 下所有 reminder（按插入顺序拼接）。
+            stream_id: 聊天流 ID。为 ``None`` 时从全局命名空间读取；为具体值时从该流的私有命名空间读取。
 
         Returns:
             bucket 下的reminder文本，格式为 [name]\ncontent，多个reminder之间以 \n\n 分隔；如果没有找到任何reminder，则返回空字符串。
         """
 
-        selected_items = self.get_items(bucket=bucket, names=names)
+        selected_items = self.get_items(bucket=bucket, names=names, stream_id=stream_id)
         if not selected_items:
             return ""
 
         return "\n\n".join(item.render() for item in selected_items)
 
-    def clear_bucket(self, bucket: BucketLike) -> None:
-        """清空指定 bucket 下的所有 reminder。"""
+    def clear_bucket(
+        self,
+        bucket: BucketLike,
+        stream_id: str | None = None,
+    ) -> None:
+        """清空指定 bucket 下的 reminder。
+
+        Args:
+            bucket: reminder所属的 bucket。
+            stream_id: 聊天流 ID。为 ``None`` 时清空全局命名空间；
+                为具体值时仅清空该流的私有命名空间。不传或传 ``None``
+                不会影响其他流的私有数据。
+        """
 
         bucket_key = _normalize_bucket(bucket)
         with self._lock:
-            self._data.pop(bucket_key, None)
+            stream_map = self._data.get(bucket_key)
+            if stream_map is None:
+                return
+            stream_map.pop(stream_id, None)
+            if not stream_map:
+                self._data.pop(bucket_key, None)
 
-    def delete(self, bucket: BucketLike, name: str) -> bool:
+    def delete(
+        self,
+        bucket: BucketLike,
+        name: str,
+        stream_id: str | None = None,
+    ) -> bool:
         """删除指定 bucket 下的单条 reminder。
 
         Args:
             bucket: reminder 所属的 bucket。
             name: reminder 名称。
+            stream_id: 聊天流 ID。为 ``None`` 时从全局命名空间删除；为具体值时从该流删除。
 
         Returns:
             bool: 删除成功返回 True；不存在时返回 False。
@@ -257,20 +317,46 @@ class SystemReminderStore:
         normalized_name = name.strip()
 
         with self._lock:
-            bucket_map = self._data.get(bucket_key)
-            if not bucket_map or normalized_name not in bucket_map:
+            stream_map = self._data.get(bucket_key)
+            if stream_map is None:
+                return False
+            name_map = stream_map.get(stream_id)
+            if not name_map or normalized_name not in name_map:
                 return False
 
-            del bucket_map[normalized_name]
-            if not bucket_map:
+            del name_map[normalized_name]
+            if not name_map:
+                stream_map.pop(stream_id, None)
+            if not stream_map:
                 self._data.pop(bucket_key, None)
             return True
 
     def clear_all(self) -> None:
-        """清空所有 bucket 下的所有 reminder。"""
+        """清空所有 bucket 下的所有 reminder（包括全局和所有流私有）。"""
 
         with self._lock:
             self._data.clear()
+
+    def clear_stream(self, stream_id: str) -> None:
+        """清除指定聊天流在所有 bucket 下的私有 reminder。
+
+        主要用于聊天流销毁或重置时清理资源，避免流私有 reminder 残留。
+
+        Args:
+            stream_id: 要清除的聊天流 ID。
+        """
+
+        if not stream_id:
+            return
+
+        with self._lock:
+            empty_buckets: list[str] = []
+            for bucket_key, stream_map in self._data.items():
+                stream_map.pop(stream_id, None)
+                if not stream_map:
+                    empty_buckets.append(bucket_key)
+            for bucket_key in empty_buckets:
+                self._data.pop(bucket_key, None)
 
 
 _global_store: SystemReminderStore | None = None

--- a/src/kernel/llm/context.py
+++ b/src/kernel/llm/context.py
@@ -53,6 +53,7 @@ class RegisteredReminderSource:
     bucket: str
     names: tuple[str, ...] | None
     wrap_with_system_tag: bool
+    stream_id: str | None = None
     last_rendered: tuple[RegisteredReminder, ...] = ()
 
 
@@ -62,6 +63,7 @@ class ReminderSourceSpec:
     bucket: str
     names: tuple[str, ...] | None = None
     wrap_with_system_tag: bool = False
+    stream_id: str | None = None
 
 
 @dataclass(slots=True)
@@ -104,6 +106,7 @@ class LLMContextManager:
                     bucket=normalized_bucket,
                     names=normalized_names,
                     wrap_with_system_tag=bool(source.wrap_with_system_tag),
+                    stream_id=source.stream_id,
                 )
             )
 
@@ -248,7 +251,11 @@ class LLMContextManager:
                 for previous in source.last_rendered:
                     strip_texts_by_type[previous.insert_type].append(previous.text)
 
-                items = store.get_items(source.bucket, names=source.names)
+                items = store.get_items(
+                    source.bucket,
+                    names=source.names,
+                    stream_id=source.stream_id,
+                )
                 current_items: list[RegisteredReminder] = []
                 for item in items:
                     rendered_content = item.render()


### PR DESCRIPTION
## 变更概述

为 SystemReminderStore 增加 per-stream 隔离能力，使插件可以针对单个聊天流写入和查询 system reminder，而不影响其他流。

## 背景

`prompt_injector` 插件需要根据 `include`/`exclude` 规则向特定聊天流注入提示词。原 SystemReminderStore 只支持全局存储，无法实现流隔离。本 PR 在框架层面增加 `stream_id` 维度，使插件可以按流写入和查询 reminder。

## 修改文件

### 1. `src/core/prompt/system_reminder.py`
- SystemReminderStore 内部存储结构从 `dict[bucket, dict[name, item]]` 改为 `dict[bucket, dict[stream_id, dict[name, item]]]`
- `set()` / `get_items()` / `get()` / `clear_bucket()` / `delete()` 均增加 `stream_id` 参数（默认 `None` 表示全局命名空间，向后兼容）
- 新增 `clear_stream()` 方法，清除指定流在所有 bucket 下的私有 reminder

### 2. `src/kernel/llm/context.py`
- `ReminderSourceSpec` 增加 `stream_id: str | None` 字段
- `RegisteredReminderSource` 同步增加 `stream_id` 字段
- `_resolve_reminders()` 将 `stream_id` 传递给 `store.get_items()`

### 3. `src/core/components/base/chatter.py`
- `BaseChatter.create_request()` 在构造 `ReminderSourceSpec` 时传入 `stream_id=self.stream_id`

### 4. `src/app/plugin_system/api/prompt_api.py`
- `add_system_reminder()` / `get_system_reminder()` 增加 `stream_id` 参数

## 向后兼容性

- `stream_id` 默认为 `None`，对应全局命名空间
- 未传 `stream_id` 的旧调用行为不变
- 已有全局 reminder（`stream_id=None`）仍可正常查询

## 测试

已实测验证：
- `prompt_injector` 插件通过 `add_system_reminder(stream_id=...)` 写入 per-stream reminder
- chatter 通过 `with_reminder` + `ReminderSourceSpec(stream_id=...)` 正确拾取
- DYNAMIC 模式正常注入到最新 user 消息并自动剥离历史旧注入
- 全局 reminder（`stream_id=None`）不受影响

## Summary by Sourcery

Add per-stream isolation support to system reminders so plugins and chat contexts can read and write reminders scoped by stream_id while keeping global behavior backward compatible.

New Features:
- Introduce stream_id-scoped storage in SystemReminderStore, allowing reminders to be isolated per chat stream or shared globally when stream_id is None.
- Expose stream_id parameters in the prompt API for adding and retrieving system reminders to support per-stream injections.
- Propagate stream_id through LLM context reminder resolution and BaseChatter so reminder sources can target specific streams.

Enhancements:
- Add APIs to clear reminders per bucket, per stream, and globally, including a helper to clear all reminders of a specific chat stream across buckets.