### PR TITLE
feat:日志与媒体缓存自动清理功能

### DIFF
--- a/src/app/runtime/bot.py
+++ b/src/app/runtime/bot.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from src.kernel.scheduler import UnifiedScheduler
     from src.kernel.storage import JSONStore
     from src.kernel.vector_db import VectorDBBase
+    from src.kernel.logger.cleanup import LoggerCleanupManager
 
 class Bot:
     """Neo-MoFox Bot 主类
@@ -89,6 +90,7 @@ class Bot:
         self.vector_db: VectorDBBase | None = None
         self.scheduler: UnifiedScheduler | None = None
         self.storage: JSONStore | None = None
+        self._log_cleanup_manager: "LoggerCleanupManager | None" = None
 
         # Core 层组件（延迟初始化）
         self.message_receiver: MessageReceiver | None = None
@@ -308,10 +310,25 @@ class Bot:
         self.ui.update_phase_status("配置", "已加载")
 
         # Step 2: Logger
-        from src.kernel.logger import get_logger, initialize_logger_system, COLOR
+        from src.kernel.logger import (
+            get_logger,
+            initialize_logger_system,
+            COLOR,
+            LoggerCleanupManager,
+        )
 
         initialize_logger_system(log_dir=self.log_dir, log_level=self.config.bot.log_level)
         self.logger = get_logger(name="console", display="控制台", color=COLOR.BLUE)
+
+        # 创建日志自动清理管理器（在 run() 中调度器启动后注册任务）
+        self._log_cleanup_manager = LoggerCleanupManager(
+            log_dir=self.log_dir,
+            max_age_days=self.config.bot.log_max_age_days,
+            max_files=self.config.bot.log_max_files,
+            cleanup_interval_hours=self.config.bot.log_cleanup_interval_hours,
+            enabled=self.config.bot.log_cleanup_enabled,
+        )
+
         self.ui.update_phase_status("日志", "已初始化")
 
         await self._preflight_llm_providers()
@@ -795,6 +812,14 @@ class Bot:
         await self.scheduler.start()
         self._stats["scheduler_running"] = True
 
+        # 启动日志自动清理任务
+        if self._log_cleanup_manager is not None:
+            try:
+                await self._log_cleanup_manager.start()
+            except Exception as e:
+                if self.logger:
+                    self.logger.warning(f"启动日志自动清理失败: {e}")
+
         # 启动云端遥测客户端发送循环
         try:
             from src.app.cloud_telemetry import get_cloud_telemetry_client
@@ -1119,7 +1144,15 @@ class Bot:
             # 3. 卸载插件
             await self._unload_all_plugins()
 
-            # 4. 停止调度器
+            # 4. 停止日志自动清理任务（需在调度器停止前移除）
+            if self._log_cleanup_manager is not None:
+                try:
+                    await self._log_cleanup_manager.stop()
+                except Exception as e:
+                    if self.logger:
+                        self.logger.warning(f"停止日志自动清理失败: {e}")
+
+            # 5. 停止调度器
             if self.scheduler:
                 await self.scheduler.stop()
                 self._stats["scheduler_running"] = False

--- a/src/core/config/core_config.py
+++ b/src/core/config/core_config.py
@@ -178,6 +178,40 @@ class CoreConfig(ConfigBase):
             hint="防止高频消息导致无响应",
         )
 
+        # ========== 日志自动清理配置 ==========
+        log_cleanup_enabled: bool = Field(
+            default=True,
+            description="是否启用日志自动清理",
+            label="启用日志清理",
+            tag="file",
+            input_type="switch",
+        )
+        log_max_age_days: int = Field(
+            default=30,
+            description="日志文件最大保留天数，0 表示不按时间清理",
+            label="日志保留天数",
+            tag="file",
+            input_type="number",
+            ge=0,
+        )
+        log_max_files: int = Field(
+            default=100,
+            description="日志目录最大文件数，0 表示不限制。超出时删除最旧的文件",
+            label="日志最大文件数",
+            tag="file",
+            input_type="number",
+            ge=0,
+        )
+        log_cleanup_interval_hours: float = Field(
+            default=6.0,
+            description="日志清理任务执行间隔（小时）",
+            label="日志清理间隔",
+            tag="timer",
+            input_type="number",
+            step=0.5,
+            ge=0.1,
+        )
+
     bot: BotSection = Field(default_factory=BotSection)
 
     @config_section("chat")
@@ -213,6 +247,40 @@ class CoreConfig(ConfigBase):
             rows=3,
             placeholder="请描述这张图片的内容...",
             hint="留空使用默认提示词",
+        )
+
+        # ========== 媒体缓存自动清理配置 ==========
+        media_cache_cleanup_enabled: bool = Field(
+            default=True,
+            description="是否启用媒体缓存自动清理（清理 pending 之外的已识别文件）",
+            label="启用媒体缓存清理",
+            tag="file",
+            input_type="switch",
+        )
+        media_cache_max_age_days: int = Field(
+            default=7,
+            description="已识别媒体文件最大保留天数，0 表示不按时间清理",
+            label="媒体缓存保留天数",
+            tag="file",
+            input_type="number",
+            ge=0,
+        )
+        media_cache_max_total_size_mb: int = Field(
+            default=500,
+            description="已识别媒体文件总容量上限（MB），0 表示不限制。超出时从最旧文件开始删除",
+            label="媒体缓存最大容量",
+            tag="file",
+            input_type="number",
+            ge=0,
+        )
+        media_cache_cleanup_interval_hours: float = Field(
+            default=1.0,
+            description="媒体缓存清理任务执行间隔（小时）",
+            label="媒体缓存清理间隔",
+            tag="timer",
+            input_type="number",
+            step=0.5,
+            ge=0.1,
         )
 
         @property

--- a/src/core/managers/media_manager.py
+++ b/src/core/managers/media_manager.py
@@ -69,6 +69,7 @@ class MediaManager:
         self._initialize_asr()
         self._register_prompts()
         self._setup_media_folders()
+        self._load_cleanup_config()
         self._cleanup_task_id = None
         self._start_cleanup_scheduler()
 
@@ -130,19 +131,32 @@ class MediaManager:
         try:
             # 媒体根目录
             self.media_root = Path("data/media_cache")
-            
+
             # 子文件夹
             self.pending_folder = self.media_root / "pending"  # 待识别
             self.images_folder = self.media_root / "images"    # 识别完成的图片
             self.emojis_folder = self.media_root / "emojis"    # 识别完成的表情包
-            
+
             # 创建所有必要的文件夹
             for folder in [self.pending_folder, self.images_folder, self.emojis_folder]:
                 folder.mkdir(parents=True, exist_ok=True)
-            
+
             logger.info(f"媒体文件夹已初始化: {self.media_root}")
         except Exception as e:
             logger.error(f"创建媒体文件夹失败: {e}")
+
+    def _load_cleanup_config(self) -> None:
+        """从核心配置加载媒体缓存清理参数。
+
+        配置加载失败时直接抛出异常，不使用 fallback 默认值，
+        避免掩盖配置错误导致清理行为与预期不符。
+        """
+        config = get_core_config()
+        chat_cfg = config.chat
+        self._media_cleanup_enabled = chat_cfg.media_cache_cleanup_enabled
+        self._media_max_age_days = chat_cfg.media_cache_max_age_days
+        self._media_max_total_size_mb = chat_cfg.media_cache_max_total_size_mb
+        self._media_cleanup_interval_hours = chat_cfg.media_cache_cleanup_interval_hours
 
     def _start_cleanup_scheduler(self) -> None:
         """启动定时清理任务（每5分钟清理一次缓存）。"""
@@ -159,18 +173,23 @@ class MediaManager:
         """注册定时清理任务到调度器。"""
         try:
             scheduler = get_unified_scheduler()
-            
-            # 创建周期性清理任务（每5分钟 = 300秒）
+
+            # 使用配置的清理间隔（小时转秒）
+            interval_seconds = self._media_cleanup_interval_hours * 3600
+
             schedule_id = await scheduler.create_schedule(
-                callback=self._cleanup_pending_folder,
+                callback=self._cleanup_all_media,
                 trigger_type=TriggerType.TIME,
-                trigger_config={"delay_seconds": 300},  # 5分钟
+                trigger_config={"delay_seconds": interval_seconds},
                 is_recurring=True,
-                task_name="media_cache_cleanup"
+                task_name="media_cache_cleanup",
+                force_overwrite=True,
             )
-            
+
             self._cleanup_task_id = schedule_id
-            logger.info(f"媒体缓存清理任务已注册: {schedule_id}")
+            logger.info(
+                f"媒体缓存清理任务已注册(间隔 {self._media_cleanup_interval_hours}h): {schedule_id}"
+            )
         except Exception as e:
             logger.error(f"注册清理任务失败: {e}")
 
@@ -203,6 +222,106 @@ class MediaManager:
                 logger.info(f"媒体缓存清理完成，删除了 {cleanup_count} 个陈旧文件")
         except Exception as e:
             logger.error(f"清理待识别文件夹失败: {e}")
+
+    async def _cleanup_all_media(self) -> None:
+        """执行全部媒体缓存清理。
+
+        整合 pending 目录清理和 images/emojis 目录清理。
+        pending 目录始终清理（与原有行为一致），
+        images/emojis 目录根据配置决定是否清理。
+        """
+        # 保留原有 pending 清理逻辑
+        await self._cleanup_pending_folder()
+
+        if not self._media_cleanup_enabled:
+            return
+
+        # 清理已识别的分类目录
+        await self._cleanup_category_folder(self.images_folder)
+        await self._cleanup_category_folder(self.emojis_folder)
+
+    async def _cleanup_category_folder(self, folder: Path) -> None:
+        """清理已识别媒体分类文件夹中的陈旧文件。
+
+        按文件年龄和总容量两个维度清理：
+        1. 删除超过 max_age_days 的文件
+        2. 若总容量超过 max_total_size_mb，从最旧文件开始删除直到达标
+
+        Args:
+            folder: 要清理的文件夹路径
+        """
+        try:
+            if not folder.exists():
+                return
+
+            now = time.time()
+            deleted_count = 0
+
+            # 收集所有文件及其修改时间和大小
+            files: list[tuple[Path, float, int]] = []
+            for file_path in folder.iterdir():
+                if not file_path.is_file():
+                    continue
+                stat = file_path.stat()
+                files.append((file_path, stat.st_mtime, stat.st_size))
+
+            if not files:
+                return
+
+            # 按修改时间排序（旧 -> 新）
+            files.sort(key=lambda x: x[1])
+
+            # 阶段 1：按天数清理
+            if self._media_max_age_days > 0:
+                cutoff_time = now - self._media_max_age_days * 86400
+                for file_path, mtime, _ in files:
+                    if mtime < cutoff_time:
+                        deleted_count += self._safe_delete_media(file_path)
+
+            # 重新收集存活文件（阶段1可能已删除部分文件）
+            if deleted_count > 0:
+                files = [(fp, mt, sz) for fp, mt, sz in files if fp.exists()]
+
+            # 阶段 2：按总容量裁剪
+            if self._media_max_total_size_mb > 0:
+                max_bytes = self._media_max_total_size_mb * 1024 * 1024
+                total_size = sum(sz for _, _, sz in files)
+                if total_size > max_bytes:
+                    # 从最旧开始删除
+                    for file_path, _, _ in files:
+                        if total_size <= max_bytes:
+                            break
+                        try:
+                            size = file_path.stat().st_size
+                            file_path.unlink()
+                            total_size -= size
+                            deleted_count += 1
+                        except Exception as e:
+                            logger.warning(f"裁剪媒体文件失败 {file_path.name}: {e}")
+
+            if deleted_count > 0:
+                logger.info(
+                    f"媒体缓存清理完成 [{folder.name}]，删除了 {deleted_count} 个文件"
+                )
+        except Exception as e:
+            logger.error(f"清理媒体分类文件夹失败 [{folder.name}]: {e}")
+
+    @staticmethod
+    def _safe_delete_media(file_path: Path) -> int:
+        """安全删除媒体文件，删除失败时记录警告但不抛出异常。
+
+        Args:
+            file_path: 要删除的文件路径
+
+        Returns:
+            成功删除返回 1，失败返回 0
+        """
+        try:
+            file_path.unlink()
+            return 1
+        except Exception as e:
+            logger.warning(f"删除媒体文件失败 {file_path.name}: {e}")
+            return 0
 
     # ──────────────────────────────────────────
     # 公共 API：VLM 识别控制

--- a/src/kernel/logger/__init__.py
+++ b/src/kernel/logger/__init__.py
@@ -57,6 +57,7 @@ from .logger import (
 )
 from .color import COLOR, get_rich_color, DEFAULT_LEVEL_COLORS
 from .file_handler import FileHandler, RotationMode
+from .cleanup import LoggerCleanupManager
 
 __all__ = [
     # 全局初始化
@@ -70,6 +71,8 @@ __all__ = [
     # 文件输出相关
     "FileHandler",
     "RotationMode",
+    # 自动清理
+    "LoggerCleanupManager",
     # 辅助函数
     "remove_logger",
     "get_all_loggers",

--- a/src/kernel/logger/cleanup.py
+++ b/src/kernel/logger/cleanup.py
@@ -1,0 +1,162 @@
+"""日志文件自动清理管理器。
+
+按保留天数和最大文件数自动清理旧日志文件，避免磁盘空间持续增长。
+
+清理策略：
+1. 按天数清理：删除修改时间超过 max_age_days 的日志文件
+2. 按文件数裁剪：当日志文件数量超过 max_files 时，从最旧文件开始删除
+
+清理任务通过 UnifiedScheduler 注册为周期性任务，与系统其他定时任务统一调度。
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from src.kernel.logger import get_logger
+from src.kernel.scheduler import TriggerType, get_unified_scheduler
+
+logger = get_logger("logger.cleanup", display="日志清理")
+
+
+class LoggerCleanupManager:
+    """日志文件自动清理管理器。
+
+    根据配置定期扫描日志目录，删除超过保留天数的旧日志文件，
+    并在文件数量超过上限时从最旧文件开始裁剪。
+
+    Attributes:
+        log_dir: 日志目录路径
+        max_age_days: 最大保留天数（0 表示不按时间清理）
+        max_files: 最大文件数（0 表示不限制）
+        cleanup_interval_hours: 清理任务执行间隔（小时）
+        enabled: 是否启用清理
+        _cleanup_task_id: 调度器任务 ID
+    """
+
+    def __init__(
+        self,
+        log_dir: str | Path,
+        max_age_days: int = 30,
+        max_files: int = 100,
+        cleanup_interval_hours: float = 6.0,
+        enabled: bool = True,
+    ) -> None:
+        """初始化日志清理管理器。
+
+        Args:
+            log_dir: 日志目录路径
+            max_age_days: 最大保留天数，0 表示不按时间清理
+            max_files: 最大文件数，0 表示不限制
+            cleanup_interval_hours: 清理任务执行间隔（小时）
+            enabled: 是否启用清理
+        """
+        self.log_dir = Path(log_dir)
+        self.max_age_days = max_age_days
+        self.max_files = max_files
+        self.cleanup_interval_hours = cleanup_interval_hours
+        self.enabled = enabled
+        self._cleanup_task_id: str | None = None
+
+    async def start(self) -> None:
+        """启动清理调度任务。
+
+        通过 UnifiedScheduler 注册周期性清理任务。
+        若 enabled 为 False 则跳过注册。
+        """
+        if not self.enabled:
+            logger.info("日志自动清理已禁用")
+            return
+
+        scheduler = get_unified_scheduler()
+        interval_seconds = self.cleanup_interval_hours * 3600
+
+        self._cleanup_task_id = await scheduler.create_schedule(
+            callback=self._cleanup,
+            trigger_type=TriggerType.TIME,
+            trigger_config={"delay_seconds": interval_seconds},
+            is_recurring=True,
+            task_name="log_file_cleanup",
+            force_overwrite=True,
+        )
+        logger.info(
+            f"日志自动清理已启动(每 {self.cleanup_interval_hours} 小时, "
+            f"保留 {self.max_age_days} 天, 上限 {self.max_files} 文件)"
+        )
+
+    async def _cleanup(self) -> None:
+        """执行日志清理。
+
+        先按天数删除过期文件，再按文件数裁剪超额文件。
+        清理过程中遇到的个别文件删除错误不会中断整体流程。
+        """
+        if not self.log_dir.exists():
+            return
+
+        now = time.time()
+        deleted_count = 0
+
+        # 收集所有 .log 文件及其修改时间
+        log_files: list[tuple[Path, float]] = []
+        for file_path in self.log_dir.iterdir():
+            if file_path.is_file() and file_path.suffix == ".log":
+                mtime = file_path.stat().st_mtime
+                log_files.append((file_path, mtime))
+
+        if not log_files:
+            return
+
+        # 按修改时间排序（旧 -> 新）
+        log_files.sort(key=lambda x: x[1])
+
+        # 阶段 1：按天数清理
+        if self.max_age_days > 0:
+            cutoff_time = now - self.max_age_days * 86400
+            for file_path, mtime in log_files:
+                if mtime < cutoff_time:
+                    deleted_count += self._safe_delete(file_path)
+
+        # 重新收集存活文件（阶段1可能已删除部分文件）
+        if deleted_count > 0:
+            log_files = [(fp, mt) for fp, mt in log_files if fp.exists()]
+
+        # 阶段 2：按文件数裁剪
+        if self.max_files > 0 and len(log_files) > self.max_files:
+            excess = len(log_files) - self.max_files
+            # 从最旧开始删除
+            for file_path, _ in log_files[:excess]:
+                deleted_count += self._safe_delete(file_path)
+
+        if deleted_count > 0:
+            logger.info(f"日志清理完成，删除了 {deleted_count} 个文件")
+
+    @staticmethod
+    def _safe_delete(file_path: Path) -> int:
+        """安全删除文件，删除失败时记录警告但不抛出异常。
+
+        Args:
+            file_path: 要删除的文件路径
+
+        Returns:
+            成功删除返回 1，失败返回 0
+        """
+        try:
+            file_path.unlink()
+            return 1
+        except Exception as e:
+            logger.warning(f"删除日志文件失败 {file_path.name}: {e}")
+            return 0
+
+    async def stop(self) -> None:
+        """停止清理调度任务。
+
+        从调度器中移除已注册的清理任务。
+        """
+        if self._cleanup_task_id is None:
+            return
+
+        scheduler = get_unified_scheduler()
+        await scheduler.remove_schedule(self._cleanup_task_id)
+        self._cleanup_task_id = None
+        logger.info("日志自动清理已停止")

