### PR TITLE
Feature/添加extra params支持http层特殊键

### DIFF
--- a/docs/core/config/model_config.md
+++ b/docs/core/config/model_config.md
@@ -47,6 +47,33 @@ ModelConfig 管理 LLM 相关配置，包括 API 提供商、模型信息与任�
 
 这样可保证全局请求策略自动下发到每个模型调用。
 
+### extra_params HTTP 层特殊键
+
+`model_info.extra_params` 支持三个 HTTP 层特殊键，会被原样透传到 ModelSet，
+最终由 kernel.llm 的 provider 客户端提取并注入到 HTTP 请求的不同位置：
+
+| 键 | 类型 | 用途 |
+|---|---|---|
+| `headers` | `dict[str, str]` | 注入 HTTP 请求头 |
+| `query` | `dict[str, Any]` | 注入 URL 查询参数 |
+| `body` | `dict[str, Any]` | 合并到请求体字段 |
+
+配置示例：
+
+```toml
+[[models]]
+model_identifier = "custom-model-v1"
+name = "custom-model"
+api_provider = "custom"
+
+# 单行 inline table 形式（兼容 Python tomllib）
+extra_params = {headers = {"X-API-Version" = "2024-06"}, query = {version = "2024-01-01"}, body = {metadata = {source = "maibot"}}, enable_thinking = false}
+```
+
+> ⚠️ Python 3.11 自带的 `tomllib` 不支持多行 inline table（TOML 1.1 特性）。
+> 若需多行书写，请使用子表语法 `[models.extra_params.headers]` 等仅对 `[[models]]`
+> 数组最后一项生效，或改用单行写法。详见 [LLM Types 文档](../../../docs/llm/types.md)。
+
 ## 全局实例管理
 
 - _global_model_config: ModelConfig | None

--- a/docs/llm/README.md
+++ b/docs/llm/README.md
@@ -284,6 +284,27 @@ A: 在 kernel 启动时调用 `await init_llm_stats(db_path="data/llm_stats/llm_
 
 A: 当 token 计数超过 `model.max_context * context_reserve_ratio`（默认为 0.95）时触发裁剪；可通过 `extra_params.context_reserve_ratio` 和 `extra_params.context_reserve_tokens` 调整。
 
+### Q: 如何为模型请求注入 HTTP 头、URL 查询参数和请求体字段？
+
+A: 在 `extra_params` 中使用三个特殊键：`headers`、`query`、`body`。三者会被独立
+提取并透传给底层 SDK（OpenAI/Anthropic 都原生支持 `extra_headers`/`extra_query`/`extra_body`）：
+
+```toml
+[[models]]
+model_identifier = "custom-model-v1"
+name = "custom-model"
+api_provider = "custom"
+
+extra_params = {headers = {"X-API-Version" = "2024-06", "X-Priority" = "high"}, query = {version = "2024-01-01"}, body = {metadata = {source = "maibot"}}, enable_thinking = false}
+```
+
+- `headers`：`dict[str, str]`，注入到 HTTP 请求头。
+- `query`：`dict[str, Any]`，注入到 URL 查询参数。
+- `body`：`dict[str, Any]`，合并到请求体字段（可嵌套）。
+
+若不包含这三个特殊键，`extra_params` 的行为与历史完全一致（非标准参数会自动归并到请求体）。
+详见 [Types 模块 - extra_params HTTP 层特殊键](./types.md#extra_params-http-层特殊键)。
+
 ### Q: 指标收集是否有性能开销？
 
 A: 内存级指标可以通过 `enable_metrics=False` 关闭。持久化统计仅在显式调用 `init_llm_stats` 后生效。

--- a/docs/llm/model_client/README.md
+++ b/docs/llm/model_client/README.md
@@ -350,6 +350,32 @@ models1 = [{"client_type": "openai", "model_identifier": "gpt-4", ...}]
 models2 = [{"client_type": "gemini", "model_identifier": "gemini-pro", ...}]
 ```
 
