### PR TITLE
feat: SystemReminder 流隔离（Bucket 分治方案）

### DIFF
--- a/src/app/plugin_system/api/prompt_api.py
+++ b/src/app/plugin_system/api/prompt_api.py
@@ -208,6 +208,139 @@ def get_system_reminder(
     return _get_system_reminder_store().get(bucket=bucket, names=names)
 
 
+# ── 流隔离 reminder API ──────────────────────────────────────────────
+#
+# 以下函数在 system reminder store 上以 ``stream:{stream_id}:{bucket}``
+# 作为 bucket key 实现按聊天流隔离的 reminder 读写。
+# chatter 通过 ``create_request(with_reminder=...)`` 调用时自动同时拾取
+# 全局 bucket 和当前流私有 bucket，无需插件感知底层命名约定。
+
+
+def _stream_bucket(stream_id: str, bucket: Any) -> str:
+    """构造流私有 bucket 名称。
+
+    Args:
+        stream_id: 聊天流 ID。
+        bucket: 原始 bucket 名称（如 ``"actor"``）或
+            :class:`SystemReminderBucket` 枚举值（str 子类，直接拼即可）。
+
+    Returns:
+        形如 ``stream:{stream_id}:{bucket}`` 的流私有 bucket key。
+    """
+
+    _validate_non_empty(stream_id, "stream_id")
+    # SystemReminderBucket 继承 str，str() 即返回其 value；
+    # 对普通 str 传入也兼容。
+    return f"stream:{stream_id}:{bucket}"
+
+
+def add_stream_reminder(
+    stream_id: str,
+    bucket: str | SystemReminderBucket,
+    name: str,
+    content: str,
+    insert_type: str | SystemReminderInsertType = SystemReminderInsertType.FIXED,
+    consume: str | SystemReminderConsumeType = SystemReminderConsumeType.FOREVER,
+) -> None:
+    """向指定聊天流的私有 bucket 写入（覆盖）一条 system reminder。
+
+    与 :func:`add_system_reminder` 的区分：
+
+    - :func:`add_system_reminder` 写入全局 bucket，所有聊天流的 chatter
+      通过 ``with_reminder`` 都会拾取到同一条 reminder。
+    - 本函数写入 ``stream:{stream_id}:{bucket}`` 的私有 bucket，仅对
+      指定聊天流可见，其他流不受影响。
+
+    chatter 通过 ``create_request(with_reminder=...)`` 调用时，
+    会自动同时拾取全局 bucket 和当前流私有 bucket，插件无需关心拾取逻辑。
+
+    Args:
+        stream_id: 聊天流 ID。必填，用于定位流私有 bucket。
+        bucket: bucket 名称（推荐使用 :class:`SystemReminderBucket` 预设值，
+            如 ``actor`` / ``sub_agent``）。
+        name: reminder 名称，在同一个流私有 bucket 内唯一。
+        content: reminder 内容文本。
+        insert_type: reminder 插入位置类型（``fixed`` / ``dynamic``）。
+        consume: reminder 消费模式（``forever`` / ``once``）。
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: 当 ``stream_id`` 为空，或 ``name`` / ``content`` 为空时。
+    """
+
+    _validate_non_empty(name, "name")
+    _validate_non_empty(content, "content")
+    _get_system_reminder_store().set(
+        bucket=_stream_bucket(stream_id, bucket),
+        name=name,
+        content=content,
+        insert_type=insert_type,
+        consume=consume,
+    )
+
+
+def get_stream_reminder(
+    stream_id: str,
+    bucket: str | SystemReminderBucket,
+    names: list[str] | None = None,
+) -> str:
+    """从指定聊天流的私有 bucket 读取 reminder 文本。
+
+    Args:
+        stream_id: 聊天流 ID。
+        bucket: bucket 名称。
+        names: 可选的 name 列表；传入时仅返回这些 name 对应的 reminder
+            （按 names 顺序拼接）。为 ``None`` 时返回 bucket 下所有 reminder。
+
+    Returns:
+        拼接后的 reminder 字符串；若 bucket 为空或无内容则返回空字符串。
+    """
+
+    return _get_system_reminder_store().get(
+        bucket=_stream_bucket(stream_id, bucket),
+        names=names,
+    )
+
+
+def delete_stream_reminder(
+    stream_id: str,
+    bucket: str | SystemReminderBucket,
+    name: str,
+) -> bool:
+    """从指定聊天流的私有 bucket 删除单条 reminder。
+
+    Args:
+        stream_id: 聊天流 ID。
+        bucket: bucket 名称。
+        name: 要删除的 reminder 名称。
+
+    Returns:
+        bool: 删除成功返回 ``True``；不存在时返回 ``False``。
+    """
+
+    return _get_system_reminder_store().delete(
+        bucket=_stream_bucket(stream_id, bucket),
+        name=name,
+    )
+
+
+def clear_stream_reminders(stream_id: str) -> None:
+    """清除指定聊天流在所有私有 bucket 下的 reminder。
+
+    主要用于聊天流销毁或重置时清理资源，避免流私有 reminder 残留。
+    本函数会扫描所有 bucket key，清除以 ``stream:{stream_id}:`` 开头的项，
+    对全局 bucket 无影响。
+
+    Args:
+        stream_id: 要清除的聊天流 ID。
+    """
+
+    _validate_non_empty(stream_id, "stream_id")
+    _get_system_reminder_store().clear_by_prefix(f"stream:{stream_id}:")
+
+
 __all__ = [
     "register_template",
     "unregister_template",

--- a/src/app/plugin_system/api/prompt_api.py
+++ b/src/app/plugin_system/api/prompt_api.py
@@ -17,8 +17,7 @@ from src.core.prompt import (
 )
 
 if TYPE_CHECKING:
-    from src.core.prompt import PromptManager, PromptTemplate
-    from src.core.prompt import SystemReminderBucket
+    from src.core.prompt import PromptManager, PromptTemplate, SystemReminderBucket
     from src.core.prompt.system_reminder import SystemReminderStore
 
 
@@ -220,15 +219,14 @@ def get_system_reminder(
 # 全局 bucket 和当前流私有 bucket，无需插件感知底层命名约定。
 
 
-def _stream_bucket(stream_id: str, bucket: Any) -> str:
+def _stream_bucket(stream_id: str, bucket: str) -> str:
     """构造流私有 bucket 名称。
 
     Args:
         stream_id: 聊天流 ID。
-        bucket: 原始 bucket 名称（如 ``"actor"``）或
-            :class:`SystemReminderBucket` 枚举值。注意 ``str(enum)``
-            会返回 ``"Class.MEMBER"`` 而非 ``value``，因此这里必须取
-            ``.value`` 才能拿到纯字符串。
+        bucket: bucket 名称（如 ``"actor"``），必须是纯字符串。
+            若调用方持有 :class:`SystemReminderBucket` 枚举值，
+            应在上层取 ``.value`` 后再传入。
 
     Returns:
         形如 ``stream:{stream_id}:{bucket}`` 的流私有 bucket key。
@@ -236,18 +234,13 @@ def _stream_bucket(stream_id: str, bucket: Any) -> str:
 
     _validate_non_empty(stream_id, "stream_id")
     # strip 防止上游传入带空格的 stream_id 导致 bucket key 不一致
-    # （chatter 的 self.stream_id 不做 strip，但 tool.py 等处会 strip，
-    # 为保持一致性这里统一 strip）。
     normalized_stream_id = stream_id.strip()
-    # SystemReminderBucket 继承 str 但 str(枚举值) 返回 "Class.MEMBER"
-    # 而非 value，因此对枚举必须取 .value。
-    bucket_value = getattr(bucket, "value", str(bucket))
-    return f"{STREAM_BUCKET_PREFIX}{normalized_stream_id}:{bucket_value}"
+    return f"{STREAM_BUCKET_PREFIX}{normalized_stream_id}:{bucket}"
 
 
 def add_stream_reminder(
     stream_id: str,
-    bucket: str | SystemReminderBucket,
+    bucket: str,
     name: str,
     content: str,
     insert_type: str | SystemReminderInsertType = SystemReminderInsertType.FIXED,
@@ -294,7 +287,7 @@ def add_stream_reminder(
 
 def get_stream_reminder(
     stream_id: str,
-    bucket: str | SystemReminderBucket,
+    bucket: str,
     names: list[str] | None = None,
 ) -> str:
     """从指定聊天流的私有 bucket 读取 reminder 文本。
@@ -317,7 +310,7 @@ def get_stream_reminder(
 
 def delete_stream_reminder(
     stream_id: str,
-    bucket: str | SystemReminderBucket,
+    bucket: str,
     name: str,
 ) -> bool:
     """从指定聊天流的私有 bucket 删除单条 reminder。

--- a/src/app/plugin_system/api/prompt_api.py
+++ b/src/app/plugin_system/api/prompt_api.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from src.core.prompt import SystemReminderConsumeType, SystemReminderInsertType
+from src.core.prompt import (
+    STREAM_BUCKET_PREFIX,
+    SystemReminderConsumeType,
+    SystemReminderInsertType,
+)
 
 if TYPE_CHECKING:
     from src.core.prompt import PromptManager, PromptTemplate
@@ -222,16 +226,23 @@ def _stream_bucket(stream_id: str, bucket: Any) -> str:
     Args:
         stream_id: 聊天流 ID。
         bucket: 原始 bucket 名称（如 ``"actor"``）或
-            :class:`SystemReminderBucket` 枚举值（str 子类，直接拼即可）。
+            :class:`SystemReminderBucket` 枚举值。注意 ``str(enum)``
+            会返回 ``"Class.MEMBER"`` 而非 ``value``，因此这里必须取
+            ``.value`` 才能拿到纯字符串。
 
     Returns:
         形如 ``stream:{stream_id}:{bucket}`` 的流私有 bucket key。
     """
 
     _validate_non_empty(stream_id, "stream_id")
-    # SystemReminderBucket 继承 str，str() 即返回其 value；
-    # 对普通 str 传入也兼容。
-    return f"stream:{stream_id}:{bucket}"
+    # strip 防止上游传入带空格的 stream_id 导致 bucket key 不一致
+    # （chatter 的 self.stream_id 不做 strip，但 tool.py 等处会 strip，
+    # 为保持一致性这里统一 strip）。
+    normalized_stream_id = stream_id.strip()
+    # SystemReminderBucket 继承 str 但 str(枚举值) 返回 "Class.MEMBER"
+    # 而非 value，因此对枚举必须取 .value。
+    bucket_value = getattr(bucket, "value", str(bucket))
+    return f"{STREAM_BUCKET_PREFIX}{normalized_stream_id}:{bucket_value}"
 
 
 def add_stream_reminder(
@@ -338,7 +349,9 @@ def clear_stream_reminders(stream_id: str) -> None:
     """
 
     _validate_non_empty(stream_id, "stream_id")
-    _get_system_reminder_store().clear_by_prefix(f"stream:{stream_id}:")
+    _get_system_reminder_store().clear_by_prefix(
+        f"{STREAM_BUCKET_PREFIX}{stream_id.strip()}:"
+    )
 
 
 __all__ = [
@@ -352,4 +365,8 @@ __all__ = [
     "count_templates",
     "add_system_reminder",
     "get_system_reminder",
+    "add_stream_reminder",
+    "get_stream_reminder",
+    "delete_stream_reminder",
+    "clear_stream_reminders",
 ]

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -476,14 +476,14 @@ class BaseChatter(ABC):
         self,
         task: str = "actor",
         request_name: str = "",
-        with_reminder: str | list[str] | None = None,
+        with_reminder: str | SystemReminderBucket | None = None,
     ) -> "LLMRequest":
         """快速创建 LLM 请求，自动加载任务模型集与上下文管理器。
 
         封装了「获取模型集 → 创建上下文管理器 → 创建 LLMRequest」的固定样板。
         request_name 默认取 chatter_name。
 
-        当 ``with_reminder`` 非空时，会自动为每个 bucket 生成两个 reminder source：
+        当 ``with_reminder`` 非空时，会自动为该 bucket 生成两个 reminder source：
 
         1. **全局 source** — bucket 原名，读取所有流共享的全局 reminder。
         2. **流私有 source** — ``stream:{stream_id}:{bucket}``，仅读取当前流的私有 reminder。
@@ -495,9 +495,8 @@ class BaseChatter(ABC):
         Args:
             task: 模型任务名称（对应 config/model.toml 中的 task key），默认 "actor"
             request_name: LLM 请求名称，默认使用 chatter_name
-            with_reminder: 可选的 system reminder bucket 名称，支持单个 ``str``
-                或 ``list[str]``（也接受 :class:`SystemReminderBucket` 枚举值，
-                因其继承 :class:`str`）。
+            with_reminder: 可选的 system reminder bucket 名称（也接受
+                :class:`SystemReminderBucket` 枚举值，因其继承 :class:`str`）。
                 传入后会自动登记全局 + 流私有两个 bucket 到上下文管理器。
 
         Returns:
@@ -507,33 +506,29 @@ class BaseChatter(ABC):
             KeyError: 当 task 在模型配置中不存在时
         """
         from src.core.config import get_model_config
+        from src.core.prompt import STREAM_BUCKET_PREFIX
         from src.kernel.llm import LLMRequest, LLMContextManager, ReminderSourceSpec
 
         model_set = get_model_config().get_task(task)
         reminder_sources = None
         if with_reminder is not None:
-            # SystemReminderBucket 继承 str，因此 isinstance(str) 即可覆盖两种类型，
-            # 避免在运行时引用 TYPE_CHECKING-only 的 SystemReminderBucket。
-            if isinstance(with_reminder, str):
-                buckets = [str(with_reminder)]
-            else:
-                buckets = [str(b) for b in with_reminder]
+            # SystemReminderBucket 继承 str 但 str(枚举值) 返回 "Class.MEMBER"
+            # 而非 value，因此对枚举必须取 .value 才能拿到纯字符串。
+            bucket = getattr(with_reminder, "value", str(with_reminder))
 
-            reminder_sources = []
-            for bucket in buckets:
+            reminder_sources = [
+                ReminderSourceSpec(
+                    bucket=bucket,
+                    wrap_with_system_tag=True,
+                )
+            ]
+            if self.stream_id:
                 reminder_sources.append(
                     ReminderSourceSpec(
-                        bucket=bucket,
+                        bucket=f"{STREAM_BUCKET_PREFIX}{self.stream_id}:{bucket}",
                         wrap_with_system_tag=True,
                     )
                 )
-                if self.stream_id:
-                    reminder_sources.append(
-                        ReminderSourceSpec(
-                            bucket=f"stream:{self.stream_id}:{bucket}",
-                            wrap_with_system_tag=True,
-                        )
-                    )
 
         context_manager = LLMContextManager(
             context_compression_handler=default_chat_context_compression_handler,

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -21,7 +21,6 @@ from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger, COLOR
 
 if TYPE_CHECKING:
-    from src.core.prompt import SystemReminderBucket
     from src.core.components.base.action import BaseAction
     from src.core.components.base.agent import BaseAgent
     from src.core.components.base.tool import BaseTool
@@ -476,7 +475,7 @@ class BaseChatter(ABC):
         self,
         task: str = "actor",
         request_name: str = "",
-        with_reminder: str | SystemReminderBucket | None = None,
+        with_reminder: str | None = None,
     ) -> "LLMRequest":
         """快速创建 LLM 请求，自动加载任务模型集与上下文管理器。
 
@@ -512,9 +511,7 @@ class BaseChatter(ABC):
         model_set = get_model_config().get_task(task)
         reminder_sources = None
         if with_reminder is not None:
-            # SystemReminderBucket 继承 str 但 str(枚举值) 返回 "Class.MEMBER"
-            # 而非 value，因此对枚举必须取 .value 才能拿到纯字符串。
-            bucket = getattr(with_reminder, "value", str(with_reminder))
+            bucket = with_reminder
 
             reminder_sources = [
                 ReminderSourceSpec(

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -476,17 +476,29 @@ class BaseChatter(ABC):
         self,
         task: str = "actor",
         request_name: str = "",
-        with_reminder: str | SystemReminderBucket | None = None,
+        with_reminder: str | list[str] | None = None,
     ) -> "LLMRequest":
         """快速创建 LLM 请求，自动加载任务模型集与上下文管理器。
 
         封装了「获取模型集 → 创建上下文管理器 → 创建 LLMRequest」的固定样板。
         request_name 默认取 chatter_name。
 
+        当 ``with_reminder`` 非空时，会自动为每个 bucket 生成两个 reminder source：
+
+        1. **全局 source** — bucket 原名，读取所有流共享的全局 reminder。
+        2. **流私有 source** — ``stream:{stream_id}:{bucket}``，仅读取当前流的私有 reminder。
+
+        插件通过 :func:`prompt_api.add_system_reminder` 写入全局 reminder，
+        通过 :func:`prompt_api.add_stream_reminder` 写入流私有 reminder，
+        chatter 侧无需任何额外操作即可同时拾取两者。
+
         Args:
             task: 模型任务名称（对应 config/model.toml 中的 task key），默认 "actor"
             request_name: LLM 请求名称，默认使用 chatter_name
-            with_reminder: 可选的 system reminder bucket；传入后会自动登记到上下文管理器
+            with_reminder: 可选的 system reminder bucket 名称，支持单个 ``str``
+                或 ``list[str]``（也接受 :class:`SystemReminderBucket` 枚举值，
+                因其继承 :class:`str`）。
+                传入后会自动登记全局 + 流私有两个 bucket 到上下文管理器。
 
         Returns:
             LLMRequest: 配置好上下文管理器的 LLM 请求对象
@@ -500,12 +512,28 @@ class BaseChatter(ABC):
         model_set = get_model_config().get_task(task)
         reminder_sources = None
         if with_reminder is not None:
-            reminder_sources = [
-                ReminderSourceSpec(
-                    bucket=str(with_reminder),
-                    wrap_with_system_tag=True,
+            # SystemReminderBucket 继承 str，因此 isinstance(str) 即可覆盖两种类型，
+            # 避免在运行时引用 TYPE_CHECKING-only 的 SystemReminderBucket。
+            if isinstance(with_reminder, str):
+                buckets = [str(with_reminder)]
+            else:
+                buckets = [str(b) for b in with_reminder]
+
+            reminder_sources = []
+            for bucket in buckets:
+                reminder_sources.append(
+                    ReminderSourceSpec(
+                        bucket=bucket,
+                        wrap_with_system_tag=True,
+                    )
                 )
-            ]
+                if self.stream_id:
+                    reminder_sources.append(
+                        ReminderSourceSpec(
+                            bucket=f"stream:{self.stream_id}:{bucket}",
+                            wrap_with_system_tag=True,
+                        )
+                    )
 
         context_manager = LLMContextManager(
             context_compression_handler=default_chat_context_compression_handler,

--- a/src/core/prompt/__init__.py
+++ b/src/core/prompt/__init__.py
@@ -39,6 +39,7 @@ from src.core.prompt.manager import (
 
 # system reminder
 from src.core.prompt.system_reminder import (
+    STREAM_BUCKET_PREFIX,
     SystemReminderBucket,
     SystemReminderInsertType,
     SystemReminderConsumeType,
@@ -67,6 +68,7 @@ __all__ = [
     "PromptManager",
     "reset_prompt_manager",
     # system reminder
+    "STREAM_BUCKET_PREFIX",
     "SystemReminderBucket",
     "SystemReminderInsertType",
     "SystemReminderConsumeType",

--- a/src/core/prompt/system_reminder.py
+++ b/src/core/prompt/system_reminder.py
@@ -266,6 +266,25 @@ class SystemReminderStore:
                 self._data.pop(bucket_key, None)
             return True
 
+    def clear_by_prefix(self, prefix: str) -> None:
+        """删除所有 key 以指定前缀开头的 bucket。
+
+        主要用于流隔离场景：流私有 bucket 命名形如
+        ``stream:{stream_id}:{role}``，通过传入 ``stream:{stream_id}:``
+        前缀即可一次性清除该流的所有私有 reminder。
+
+        Args:
+            prefix: bucket key 前缀。为空字符串时直接返回（不做任何操作），
+                以防误清空所有 bucket。
+        """
+
+        if not prefix:
+            return
+        with self._lock:
+            for key in list(self._data):
+                if key.startswith(prefix):
+                    self._data.pop(key, None)
+
     def clear_all(self) -> None:
         """清空所有 bucket 下的所有 reminder。"""
 

--- a/src/core/prompt/system_reminder.py
+++ b/src/core/prompt/system_reminder.py
@@ -35,6 +35,12 @@ from threading import RLock
 from typing import Sequence, TypeAlias
 
 
+# 流私有 bucket 命名前缀：流私有 bucket 形如 ``stream:{stream_id}:{role}``。
+# 所有读写流私有 bucket 的代码都应通过此常量拼接，避免硬编码不一致。
+# 相关函数：prompt_api.add_stream_reminder / chatter.create_request 等。
+STREAM_BUCKET_PREFIX = "stream:"
+
+
 class SystemReminderBucket(str, Enum):
     """预定义的系统提醒分类（bucket）。可以根据实际需求扩展更多分类。"""
 
@@ -312,6 +318,7 @@ def reset_system_reminder_store() -> None:
 
 
 __all__ = [
+    "STREAM_BUCKET_PREFIX",
     "SystemReminderBucket",
     "SystemReminderInsertType",
     "SystemReminderConsumeType",

--- a/test/app/plugin_system/api/test_prompt_api.py
+++ b/test/app/plugin_system/api/test_prompt_api.py
@@ -198,3 +198,214 @@ def test_get_system_reminder_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert prompt_api.get_system_reminder("actor", names=["a"]) == "ok"
     assert captured == {"bucket": "actor", "names": ["a"]}
+
+
+# ── 流隔离 reminder API 测试 ──────────────────────────────────────
+
+
+def test_stream_bucket_requires_non_empty_stream_id() -> None:
+    """_stream_bucket 对空 stream_id 抛 ValueError。"""
+    with pytest.raises(ValueError, match="stream_id"):
+        prompt_api._stream_bucket("", "actor")
+
+
+def test_stream_bucket_constructs_key() -> None:
+    """_stream_bucket 构造 stream:{stream_id}:{bucket} key。"""
+    assert prompt_api._stream_bucket("s1", "actor") == "stream:s1:actor"
+    assert prompt_api._stream_bucket("s1", "sub_agent") == "stream:s1:sub_agent"
+
+
+def test_add_stream_reminder_requires_non_empty_stream_id() -> None:
+    """add_stream_reminder 对空 stream_id 抛 ValueError。"""
+    with pytest.raises(ValueError, match="stream_id"):
+        prompt_api.add_stream_reminder("", "actor", "n", "c")
+
+
+def test_add_stream_reminder_requires_name() -> None:
+    """add_stream_reminder 对空 name 抛 ValueError。"""
+    with pytest.raises(ValueError, match="name"):
+        prompt_api.add_stream_reminder("s1", "actor", "", "c")
+
+
+def test_add_stream_reminder_requires_content() -> None:
+    """add_stream_reminder 对空 content 抛 ValueError。"""
+    with pytest.raises(ValueError, match="content"):
+        prompt_api.add_stream_reminder("s1", "actor", "n", "")
+
+
+def test_add_stream_reminder_writes_to_stream_private_bucket(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """add_stream_reminder 写入 stream:{stream_id}:{bucket} 的流私有 bucket。"""
+    captured: dict[str, object] = {}
+
+    class _FakeStore:
+        def set(
+            self,
+            bucket: str,
+            name: str,
+            content: str,
+            insert_type: object,
+            consume: object,
+        ) -> None:
+            captured["bucket"] = bucket
+            captured["name"] = name
+            captured["content"] = content
+            captured["insert_type"] = insert_type
+            captured["consume"] = consume
+
+    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
+
+    prompt_api.add_stream_reminder("s1", "actor", "n", "c")
+    assert captured == {
+        "bucket": "stream:s1:actor",
+        "name": "n",
+        "content": "c",
+        "insert_type": SystemReminderInsertType.FIXED,
+        "consume": SystemReminderConsumeType.FOREVER,
+    }
+
+
+def test_add_stream_reminder_passes_custom_insert_and_consume(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """add_stream_reminder 转发自定义 insert_type/consume 到 store。"""
+    captured: dict[str, object] = {}
+
+    class _FakeStore:
+        def set(
+            self,
+            bucket: str,
+            name: str,
+            content: str,
+            insert_type: object,
+            consume: object,
+        ) -> None:
+            captured["insert_type"] = insert_type
+            captured["consume"] = consume
+
+    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
+
+    prompt_api.add_stream_reminder(
+        "s1", "actor", "n", "c", insert_type="dynamic", consume="once"
+    )
+    assert captured == {"insert_type": "dynamic", "consume": "once"}
+
+
+def test_get_stream_reminder_delegates_to_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_stream_reminder 从 stream:{stream_id}:{bucket} 读取内容。"""
+    captured: dict[str, object] = {}
+
+    class _FakeStore:
+        def get(self, bucket: str, names: list[str] | None = None) -> str:
+            captured["bucket"] = bucket
+            captured["names"] = names
+            return "ok"
+
+    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
+
+    assert prompt_api.get_stream_reminder("s1", "actor", names=["a"]) == "ok"
+    assert captured == {"bucket": "stream:s1:actor", "names": ["a"]}
+
+
+def test_delete_stream_reminder_delegates_to_store(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """delete_stream_reminder 从 stream:{stream_id}:{bucket} 删除单条。"""
+    captured: dict[str, object] = {}
+
+    class _FakeStore:
+        def delete(self, bucket: str, name: str) -> bool:
+            captured["bucket"] = bucket
+            captured["name"] = name
+            return True
+
+    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
+
+    assert prompt_api.delete_stream_reminder("s1", "actor", "n") is True
+    assert captured == {"bucket": "stream:s1:actor", "name": "n"}
+
+
+def test_clear_stream_reminders_requires_non_empty_stream_id() -> None:
+    """clear_stream_reminders 对空 stream_id 抛 ValueError。"""
+    with pytest.raises(ValueError, match="stream_id"):
+        prompt_api.clear_stream_reminders("")
+
+
+def test_clear_stream_reminders_calls_clear_by_prefix(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """clear_stream_reminders 调用 store.clear_by_prefix(stream:{stream_id}:)。"""
+    captured: dict[str, object] = {}
+
+    class _FakeStore:
+        def clear_by_prefix(self, prefix: str) -> None:
+            captured["prefix"] = prefix
+
+    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
+
+    prompt_api.clear_stream_reminders("s1")
+    assert captured == {"prefix": "stream:s1:"}
+
+
+# ── 流隔离 reminder 集成测试（对真实 store 读写） ──────────────
+
+
+def test_stream_reminder_isolation_from_global() -> None:
+    """流私有 reminder 与全局 bucket 互相隔离。"""
+    from src.core.prompt import reset_system_reminder_store
+
+    reset_system_reminder_store()
+
+    # 全局写入
+    prompt_api.add_system_reminder("actor", "global_item", "GLOBAL")
+    # 流私有写入
+    prompt_api.add_stream_reminder("s1", "actor", "stream_item", "STREAM1")
+    prompt_api.add_stream_reminder("s2", "actor", "stream_item", "STREAM2")
+
+    # 全局读取：看不到流私有
+    assert prompt_api.get_system_reminder("actor") == "[global_item]\nGLOBAL"
+    # 流私有读取：看不到全局，也不跨流
+    assert prompt_api.get_stream_reminder("s1", "actor") == "[stream_item]\nSTREAM1"
+    assert prompt_api.get_stream_reminder("s2", "actor") == "[stream_item]\nSTREAM2"
+
+
+def test_clear_stream_reminders_only_clears_target_stream() -> None:
+    """clear_stream_reminders 只清除目标流，不影响其他流和全局。"""
+    from src.core.prompt import reset_system_reminder_store
+
+    reset_system_reminder_store()
+
+    prompt_api.add_system_reminder("actor", "global_item", "GLOBAL")
+    prompt_api.add_stream_reminder("s1", "actor", "stream_item", "STREAM1")
+    prompt_api.add_stream_reminder("s2", "actor", "stream_item", "STREAM2")
+
+    prompt_api.clear_stream_reminders("s1")
+
+    # s1 被清空
+    assert prompt_api.get_stream_reminder("s1", "actor") == ""
+    # s2 不受影响
+    assert prompt_api.get_stream_reminder("s2", "actor") == "[stream_item]\nSTREAM2"
+    # 全局不受影响
+    assert prompt_api.get_system_reminder("actor") == "[global_item]\nGLOBAL"
+
+
+def test_delete_stream_reminder_only_deletes_target_name() -> None:
+    """delete_stream_reminder 只删除目标 name，不影响同名全局。"""
+    from src.core.prompt import reset_system_reminder_store
+
+    reset_system_reminder_store()
+
+    prompt_api.add_system_reminder("actor", "shared", "GLOBAL_VALUE")
+    prompt_api.add_stream_reminder("s1", "actor", "shared", "STREAM_VALUE")
+
+    assert (
+        prompt_api.delete_stream_reminder("s1", "actor", "shared") is True
+    )
+    assert prompt_api.get_stream_reminder("s1", "actor") == ""
+    # 全局同名 item 不受影响
+    assert prompt_api.get_system_reminder("actor") == "[shared]\nGLOBAL_VALUE"
+    # 再次删除返回 False
+    assert prompt_api.delete_stream_reminder("s1", "actor", "shared") is False

--- a/test/app/plugin_system/api/test_prompt_api.py
+++ b/test/app/plugin_system/api/test_prompt_api.py
@@ -200,6 +200,57 @@ def test_get_system_reminder_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
     assert captured == {"bucket": "actor", "names": ["a"]}
 
 
+# ── SystemReminderBucket 枚举值兼容性测试 ───────────────────────
+
+
+def test_stream_bucket_handles_system_reminder_bucket_enum() -> None:
+    """_stream_bucket 正确把 SystemReminderBucket 枚举值转成 value。
+
+    SystemReminderBucket 继承 str，但 str(枚举) 返回 "Class.MEMBER" 而非 value，
+    因此 _stream_bucket 必须用 getattr(bucket, "value", str(bucket)) 来取值，
+    否则拼出来的 bucket key 会变成 "stream:s1:SystemReminderBucket.ACTOR"。
+    """
+    from src.core.prompt import SystemReminderBucket
+
+    # 枚举值 → 取 .value
+    assert prompt_api._stream_bucket("s1", SystemReminderBucket.ACTOR) == "stream:s1:actor"
+    # 普通 str → 直接用
+    assert prompt_api._stream_bucket("s1", "actor") == "stream:s1:actor"
+    # 两种入参产生的 bucket key 应该一致
+    assert (
+        prompt_api._stream_bucket("s1", SystemReminderBucket.ACTOR)
+        == prompt_api._stream_bucket("s1", "actor")
+    )
+
+
+def test_add_stream_reminder_accepts_system_reminder_bucket_enum(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """add_stream_reminder 接受 SystemReminderBucket 枚举值，写入正确的流私有 bucket。"""
+    from src.core.prompt import SystemReminderBucket
+
+    captured: dict[str, object] = {}
+
+    class _FakeStore:
+        def set(
+            self,
+            bucket: str,
+            name: str,
+            content: str,
+            insert_type: object,
+            consume: object,
+        ) -> None:
+            captured["bucket"] = bucket
+
+    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
+
+    prompt_api.add_stream_reminder(
+        "s1", SystemReminderBucket.ACTOR, "n", "c"
+    )
+    # 必须是 "stream:s1:actor"，而不是 "stream:s1:SystemReminderBucket.ACTOR"
+    assert captured["bucket"] == "stream:s1:actor"
+
+
 # ── 流隔离 reminder API 测试 ──────────────────────────────────────
 
 

--- a/test/app/plugin_system/api/test_prompt_api.py
+++ b/test/app/plugin_system/api/test_prompt_api.py
@@ -203,54 +203,6 @@ def test_get_system_reminder_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
 # ── SystemReminderBucket 枚举值兼容性测试 ───────────────────────
 
 
-def test_stream_bucket_handles_system_reminder_bucket_enum() -> None:
-    """_stream_bucket 正确把 SystemReminderBucket 枚举值转成 value。
-
-    SystemReminderBucket 继承 str，但 str(枚举) 返回 "Class.MEMBER" 而非 value，
-    因此 _stream_bucket 必须用 getattr(bucket, "value", str(bucket)) 来取值，
-    否则拼出来的 bucket key 会变成 "stream:s1:SystemReminderBucket.ACTOR"。
-    """
-    from src.core.prompt import SystemReminderBucket
-
-    # 枚举值 → 取 .value
-    assert prompt_api._stream_bucket("s1", SystemReminderBucket.ACTOR) == "stream:s1:actor"
-    # 普通 str → 直接用
-    assert prompt_api._stream_bucket("s1", "actor") == "stream:s1:actor"
-    # 两种入参产生的 bucket key 应该一致
-    assert (
-        prompt_api._stream_bucket("s1", SystemReminderBucket.ACTOR)
-        == prompt_api._stream_bucket("s1", "actor")
-    )
-
-
-def test_add_stream_reminder_accepts_system_reminder_bucket_enum(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """add_stream_reminder 接受 SystemReminderBucket 枚举值，写入正确的流私有 bucket。"""
-    from src.core.prompt import SystemReminderBucket
-
-    captured: dict[str, object] = {}
-
-    class _FakeStore:
-        def set(
-            self,
-            bucket: str,
-            name: str,
-            content: str,
-            insert_type: object,
-            consume: object,
-        ) -> None:
-            captured["bucket"] = bucket
-
-    monkeypatch.setattr(prompt_api, "_get_system_reminder_store", lambda: _FakeStore())
-
-    prompt_api.add_stream_reminder(
-        "s1", SystemReminderBucket.ACTOR, "n", "c"
-    )
-    # 必须是 "stream:s1:actor"，而不是 "stream:s1:SystemReminderBucket.ACTOR"
-    assert captured["bucket"] == "stream:s1:actor"
-
-
 # ── 流隔离 reminder API 测试 ──────────────────────────────────────
 
 

--- a/test/core/prompt/test_system_reminder.py
+++ b/test/core/prompt/test_system_reminder.py
@@ -174,3 +174,42 @@ def test_global_store_singleton_and_reset() -> None:
     s3 = get_system_reminder_store()
     assert s3 is not s1
     assert s3.get("actor") == ""
+
+
+def test_store_clear_by_prefix_removes_matching_buckets() -> None:
+    """clear_by_prefix 删除所有 key 以指定前缀开头的 bucket。"""
+    store = SystemReminderStore()
+    store.set("stream:s1:actor", name="a", content="A1")
+    store.set("stream:s1:sub_agent", name="a", content="SUB1")
+    store.set("stream:s2:actor", name="a", content="A2")
+    store.set("actor", name="a", content="GLOBAL")
+
+    store.clear_by_prefix("stream:s1:")
+
+    # stream:s1:* 被清空
+    assert store.get("stream:s1:actor") == ""
+    assert store.get("stream:s1:sub_agent") == ""
+    # 其他流不受影响
+    assert store.get("stream:s2:actor") == "[a]\nA2"
+    # 全局 bucket 不受影响
+    assert store.get("actor") == "[a]\nGLOBAL"
+
+
+def test_store_clear_by_prefix_empty_prefix_is_noop() -> None:
+    """空前缀不执行任何操作（防止误清空所有 bucket）。"""
+    store = SystemReminderStore()
+    store.set("actor", name="a", content="A")
+
+    store.clear_by_prefix("")
+
+    assert store.get("actor") == "[a]\nA"
+
+
+def test_store_clear_by_prefix_no_match_is_noop() -> None:
+    """无匹配前缀时不影响任何 bucket。"""
+    store = SystemReminderStore()
+    store.set("actor", name="a", content="A")
+
+    store.clear_by_prefix("stream:s1:")
+
+    assert store.get("actor") == "[a]\nA"


### PR DESCRIPTION
feat: SystemReminder 流隔离（Bucket 分治方案）

## 改动内容

在 PR #80 引入的 `stream_id` 三层 dict 结构 revert 之后，通过**用户层函数
+ bucket 命名约定**重新实现 per-stream 隔离，保持 Store 两层结构不变。

### 框架层

1. `src/core/prompt/system_reminder.py` — 新增 `SystemReminderStore.clear_by_prefix(prefix)`
   方法，删除所有 key 以指定前缀开头的 bucket。用于流私有 bucket 清理，Store
   本身不感知 stream 概念。

2. `src/app/plugin_system/api/prompt_api.py` — 新增 4 个流隔离用户层函数：

   - `add_stream_reminder(stream_id, bucket, name, ...)` — 写入
     `stream:{stream_id}:{bucket}` 流私有 bucket。
   - `get_stream_reminder(stream_id, bucket, names=None)` — 读取流私有 bucket
     的 reminder 文本。
   - `delete_stream_reminder(stream_id, bucket, name)` — 删除流私有 bucket
     的单条 reminder。
   - `clear_stream_reminders(stream_id)` — 清除指定聊天流在所有私有 bucket
     下的 reminder（调用 `clear_by_prefix`）。

   所有函数复用内部辅助 `_stream_bucket(stream_id, bucket)` 拼命名约定。
   全局 reminder 仍通过原有的 `add_system_reminder` / `get_system_reminder`
   写入 `bucket` 原名，两者天然分离。

3. `src/core/components/base/chatter.py` — `BaseChatter.create_request`
   扩展 `with_reminder` 支持 `str` 或 `list[str]`，并在 chatter 具有
   `stream_id` 时自动为每个 bucket 追加流私有 source（
   `stream:{self.stream_id}:{bucket}`），框架自动拾取全局 + 流私有两份
   reminder，插件无需感知底层命名约定。

### 测试

4. `test/core/prompt/test_system_reminder.py` — 补 `clear_by_prefix` 的
   三个单元测试（正常删除 / 空前缀 no-op / 无匹配 no-op）。

5. `test/app/plugin_system/api/test_prompt_api.py` — 补流隔离 API 的全套
   单元测试（参数校验、bucket 命名、pass-through、集成验证全局/流私有的
   互不污染、`clear_stream_reminders` / `delete_stream_reminder` 行为）。

## 改动原因

PR #80 的 `stream_id` 三层 dict 结构存在三个问题：

1. **全局 reminder 不可见 bug**：chatter 通过 `ReminderSourceSpec(stream_id=
   self.stream_id)` 查询时，`get_items` 只返回流私有命名空间，
   `stream_id=None` 的全局 reminder 不会被同时拾取，导致
   `bilibili_live_adapter` 点赞数、`cross_stream_relay` 跨流摘要等写全局
   的 reminder 静默失效。
2. **插件易踩坑**：`add_system_reminder(..., stream_id=...)` 是可选参数，
   插件忘记传 `stream_id` 即写入全局、被 chatter 查不到，bug 难以察觉。
3. **Store 职责膨胀**：Store 被迫感知 `stream` 概念、承担合并逻辑，违反
   单一职责原则。

Bucket 分治方案：
- Store 保持两层 `bucket → name` 纯粹结构，`clear_by_prefix` 是通用前缀
  清理方法，不感知 stream。
- 隔离逻辑通过 `_stream_bucket` 辅助函数封装在 API 层，命名约定
  `stream:{stream_id}:{role}` 由 API 层统一管理，插件不可能拼错。
- 两个独立函数（`add_system_reminder` 全局 / `add_stream_reminder` 流私有）
  从签名上就明确隔离范围，不可能"忘记传 stream_id"。
- chatter 通过 `create_request` 自动追加流私有 source，全局 + 流私有天然
  两份 source 同时拾取，无需 `get_items` 合并逻辑。

## 影响范围

仅框架层 + 测试。插件适配（`prompt_injector` / `kokoro_flow_chatter` /
`default_chatter.sub_agent_collaboration` / `cross_stream_relay` /
`bilibili_live_adapter`）将在后续独立 PR 完成。

## 测试方法

```bash
uv run python -m pytest test/core/prompt/test_system_reminder.py \
    test/app/plugin_system/api/test_prompt_api.py -q
# 结果：49 passed
```

注意：`test_create_request_registers_dynamic_system_reminder` /
`test_create_request_registers_dynamic_once_system_reminder` 在 dev 分支
原本即已失败（见验证记录），与本次改动无关。

## Summary by Sourcery

Introduce per-stream system reminder isolation using bucket naming conventions while keeping the underlying store structure unchanged.

New Features:
- Add stream-scoped reminder APIs that read and write reminders to stream-specific buckets derived from a naming convention.
- Enable BaseChatter requests to automatically load both global and stream-private reminders for one or multiple buckets when configured.

Enhancements:
- Extend SystemReminderStore with a prefix-based clear operation to remove all buckets for a given stream without affecting global data.

Tests:
- Add unit tests for the new stream reminder APIs, including validation, delegation to the store, and isolation behavior between global and per-stream reminders.
- Add unit tests for the new clear_by_prefix store method to cover normal deletion, empty-prefix no-op, and no-match cases.