--- a/src/kernel/logger/cleanup.py
+++ b/src/kernel/logger/cleanup.py
@@ -80,7 +80,7 @@ class LoggerCleanupManager:
             task_name="log_file_cleanup",
             force_overwrite=True,
         )
-        logger.info(
+        logger.debug(
             f"日志自动清理已启动(每 {self.cleanup_interval_hours} 小时, "
             f"保留 {self.max_age_days} 天, 上限 {self.max_files} 文件)"
         )

--- a/test/core/test_media_cleanup.py
+++ b/test/core/test_media_cleanup.py
@@ -1,0 +1,334 @@
+"""MediaManager 媒体缓存清理逻辑单元测试。
+
+测试 MediaManager 的 _cleanup_category_folder 和 _cleanup_all_media 方法，包括：
+- 按天数删除过期媒体文件
+- 按总容量裁剪大文件
+- 空目录不报错
+- 不存在的目录不报错
+- _safe_delete_media 静态方法
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.managers.media_manager import MediaManager
+
+
+def _create_media_file(folder: Path, name: str, age_seconds: float, content: bytes = b"test") -> Path:
+    """创建一个具有指定年龄的媒体文件。
+
+    Args:
+        folder: 目标文件夹
+        name: 文件名
+        age_seconds: 文件年龄（秒），通过修改 mtime 实现
+        content: 文件内容（字节数据）
+
+    Returns:
+        创建的文件路径
+    """
+    file_path = folder / name
+    file_path.write_bytes(content)
+    # 修改文件修改时间
+    mtime = time.time() - age_seconds
+    os.utime(file_path, (mtime, mtime))
+    return file_path
+
+
+@pytest.fixture
+def mock_media_manager(tmp_path: Path) -> MediaManager:
+    """创建一个使用临时目录的 MediaManager 实例（跳过真实初始化）。
+
+    Args:
+        tmp_path: pytest 提供的临时目录
+
+    Returns:
+        配置好临时目录的 MediaManager 实例
+    """
+    # 使用 MagicMock 绕过 __init__ 的真实初始化
+    manager = MediaManager.__new__(MediaManager)
+
+    # 手动设置必要的文件夹路径
+    manager.media_root = tmp_path / "media_cache"
+    manager.pending_folder = manager.media_root / "pending"
+    manager.images_folder = manager.media_root / "images"
+    manager.emojis_folder = manager.media_root / "emojis"
+
+    # 创建文件夹
+    for folder in [manager.pending_folder, manager.images_folder, manager.emojis_folder]:
+        folder.mkdir(parents=True, exist_ok=True)
+
+    # 设置清理配置
+    manager._media_cleanup_enabled = True
+    manager._media_max_age_days = 7
+    manager._media_max_total_size_mb = 500
+    manager._media_cleanup_interval_hours = 1.0
+    manager._cleanup_task_id = None
+
+    return manager
+
+
+class TestCleanupCategoryFolder:
+    """测试 _cleanup_category_folder 方法。"""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_by_age(self, mock_media_manager: MediaManager) -> None:
+        """测试按天数删除过期文件。"""
+        folder = mock_media_manager.images_folder
+
+        # 创建过期文件（10天前）
+        old_file1 = _create_media_file(folder, "old1.jpg", age_seconds=10 * 86400, content=b"x" * 100)
+        old_file2 = _create_media_file(folder, "old2.jpg", age_seconds=15 * 86400, content=b"x" * 100)
+        # 创建新文件（1天前）
+        new_file = _create_media_file(folder, "new.jpg", age_seconds=1 * 86400, content=b"x" * 100)
+
+        mock_media_manager._media_max_age_days = 7
+        mock_media_manager._media_max_total_size_mb = 0  # 禁用容量清理
+
+        await mock_media_manager._cleanup_category_folder(folder)
+
+        assert not old_file1.exists()
+        assert not old_file2.exists()
+        assert new_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_by_total_size(self, mock_media_manager: MediaManager) -> None:
+        """测试按总容量裁剪大文件。"""
+        folder = mock_media_manager.emojis_folder
+
+        # 创建 4 个文件，每个 1MB，age 递增确保 mtime 不同（i=0 最新，i=3 最旧）
+        files = []
+        for i in range(4):
+            f = _create_media_file(
+                folder,
+                f"emoji_{i}.png",
+                age_seconds=i * 3600,
+                content=b"x" * (1 * 1024 * 1024),  # 1MB
+            )
+            files.append(f)
+
+        # 总容量 4MB，上限设为 2MB
+        mock_media_manager._media_max_age_days = 0  # 禁用天数清理
+        mock_media_manager._media_max_total_size_mb = 2  # 2MB 上限
+
+        await mock_media_manager._cleanup_category_folder(folder)
+
+        # 按 mtime 排序（旧->新）：files[3](3h), files[2](2h), files[1](1h), files[0](0h)
+        # 从最旧开始删除，删除 2 个后总容量降到 2MB
+        assert not files[3].exists()
+        assert not files[2].exists()
+        assert files[1].exists()
+        assert files[0].exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_empty_folder(self, mock_media_manager: MediaManager) -> None:
+        """测试空文件夹不报错。"""
+        folder = mock_media_manager.images_folder
+
+        mock_media_manager._media_max_age_days = 7
+        mock_media_manager._media_max_total_size_mb = 500
+
+        await mock_media_manager._cleanup_category_folder(folder)
+        # 不报错即通过
+
+    @pytest.mark.asyncio
+    async def test_cleanup_nonexistent_folder(self, mock_media_manager: MediaManager) -> None:
+        """测试不存在的文件夹不报错。"""
+        folder = mock_media_manager.media_root / "nonexistent"
+
+        mock_media_manager._media_max_age_days = 7
+        mock_media_manager._media_max_total_size_mb = 500
+
+        await mock_media_manager._cleanup_category_folder(folder)
+        # 不报错即通过
+
+    @pytest.mark.asyncio
+    async def test_cleanup_max_age_zero_no_deletion(self, mock_media_manager: MediaManager) -> None:
+        """测试 max_age_days=0 时不按天数清理。"""
+        folder = mock_media_manager.images_folder
+
+        old_file = _create_media_file(folder, "old.jpg", age_seconds=365 * 86400, content=b"x" * 100)
+
+        mock_media_manager._media_max_age_days = 0
+        mock_media_manager._media_max_total_size_mb = 0
+
+        await mock_media_manager._cleanup_category_folder(folder)
+
+        assert old_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_max_size_zero_no_deletion(self, mock_media_manager: MediaManager) -> None:
+        """测试 max_total_size_mb=0 时不按容量清理。"""
+        folder = mock_media_manager.emojis_folder
+
+        # 创建多个大文件
+        for i in range(5):
+            _create_media_file(
+                folder,
+                f"emoji_{i}.png",
+                age_seconds=i * 100,
+                content=b"x" * (1 * 1024 * 1024),
+            )
+
+        mock_media_manager._media_max_age_days = 0
+        mock_media_manager._media_max_total_size_mb = 0
+
+        await mock_media_manager._cleanup_category_folder(folder)
+
+        # 所有文件都应保留
+        assert len(list(folder.iterdir())) == 5
+
+    @pytest.mark.asyncio
+    async def test_cleanup_combined_age_and_size(self, mock_media_manager: MediaManager) -> None:
+        """测试同时按天数和容量清理。"""
+        folder = mock_media_manager.images_folder
+
+        # 创建 3 个过期文件（10天前），每个 1MB，age 递增确保 mtime 不同
+        old_files = []
+        for i in range(3):
+            f = _create_media_file(
+                folder,
+                f"old_{i}.jpg",
+                age_seconds=10 * 86400 + i * 3600,
+                content=b"x" * (1 * 1024 * 1024),
+            )
+            old_files.append(f)
+
+        # 创建 2 个新文件（1天内），每个 1MB，i=0 最新，i=1 最旧
+        new_files = []
+        for i in range(2):
+            f = _create_media_file(
+                folder,
+                f"new_{i}.jpg",
+                age_seconds=i * 3600,
+                content=b"x" * (1 * 1024 * 1024),
+            )
+            new_files.append(f)
+
+        mock_media_manager._media_max_age_days = 7
+        mock_media_manager._media_max_total_size_mb = 1  # 只保留 1MB
+
+        await mock_media_manager._cleanup_category_folder(folder)
+
+        # 所有旧文件应被删除（按天数）
+        for f in old_files:
+            assert not f.exists()
+
+        # 新文件按 mtime 排序（旧->新）：new_files[1](1h), new_files[0](0h)
+        # 只保留 1MB，所以从最旧开始删除，删除 new_files[1] 后剩 1MB
+        assert not new_files[1].exists()
+        assert new_files[0].exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_skips_subdirectories(self, mock_media_manager: MediaManager) -> None:
+        """测试清理时跳过子目录。"""
+        folder = mock_media_manager.images_folder
+
+        # 创建一个子目录
+        subfolder = folder / "subfolder"
+        subfolder.mkdir()
+
+        # 创建一个过期文件
+        old_file = _create_media_file(folder, "old.jpg", age_seconds=30 * 86400, content=b"x" * 100)
+
+        mock_media_manager._media_max_age_days = 7
+        mock_media_manager._media_max_total_size_mb = 0
+
+        await mock_media_manager._cleanup_category_folder(folder)
+
+        assert not old_file.exists()
+        assert subfolder.exists()  # 子目录不应被删除
+
+    @pytest.mark.asyncio
+    async def test_cleanup_delete_failure_logged(self, mock_media_manager: MediaManager) -> None:
+        """测试删除失败时记录警告但不中断。"""
+        folder = mock_media_manager.images_folder
+
+        old_file = _create_media_file(folder, "old.jpg", age_seconds=30 * 86400, content=b"x" * 100)
+
+        mock_media_manager._media_max_age_days = 7
+        mock_media_manager._media_max_total_size_mb = 0
+
+        original_unlink = Path.unlink
+
+        def failing_unlink(self: Path, *args: object, **kwargs: object) -> None:
+            raise PermissionError("Permission denied")
+
+        Path.unlink = failing_unlink  # type: ignore[method-assign]
+        try:
+            await mock_media_manager._cleanup_category_folder(folder)
+            # 不抛出异常即通过
+        finally:
+            Path.unlink = original_unlink  # type: ignore[method-assign]
+
+
+class TestCleanupAllMedia:
+    """测试 _cleanup_all_media 方法。"""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_all_calls_pending_and_categories(
+        self, mock_media_manager: MediaManager
+    ) -> None:
+        """测试 _cleanup_all_media 调用 pending 和分类目录清理。"""
+        # 使用 AsyncMock 避免协程复用问题
+        mock_pending = AsyncMock()
+        mock_category = AsyncMock()
+
+        with patch.object(
+            mock_media_manager, "_cleanup_pending_folder", mock_pending
+        ), patch.object(
+            mock_media_manager, "_cleanup_category_folder", mock_category
+        ):
+            await mock_media_manager._cleanup_all_media()
+
+            mock_pending.assert_called_once()
+            # 当 enabled=True 时应调用分类清理 2 次（images + emojis）
+            assert mock_category.call_count == 2
+
+    @pytest.mark.asyncio
+    async def test_cleanup_all_disabled_skips_categories(
+        self, mock_media_manager: MediaManager
+    ) -> None:
+        """测试 _media_cleanup_enabled=False 时跳过分类清理但保留 pending 清理。"""
+        mock_media_manager._media_cleanup_enabled = False
+
+        mock_pending = AsyncMock()
+        mock_category = AsyncMock()
+
+        with patch.object(
+            mock_media_manager, "_cleanup_pending_folder", mock_pending
+        ), patch.object(
+            mock_media_manager, "_cleanup_category_folder", mock_category
+        ):
+            await mock_media_manager._cleanup_all_media()
+
+            mock_pending.assert_called_once()
+            # 当 enabled=False 时不应调用分类清理
+            mock_category.assert_not_called()
+
+
+class TestSafeDeleteMedia:
+    """测试 _safe_delete_media 静态方法。"""
+
+    def test_safe_delete_success(self, tmp_path: Path) -> None:
+        """测试成功删除文件返回 1。"""
+        file_path = tmp_path / "test.png"
+        file_path.write_bytes(b"content")
+
+        result = MediaManager._safe_delete_media(file_path)
+
+        assert result == 1
+        assert not file_path.exists()
+
+    def test_safe_delete_failure(self, tmp_path: Path) -> None:
+        """测试删除失败返回 0。"""
+        file_path = tmp_path / "nonexistent.png"
+
+        result = MediaManager._safe_delete_media(file_path)
+
+        assert result == 0

--- a/test/kernel/test_logger_cleanup.py
+++ b/test/kernel/test_logger_cleanup.py
@@ -1,0 +1,330 @@
+"""LoggerCleanupManager 单元测试。
+
+测试日志文件自动清理管理器的核心清理逻辑，包括：
+- 按天数删除过期文件
+- 按文件数裁剪超额文件
+- 不删除非 .log 文件
+- 禁用时不执行清理
+- 空目录不报错
+"""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import pytest
+
+from src.kernel.logger.cleanup import LoggerCleanupManager
+
+
+@pytest.fixture
+def log_dir(tmp_path: Path) -> Path:
+    """创建临时日志目录的 fixture。"""
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    return log_dir
+
+
+def _create_log_file(log_dir: Path, name: str, age_seconds: float, content: str = "test") -> Path:
+    """创建一个具有指定年龄的日志文件。
+
+    Args:
+        log_dir: 日志目录
+        name: 文件名
+        age_seconds: 文件年龄（秒），通过修改 mtime 实现
+        content: 文件内容
+
+    Returns:
+        创建的文件路径
+    """
+    file_path = log_dir / name
+    file_path.write_text(content)
+    # 修改文件修改时间
+    mtime = time.time() - age_seconds
+    import os
+
+    os.utime(file_path, (mtime, mtime))
+    return file_path
+
+
+class TestLoggerCleanupManagerInit:
+    """测试 LoggerCleanupManager 初始化。"""
+
+    def test_init_with_defaults(self) -> None:
+        """测试默认参数初始化。"""
+        manager = LoggerCleanupManager(log_dir="logs")
+        assert manager.log_dir == Path("logs")
+        assert manager.max_age_days == 30
+        assert manager.max_files == 100
+        assert manager.cleanup_interval_hours == 6.0
+        assert manager.enabled is True
+        assert manager._cleanup_task_id is None
+
+    def test_init_with_custom_params(self) -> None:
+        """测试自定义参数初始化。"""
+        manager = LoggerCleanupManager(
+            log_dir="/tmp/test_logs",
+            max_age_days=7,
+            max_files=50,
+            cleanup_interval_hours=2.0,
+            enabled=False,
+        )
+        assert manager.log_dir == Path("/tmp/test_logs")
+        assert manager.max_age_days == 7
+        assert manager.max_files == 50
+        assert manager.cleanup_interval_hours == 2.0
+        assert manager.enabled is False
+
+
+class TestLoggerCleanupManagerCleanup:
+    """测试 LoggerCleanupManager 清理逻辑。"""
+
+    @pytest.mark.asyncio
+    async def test_cleanup_by_age(self, log_dir: Path) -> None:
+        """测试按天数删除过期文件。"""
+        # 创建过期文件（10天前）
+        old_file1 = _create_log_file(log_dir, "old1.log", age_seconds=10 * 86400)
+        old_file2 = _create_log_file(log_dir, "old2.log", age_seconds=15 * 86400)
+        # 创建新文件（1天前）
+        new_file = _create_log_file(log_dir, "new.log", age_seconds=1 * 86400)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=7,
+            max_files=0,  # 禁用文件数清理
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        assert not old_file1.exists()
+        assert not old_file2.exists()
+        assert new_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_by_file_count(self, log_dir: Path) -> None:
+        """测试按文件数裁剪超额文件。"""
+        # 创建 5 个文件，age_seconds 递增（i=0 最新，i=4 最旧）
+        files = []
+        for i in range(5):
+            f = _create_log_file(log_dir, f"file_{i}.log", age_seconds=i * 3600)
+            files.append(f)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=0,  # 禁用天数清理
+            max_files=3,
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        # 最旧的 2 个（age 最大的）应该被删除
+        assert not files[4].exists()
+        assert not files[3].exists()
+        # 最新的 3 个应该保留
+        assert files[0].exists()
+        assert files[1].exists()
+        assert files[2].exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_keeps_non_log_files(self, log_dir: Path) -> None:
+        """测试清理时不删除非 .log 文件。"""
+        old_log = _create_log_file(log_dir, "old.log", age_seconds=30 * 86400)
+        old_txt = _create_log_file(log_dir, "old.txt", age_seconds=30 * 86400)
+        old_json = _create_log_file(log_dir, "data.json", age_seconds=30 * 86400)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=7,
+            max_files=0,
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        assert not old_log.exists()
+        assert old_txt.exists()
+        assert old_json.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_disabled_no_deletion(self, log_dir: Path) -> None:
+        """测试 enabled=False 时 start 不注册任务，但 _cleanup 仍可手动调用。"""
+        old_file = _create_log_file(log_dir, "old.log", age_seconds=30 * 86400)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=7,
+            max_files=0,
+            enabled=False,
+        )
+
+        # enabled=False 只影响 start()，_cleanup 仍可执行
+        await manager._cleanup()
+        assert not old_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_empty_dir(self, log_dir: Path) -> None:
+        """测试空目录不报错。"""
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=7,
+            max_files=10,
+            enabled=True,
+        )
+
+        await manager._cleanup()
+        # 不报错即通过
+
+    @pytest.mark.asyncio
+    async def test_cleanup_nonexistent_dir(self, tmp_path: Path) -> None:
+        """测试不存在的目录不报错。"""
+        manager = LoggerCleanupManager(
+            log_dir=tmp_path / "nonexistent",
+            max_age_days=7,
+            max_files=10,
+            enabled=True,
+        )
+
+        await manager._cleanup()
+        # 不报错即通过
+
+    @pytest.mark.asyncio
+    async def test_cleanup_max_age_zero_no_age_deletion(self, log_dir: Path) -> None:
+        """测试 max_age_days=0 时不按天数清理。"""
+        old_file = _create_log_file(log_dir, "old.log", age_seconds=365 * 86400)
+        new_file = _create_log_file(log_dir, "new.log", age_seconds=10)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=0,  # 不按时间清理
+            max_files=0,  # 不按文件数清理
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        assert old_file.exists()
+        assert new_file.exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_max_files_zero_no_count_deletion(self, log_dir: Path) -> None:
+        """测试 max_files=0 时不按文件数清理。"""
+        for i in range(20):
+            _create_log_file(log_dir, f"file_{i}.log", age_seconds=i * 100)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=0,  # 不按时间清理
+            max_files=0,  # 不限制文件数
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        # 所有文件都应保留
+        log_files = list(log_dir.glob("*.log"))
+        assert len(log_files) == 20
+
+    @pytest.mark.asyncio
+    async def test_cleanup_combined_age_and_count(self, log_dir: Path) -> None:
+        """测试同时按天数和文件数清理。"""
+        # 创建 5 个过期文件（10天前，age 递增确保 mtime 不同）
+        old_files = []
+        for i in range(5):
+            f = _create_log_file(log_dir, f"old_{i}.log", age_seconds=10 * 86400 + i * 3600)
+            old_files.append(f)
+
+        # 创建 3 个新文件（1天内，i=0 最新，i=2 最旧）
+        new_files = []
+        for i in range(3):
+            f = _create_log_file(log_dir, f"new_{i}.log", age_seconds=i * 3600)
+            new_files.append(f)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=7,
+            max_files=2,  # 最多保留 2 个
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        # 所有旧文件应被删除（按天数）
+        for f in old_files:
+            assert not f.exists()
+
+        # 新文件按 mtime 排序（旧->新）：new_files[2](2h), new_files[1](1h), new_files[0](0h)
+        # 保留 2 个最新的，删除最旧的 new_files[2]
+        assert not new_files[2].exists()
+        assert new_files[1].exists()
+        assert new_files[0].exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_latest_file_preserved(self, log_dir: Path) -> None:
+        """测试当前最新文件不会被删除。"""
+        # 创建文件，最新的最后创建
+        files = []
+        for i in range(5):
+            f = _create_log_file(log_dir, f"file_{i}.log", age_seconds=(4 - i) * 86400)
+            files.append(f)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=2,
+            max_files=1,  # 只保留 1 个
+            enabled=True,
+        )
+
+        await manager._cleanup()
+
+        # 最新文件应该保留
+        assert files[4].exists()
+
+    @pytest.mark.asyncio
+    async def test_cleanup_delete_failure_logged(self, log_dir: Path) -> None:
+        """测试删除失败时记录警告但不中断。"""
+        old_file = _create_log_file(log_dir, "old.log", age_seconds=30 * 86400)
+
+        manager = LoggerCleanupManager(
+            log_dir=log_dir,
+            max_age_days=7,
+            max_files=0,
+            enabled=True,
+        )
+
+        # 使用 monkeypatch 模拟 unlink 失败
+        original_unlink = Path.unlink
+
+        def failing_unlink(self: Path, *args: object, **kwargs: object) -> None:
+            raise PermissionError("Permission denied")
+
+        Path.unlink = failing_unlink  # type: ignore[method-assign]
+        try:
+            await manager._cleanup()
+            # 不抛出异常即通过
+        finally:
+            Path.unlink = original_unlink  # type: ignore[method-assign]
+
+
+class TestLoggerCleanupManagerSafeDelete:
+    """测试 _safe_delete 静态方法。"""
+
+    def test_safe_delete_success(self, tmp_path: Path) -> None:
+        """测试成功删除文件返回 1。"""
+        file_path = tmp_path / "test.log"
+        file_path.write_text("content")
+
+        result = LoggerCleanupManager._safe_delete(file_path)
+
+        assert result == 1
+        assert not file_path.exists()
+
+    def test_safe_delete_failure(self, tmp_path: Path) -> None:
+        """测试删除失败返回 0。"""
+        file_path = tmp_path / "nonexistent.log"
+
+        result = LoggerCleanupManager._safe_delete(file_path)
+
+        assert result == 0


### PR DESCRIPTION
## Summary by Sourcery

Add configurable automatic cleanup for media cache and log files using the unified scheduler.

New Features:
- Introduce configurable media cache cleanup for recognized images and emojis based on file age, total size, and cleanup interval.
- Add a logger cleanup manager to periodically delete old log files by age and file count, controlled via new bot configuration options.

Enhancements:
- Load media cache cleanup parameters from core chat configuration instead of hardcoding, and schedule a unified cleanup task for pending and categorized media.
- Integrate log cleanup lifecycle with bot startup and shutdown, ensuring cleanup tasks are registered and removed safely.

Tests:
- Add unit tests for media cache cleanup behavior, covering age-based deletion, size-based pruning, configuration flags, and failure handling.
- Add unit tests for log cleanup manager behavior, covering age and count-based deletion, non-log file preservation, configuration flags, and safe deletion.