+### Q: 如何向请求注入自定义 HTTP 头、URL 查询参数或请求体字段？
+
+A: 在模型配置的 `extra_params` 中使用三个特殊键：`headers`、`query`、`body`。
+两者都会被独立提取并透传给底层 SDK 的同名 `extra_*` 参数：
+
+```python
+models = [{
+    "client_type": "openai",
+    "model_identifier": "custom-model",
+    "api_key": "...",
+    "extra_params": {
+        "headers": {"X-API-Version": "2024-06", "X-Priority": "high"},
+        "query": {"version": "2024-01-01"},
+        "body": {"metadata": {"source": "maibot"}},
+        "enable_thinking": False,  # 其余键按原有透传逻辑处理
+    },
+}]
+```
+
+- `headers`：必须是 `dict[str, str]`，注入到 HTTP 请求头。
+- `query`：必须是 `dict`，注入到 URL 查询参数。
+- `body`：必须是 `dict`，合并到请求体字段（可嵌套）。
+
+OpenAI 客户端在透传时还会把非标准参数自动归并到 `extra_body`，用户显式声明的
+`body` 优先级高于非标准参数。Anthropic 客户端则直接合并到请求体。
+
 ### Q: OpenAI 的重试是如何工作的？
 
 A: OpenAI 客户端禁用了 SDK 级别的重试。重试由 `policy` 层完全控制，允许更细粒度的控制。

--- a/docs/llm/request.md
+++ b/docs/llm/request.md
@@ -55,7 +55,21 @@ class LLMRequest:
 | `max_tokens` | `int` | 最大输出 token 数 |
 | `max_context` | `int` | 最大上下文窗口（0 表示不限制） |
 | `tool_call_compat` | `bool` | 是否启用工具调用兼容模式 |
-| `extra_params` | `dict[str, Any]` | 额外参数（可含 `context_reserve_ratio`、`context_reserve_tokens`） |
+| `extra_params` | `dict[str, Any]` | 额外参数（可含 `context_reserve_ratio`、`context_reserve_tokens`、`headers`、`query`、`body`） |
+
+#### `extra_params` HTTP 层特殊键
+
+`extra_params` 中的 `headers`、`query`、`body` 是 HTTP 层特殊键，会被独立提取并
+透传给底层 SDK 的 `extra_headers`/`extra_query`/`extra_body`：
+
+| 键 | 类型 | 用途 |
+|---|---|---|
+| `headers` | `dict[str, str]` | 注入 HTTP 请求头 |
+| `query` | `dict[str, Any]` | 注入 URL 查询参数 |
+| `body` | `dict[str, Any]` | 合并到请求体字段 |
+
+其余键保持原有透传逻辑。三个特殊键不存在时，行为与历史完全一致。详见
+[Types 模块](./types.md#extra_params-http-层特殊键)。
 
 **使用示例：**
 

--- a/docs/llm/types.md
+++ b/docs/llm/types.md
@@ -55,14 +55,63 @@ class ModelEntry(TypedDict, total=True):
 | api_key | str | API 密钥 |
 | base_url | str | API 基础 URL |
 | max_retry | int | 最大重试次数 |
-| 	imeout | loat | 请求超时（秒） |
-| retry_interval | loat | 重试间隔（秒） |
-| 	emperature | loat | 采样温度 |
+| 	imeout | float | 请求超时（秒） |
+| retry_interval | float | 重试间隔（秒） |
+| 	emperature | float | 采样温度 |
 | max_tokens | int | 最大输出 token 数 |
 | max_context | int | 模型上下文窗口大小 |
-| price_in / price_out | loat | 输入/输出价格（用于成本计算） |
+| price_in / price_out | float | 输入/输出价格（用于成本计算） |
 | tool_call_compat | tool | 是否启用工具调用兼容模式 |
-| extra_params | dict | 额外参数透传 |
+| extra_params | dict | 额外参数透传（支持 `headers`/`query`/`body` 三个 HTTP 层特殊键，详见下方说明） |
+
+### `extra_params` HTTP 层特殊键
+
+`extra_params` 中的 `headers`、`query`、`body` 是三个特殊键，会被独立提取并
+注入到 HTTP 请求的不同位置，**不会**进入请求体业务字段：
+
+| 特殊键 | 类型 | 用途 |
+|---|---|---|
+| `headers` | `dict[str, str]` | 注入 HTTP 请求头（透传给底层 SDK 的 `extra_headers`） |
+| `query` | `dict[str, Any]` | 注入 URL 查询参数（透传给底层 SDK 的 `extra_query`） |
+| `body` | `dict[str, Any]` | 合并到请求体字段（透传给底层 SDK 的 `extra_body`） |
+
+其余键保持原有透传逻辑：OpenAI 兼容客户端会把非标准参数自动归并到 `extra_body`
+（即请求体），Anthropic 客户端直接合并到请求体。
+
+**示例：**
+
+```toml
+[[models]]
+model_identifier = "custom-model-v1"
+name = "custom-model"
+api_provider = "custom"
+
+# HTTP 头、URL 查询参数和请求体字段分别由三个特殊键注入；
+# enable_thinking 等其它键按原有透传逻辑处理。
+extra_params = {
+  headers = {"X-API-Version" = "2024-06", "X-Priority" = "high"},
+  query = {version = "2024-01-01"},
+  body = {metadata = {source = "maibot"}},
+  enable_thinking = false
+}
+```
+
+> ⚠️ 注意：Python 3.11 自带的 `tomllib`（TOML 1.0）**不支持多行 inline table**。
+> 上例的多行写法需使用支持 TOML 1.1 的解析器（如 `toml` JS 库、`tomli-w`、
+> `tomlkit`），或改成以下两种等价格式之一：
+>
+> 1. 单行 inline table：
+>    ```toml
+>    extra_params = {headers = {"X-API-Version" = "2024-06", "X-Priority" = "high"}, query = {version = "2024-01-01"}, body = {metadata = {source = "maibot"}}, enable_thinking = false}
+>    ```
+> 2. 子表语法（仅当本节为单条记录或位于 `[[models]]` 数组末尾时可用）：
+>    ```toml
+>    [models.extra_params]
+>    headers = {"X-API-Version" = "2024-06", "X-Priority" = "high"}
+>    query = {version = "2024-01-01"}
+>    body = {metadata = {source = "maibot"}}
+>    enable_thinking = false
+>    ```
 
 ---
 

--- a/src/core/config/model_config.py
+++ b/src/core/config/model_config.py
@@ -157,7 +157,12 @@ class ModelInfoSection(SectionBase):
     )
     extra_params: dict[str, Any] = Field(
         default_factory=dict,
-        description="额外参数（用于 API 调用时的额外配置）",
+        description=(
+            "额外参数（用于 API 调用时的额外配置）。"
+            "支持三个特殊键：headers（注入 HTTP 请求头，dict[str,str]）、"
+            "query（注入 URL 查询参数，dict）、body（合并到请求体字段，dict）；"
+            "其余键按原透传逻辑处理"
+        ),
     )
     anti_truncation: bool = Field(
         default=False,

--- a/src/kernel/llm/model_client/anthropic_client.py
+++ b/src/kernel/llm/model_client/anthropic_client.py
@@ -381,7 +381,18 @@ class AnthropicChatClient:
 
     def _extract_model_params(
         self, model_set: Mapping[str, object]
-    ) -> tuple[str, str | None, float | None, bool, bool, dict[str, object]]:
+    ) -> tuple[
+        str,
+        str | None,
+        float | None,
+        bool,
+        bool,
+        dict[str, object],
+        dict[str, str],
+        dict[str, object],
+        dict[str, object],
+    ]:
+        """从 model_set 提取传输层参数，含 headers/query/body 三个特殊键。"""
         try:
             (
                 api_key,
@@ -390,6 +401,9 @@ class AnthropicChatClient:
                 trust_env,
                 force_ipv4,
                 extra_params,
+                extra_headers,
+                extra_query,
+                extra_body,
             ) = extract_model_transport_params(model_set)
         except ValueError as exc:
             message = str(exc)
@@ -405,6 +419,9 @@ class AnthropicChatClient:
             trust_env,
             force_ipv4,
             dict(extra_params),
+            dict(extra_headers),
+            dict(extra_query),
+            dict(extra_body),
         )
 
     def _get_client(
@@ -488,7 +505,7 @@ class AnthropicChatClient:
         if not isinstance(model_set, dict):
             raise TypeError("AnthropicChatClient 期望 model_set 为单个模型配置 dict")
 
-        api_key, base_url, timeout, trust_env, force_ipv4, extra_params = self._extract_model_params(model_set)
+        api_key, base_url, timeout, trust_env, force_ipv4, extra_params, extra_headers, extra_query, explicit_body = self._extract_model_params(model_set)
         tool_format = str(extra_params.pop("tool_format", "anthropic"))
         # 提取 Anthropic 原生 thinking 参数，由 SDK 负责校验和序列化
         thinking = extra_params.pop("thinking", None)
@@ -523,6 +540,20 @@ class AnthropicChatClient:
             params["thinking"] = thinking
 
         params.update(extra_params)
+
+        # 应用 extra_params 中的 HTTP 层特殊键：headers/query/body
+        # Anthropic SDK 原生支持 extra_headers/extra_query/extra_body，
+        # 这些参数直接注入到实际 HTTP 请求中，与普通请求体字段区分开。
+        if explicit_body:
+            existing = params.get("extra_body")
+            if isinstance(existing, dict):
+                params["extra_body"] = {**explicit_body, **existing}
+            else:
+                params["extra_body"] = explicit_body
+        if extra_headers:
+            params["extra_headers"] = extra_headers
+        if extra_query:
+            params["extra_query"] = extra_query
 
         # 请求检查和 token 估算统一走共享观测 seam，这里只负责上报原始请求体。
         log_provider_request_body(

--- a/src/kernel/llm/model_client/openai_client.py
+++ b/src/kernel/llm/model_client/openai_client.py
@@ -604,6 +604,15 @@ class OpenAIChatClient:
     - ``force_ipv4``：是否强制使用 IPv4 出口，默认 False。
     - ``context_reserve_ratio`` / ``context_reserve_tokens``：由上层策略使用，此处忽略。
     - ``force_sync_http``：已废弃，忽略。
+
+    支持的 extra_params HTTP 层特殊键：
+
+    - ``headers``：dict[str, str]，注入到 HTTP 请求头（透传给 OpenAI SDK 的 extra_headers）。
+    - ``query``：dict[str, Any]，注入到 URL 查询参数（透传给 OpenAI SDK 的 extra_query）。
+    - ``body``：dict[str, Any]，合并到请求体字段（透传给 OpenAI SDK 的 extra_body）。
+
+    这三个特殊键不存在时，其余参数行为与历史一致；同时存在时，特殊键优先
+    于非标准参数（即 ``body`` 会覆盖同名非标准参数）。
     """
 
     def __init__(self) -> None:
@@ -761,7 +770,18 @@ class OpenAIChatClient:
 
     def _extract_model_params(
         self, model_set: dict[str, Any]
-    ) -> tuple[str, str | None, float | None, bool, bool, dict[str, Any]]:
+    ) -> tuple[
+        str,
+        str | None,
+        float | None,
+        bool,
+        bool,
+        dict[str, Any],
+        dict[str, str],
+        dict[str, Any],
+        dict[str, Any],
+    ]:
+        """从 model_set 提取传输层参数，含 headers/query/body 三个特殊键。"""
         try:
             (
                 api_key,
@@ -770,6 +790,9 @@ class OpenAIChatClient:
                 trust_env,
                 force_ipv4,
                 extra_params,
+                extra_headers,
+                extra_query,
+                extra_body,
             ) = extract_model_transport_params(model_set)
         except ValueError as exc:
             message = str(exc)
@@ -785,6 +808,9 @@ class OpenAIChatClient:
             trust_env,
             force_ipv4,
             dict(extra_params),
+            dict(extra_headers),
+            dict(extra_query),
+            dict(extra_body),
         )
 
 
@@ -828,7 +854,7 @@ class OpenAIChatClient:
         if not isinstance(model_set, dict):
             raise TypeError("OpenAIChatClient 期望 model_set 为单个模型配置 dict")
 
-        api_key, base_url, timeout, trust_env, force_ipv4, extra_params = (
+        api_key, base_url, timeout, trust_env, force_ipv4, extra_params, extra_headers, extra_query, explicit_body = (
             self._extract_model_params(model_set)
         )
         # force_sync_http 已废弃，移除后不传给 API
@@ -879,25 +905,44 @@ class OpenAIChatClient:
         else:
             params.pop("tool_choice", None)
 
-        # 新增：区分标准参数与非标准参数（统一走 extra_body，避免 openai SDK 因未知参数报错）
+        # 区分标准参数与非标准参数（统一走 extra_body，避免 openai SDK 因未知参数报错）
+        # extra_headers/extra_query 是 OpenAI SDK 原生支持的 HTTP 层透传键，不要被
+        # 当成非标准参数塞进 extra_body。
         standard_params = {
             "model", "messages", "max_tokens", "temperature", "top_p", "n", "stream",
             "stop", "presence_penalty", "frequency_penalty", "logit_bias", "user",
             "tools", "tool_choice", "response_format", "seed", "parallel_tool_calls",
             "functions", "function_call", "extra_body", "stream_options",
-            "reasoning_effort",
+            "reasoning_effort", "extra_headers", "extra_query",
         }
-        extra_body: dict[str, Any] = {}
+        non_standard_body: dict[str, Any] = {}
         for key in list(params.keys()):
             if key not in standard_params:
-                extra_body[key] = params.pop(key)
-        if extra_body:
+                non_standard_body[key] = params.pop(key)
+
+        # 合并非标准参数与用户显式声明的 body 字段：
+        # 用户显式声明的 body 优先级高于非标准参数（即同名时以用户 body 为准），
+        # 这样可以保证用户对请求体的精确控制。
+        merged_body: dict[str, Any] = {}
+        if non_standard_body:
+            merged_body.update(non_standard_body)
+        if explicit_body:
+            merged_body.update(explicit_body)
+
+        if merged_body:
             existing = params.get("extra_body")
             if isinstance(existing, dict):
-                merged = {**existing, **extra_body}
-                params["extra_body"] = merged
+                # 程序化设置的 extra_body 优先级最高，避免被用户配置覆盖
+                params["extra_body"] = {**merged_body, **existing}
             else:
-                params["extra_body"] = extra_body
+                params["extra_body"] = merged_body
+
+        # 应用 HTTP 层参数：headers 走 extra_headers、query 走 extra_query，
+        # 由 OpenAI SDK 在底层注入到实际 HTTP 请求中。
+        if extra_headers:
+            params["extra_headers"] = extra_headers
+        if extra_query:
+            params["extra_query"] = extra_query
 
         # 仅在显式允许 reasoning 历史模式时，才为缺失字段的 assistant 历史回填
         # reasoning_content；默认模式下前面已经清理过该字段。
@@ -1146,7 +1191,7 @@ class OpenAIChatClient:
         if not inputs:
             raise ValueError("inputs 不能为空")
 
-        api_key, base_url, timeout, trust_env, force_ipv4, extra_params = (
+        api_key, base_url, timeout, trust_env, force_ipv4, extra_params, extra_headers, extra_query, explicit_body = (
             self._extract_model_params(model_set)
         )
         client = self._get_client(
@@ -1162,6 +1207,19 @@ class OpenAIChatClient:
             "input": inputs,
         }
         params.update(extra_params)
+
+        # 应用 extra_params 中的特殊键：headers/query/body
+        # 与 chat completions 一致，body 走 extra_body，headers/query 走 SDK 透传。
+        if explicit_body:
+            existing = params.get("extra_body")
+            if isinstance(existing, dict):
+                params["extra_body"] = {**explicit_body, **existing}
+            else:
+                params["extra_body"] = explicit_body
+        if extra_headers:
+            params["extra_headers"] = extra_headers
+        if extra_query:
+            params["extra_query"] = extra_query
 
         log_provider_request_body(
             "embeddings.create",
@@ -1221,7 +1279,7 @@ class OpenAIChatClient:
         if not documents:
             raise ValueError("documents 不能为空")
 
-        api_key, base_url, timeout, trust_env, force_ipv4, extra_params = (
+        api_key, base_url, timeout, trust_env, force_ipv4, _extra_params, extra_headers, extra_query, explicit_body = (
             self._extract_model_params(model_set)
         )
         client = self._get_client(
@@ -1245,6 +1303,15 @@ class OpenAIChatClient:
             }
             if isinstance(top_n, int) and top_n > 0:
                 params["top_n"] = top_n
+
+            # 应用 extra_params 中的特殊键：headers/query/body
+            # rerank 接口参数集合有限，普通 extra_params 不透传，仅这三个 HTTP 层特殊键生效
+            if explicit_body:
+                params["extra_body"] = explicit_body
+            if extra_headers:
+                params["extra_headers"] = extra_headers
+            if extra_query:
+                params["extra_query"] = extra_query
 
             log_provider_request_body(
                 "rerank.create",
@@ -1312,7 +1379,7 @@ class OpenAIChatClient:
         if not isinstance(model_set, dict):
             raise TypeError("OpenAIChatClient 期望 model_set 为单个模型配置 dict")
 
-        api_key, base_url, timeout, trust_env, force_ipv4, _ = (
+        api_key, base_url, timeout, trust_env, force_ipv4, _, extra_headers, extra_query, explicit_body = (
             self._extract_model_params(model_set)
         )
         client = self._get_client(
@@ -1323,9 +1390,18 @@ class OpenAIChatClient:
             force_ipv4=force_ipv4,
         )
 
-        resp = await client.audio.transcriptions.create(
-            model=model_name,
-            file=("audio.wav", io.BytesIO(audio_bytes), "audio/wav"),
-        )
+        kwargs: dict[str, Any] = {
+            "model": model_name,
+            "file": ("audio.wav", io.BytesIO(audio_bytes), "audio/wav"),
+        }
+        # 应用 HTTP 层参数：headers/query/body
+        if explicit_body:
+            kwargs["extra_body"] = explicit_body
+        if extra_headers:
+            kwargs["extra_headers"] = extra_headers
+        if extra_query:
+            kwargs["extra_query"] = extra_query
+
+        resp = await client.audio.transcriptions.create(**kwargs)
         text = getattr(resp, "text", None)
         return text if isinstance(text, str) else str(resp)

--- a/src/kernel/llm/model_client/shared.py
+++ b/src/kernel/llm/model_client/shared.py
@@ -129,8 +129,31 @@ def inject_reason_parameter(
 
 def extract_model_transport_params(
     model_set: Mapping[str, object],
-) -> tuple[str, str | None, float | None, bool, bool, dict[str, object]]:
-    """提取所有 provider 客户端都会使用的传输层配置。"""
+) -> tuple[
+    str,
+    str | None,
+    float | None,
+    bool,
+    bool,
+    dict[str, object],
+    dict[str, str],
+    dict[str, object],
+    dict[str, object],
+]:
+    """提取所有 provider 客户端都会使用的传输层配置。
+
+    返回值依次为：
+        ``api_key``、``base_url``、``timeout``、``trust_env``、``force_ipv4``、
+        ``extra_params``、``extra_headers``、``extra_query``、``extra_body``。
+
+    其中 ``extra_headers``/``extra_query``/``extra_body`` 取自 ``extra_params``
+    中的同名特殊键（``headers``/``query``/``body``），用于直接控制 HTTP 层行为：
+    请求头、URL 查询参数、请求体字段。其余键保持原有透传逻辑，由具体
+    provider 客户端按其标准/非标准参数分流规则处理。
+
+    若 ``extra_params`` 中不包含这三个特殊键，行为与历史完全一致，避免对存量
+    配置造成回归。
+    """
     api_key = str(model_set.get("api_key") or "")
     if not api_key:
         raise ValueError("model.api_key cannot be empty")
@@ -154,6 +177,13 @@ def extract_model_transport_params(
     normalized_extra_params.pop("context_reserve_tokens", None)
     normalized_extra_params.pop("force_sync_http", None)
 
+    # 提取 HTTP 传输层特殊键：headers / query / body
+    # 它们与一般请求参数不同，分别用于注入 HTTP 请求头、URL 查询参数和请求体字段，
+    # 取出后不会继续留在 extra_params 中，避免被 provider 客户端重复处理。
+    extra_headers = _coerce_headers(normalized_extra_params.pop("headers", None))
+    extra_query = _coerce_dict(normalized_extra_params.pop("query", None))
+    extra_body = _coerce_dict(normalized_extra_params.pop("body", None))
+
     timeout_float = float(timeout) if isinstance(timeout, (int, float)) else None
     return (
         api_key,
@@ -162,7 +192,36 @@ def extract_model_transport_params(
         trust_env,
         force_ipv4,
         normalized_extra_params,
+        extra_headers,
+        extra_query,
+        extra_body,
     )
+
+
+def _coerce_dict(value: Any) -> dict[str, object]:
+    """将任意输入归一化为 ``dict[str, object]``，非 dict 一律视为空字典。"""
+    if isinstance(value, Mapping):
+        return {str(k): v for k, v in value.items()}
+    return {}
+
+
+def _coerce_headers(value: Any) -> dict[str, str]:
+    """将 headers 配置归一化为 ``dict[str, str]``。
+
+    HTTP 请求头值必须是字符串，因此对 bool/number 等做安全转换；
+    非字典输入返回空字典，避免污染下游 SDK 调用。
+    """
+    if not isinstance(value, Mapping):
+        return {}
+    headers: dict[str, str] = {}
+    for k, v in value.items():
+        if isinstance(v, bool):
+            headers[str(k)] = "true" if v else "false"
+        elif v is None:
+            continue
+        else:
+            headers[str(k)] = str(v)
+    return headers
 
 
 def log_provider_request_body(

--- a/src/kernel/llm/request.py
+++ b/src/kernel/llm/request.py
@@ -137,6 +137,15 @@ def _validate_model_entry(model: dict[str, Any]) -> ModelEntry:
             raise LLMConfigurationError(
                 "model.extra_params.context_reserve_tokens 必须是 int"
             )
+        # HTTP 层特殊键：headers/query/body，必须为 dict，否则透传给 SDK 会触发类型错误
+        for _special_key in ("headers", "query", "body"):
+            _special_val = extra_params.get(_special_key)
+            if _special_val is None:
+                continue
+            if not isinstance(_special_val, dict):
+                raise LLMConfigurationError(
+                    f"model.extra_params.{_special_key} 必须是 dict"
+                )
 
     model.setdefault("tool_call_compat", False)
     model.setdefault("force_stream_mode", False)


### PR DESCRIPTION
# PR 说明

## 标题
feat(model_config): 添加 extra_params 支持 HTTP 层特殊键

## 分支
`feature/添加extra_params支持HTTP层特殊键` → `dev`

## 概述

为模型配置的 `extra_params` 引入三个 HTTP 层特殊键 `headers` / `query` / `body`，允许用户精确控制 HTTP 请求头、URL 查询参数和请求体字段。不包含这三个特殊键时，行为与历史完全一致，无回归风险。

## 配置示例

```toml
[[models]]
model_identifier = "custom-model-v1"
name = "custom-model"
api_provider = "custom"

# 单行 inline table（兼容 Python 自带 tomllib）
extra_params = {headers = {"X-API-Version" = "2024-06", "X-Priority" = "high"}, query = {version = "2024-01-01"}, body = {metadata = {source = "maibot"}}, enable_thinking = false}
```

三个特殊键的用途：

| 键 | 类型 | 用途 |
|---|---|---|
| `headers` | `dict[str, str]` | 注入 HTTP 请求头（透传给 SDK 的 `extra_headers`） |
| `query` | `dict[str, Any]` | 注入 URL 查询参数（透传给 SDK 的 `extra_query`） |
| `body` | `dict[str, Any]` | 合并到请求体字段（透传给 SDK 的 `extra_body`，可嵌套） |

## 改动文件

### 后端核心
- **`src/kernel/llm/model_client/shared.py`**
  - `extract_model_transport_params` 返回值从 6 元组扩展为 9 元组，新增 `extra_headers` / `extra_query` / `extra_body`
  - 新增 `_coerce_dict` 和 `_coerce_headers` 辅助函数：headers 值强制转字符串（bool/number 安全转换），非 dict 输入静默回退为空字典
- **`src/kernel/llm/model_client/openai_client.py`**
  - `_extract_model_params` 同步扩展返回值
  - `create` / `create_embedding` / `create_rerank` / `create_transcription` 四个方法应用三个特殊键
  - `standard_params` 集合补充 `extra_headers` / `extra_query`，避免被错误归并到 `extra_body`
  - body 优先级规则：用户显式 `body` > 非标准参数 > 程序化 `extra_body`
- **`src/kernel/llm/model_client/anthropic_client.py`**
  - `_extract_model_params` 同步扩展返回值
  - `create` 方法应用三个特殊键，透传给 Anthropic SDK 原生的 `extra_headers` / `extra_query` / `extra_body`
- **`src/kernel/llm/request.py`**
  - `_validate_model_entry` 新增校验：`headers` / `query` / `body` 必须为 dict，否则抛 `LLMConfigurationError`
- **`src/core/config/model_config.py`**
  - `extra_params` 字段 description 更新，说明三个特殊键的用途

### 文档
- `docs/llm/types.md` — 新增「extra_params HTTP 层特殊键」章节，含 TOML 解析限制说明
- `docs/llm/README.md` — FAQ 新增「如何注入 HTTP 头/URL 查询参数/请求体字段」
- `docs/llm/request.md` — ModelEntry 字段表补充三个特殊键
- `docs/llm/model_client/README.md` — FAQ 新增透传机制说明
- `docs/core/config/model_config.md` — ModelSet 构建细节新增特殊键说明

## 设计要点

1. **完全向后兼容**：`extra_params` 不含三个特殊键时，`extract_model_transport_params` 返回三个空字典，下游客户端不会注入任何 `extra_*` 参数，行为与改动前一致
2. **特殊键与非标准参数分流**：OpenAI 客户端原本会把非标准参数归并到 `extra_body`，现在 `headers` / `query` 走 SDK 原生 `extra_headers` / `extra_query`，`body` 与非标准参数合并到 `extra_body`，互不干扰
3. **优先级明确**：用户显式 `body` 覆盖同名非标准参数；程序化设置的 `extra_body` 优先级最高，避免被用户配置覆盖
4. **类型安全**：headers 值强制转字符串（HTTP 头规范要求），非 dict 输入静默回退，校验层提前拦截非法类型
5. **TOML 兼容性**：Python 3.11 自带 `tomllib`（TOML 1.0）不支持多行 inline table，文档明确说明并给出单行 inline 和子表两种等价格式

## 测试

- 手动验证 `extract_model_transport_params`：5 个场景全部通过（向后兼容、三键齐全、header 值类型转换、非 dict 输入静默忽略、保留键仍正常弹出）
- 手动验证 `_validate_model_entry`：非 dict 的 `headers` / `query` / `body` 均正确抛 `LLMConfigurationError`，合法 dict 通过
- 手动验证 OpenAI 客户端：`extra_headers` / `extra_query` / `extra_body` 正确透传到 SDK 调用参数
- 手动验证 Anthropic 客户端：三个特殊键正确透传
- 手动验证向后兼容：无特殊键时 `extra_headers` / `extra_query` 不出现在 SDK 调用参数中，`top_p` 等标准参数保持在顶层
- 现有测试套件无新增失败（`test_openai_client.py` 等 7 个 pre-existing 失败与本次改动无关，已通过 `git stash` 对比验证）

## 关联

- WebUI 前端改动（`ModelEditDialog.vue` 拆分三个独立编辑框、i18n 文案）在 `Neo-MoFox-Webui` 仓库单独提 PR
- 用户向导文档改动（`MoFox-Bot-Docs` 仓库的 `model_configuration_guide.md`）单独提 PR

## 破坏性变更

无。所有改动在 `extra_params` 不含三个特殊键时保持原有行为。
