### PR TITLE
feat(chatter):  WaitResumeEvent的完善

### DIFF
--- a/plugins/default_chatter/session.py
+++ b/plugins/default_chatter/session.py
@@ -241,6 +241,24 @@ def _build_sub_agent_resume_prompt(_: WaitResumeEvent) -> str:
     )
 
 
+def _build_unknown_resume_prompt(event: WaitResumeEvent) -> str:
+    """未知 source 的通用恢复提示。
+
+    优先使用 ``extra["resume_prompt"]``，
+    否则返回基于 source 的默认文案。
+    """
+    custom = event.extra.get("resume_prompt")
+    if isinstance(custom, str) and custom.strip():
+        return custom
+    source_label = event.source or "未知来源"
+    return (
+        f"系统事件：收到来自 '{source_label}' 的恢复请求。"
+        "请基于已有上下文主动决定下一步。"
+        "如果现在无需继续处理，请调用 pass_and_wait；"
+        "如果需要继续回复、委派或执行动作，请直接使用相应工具。"
+    )
+
+
 def _build_sub_agent_result_user_prompt(events: list[dict[str, Any]]) -> str:
     lines = ["以下是子代理刚刚返回的结果，请基于这些结果继续处理："]
     for event in events:
@@ -510,6 +528,31 @@ class DefaultChatterSession:
                                 else "等待计时器到期"
                             )
                         ),
+                    )
+                    continue
+
+                if current_resume_event is not None:
+                    state.cross_round_seen_signatures.clear()
+                    state.plain_text_retry_count = 0
+                    state.used_tools_in_round.clear()
+                    state.unreads = []
+                    state.unread_msgs_to_flush = []
+
+                    reminder_text = _build_unknown_resume_prompt(current_resume_event)
+
+                    context_ids = current_resume_event.extra.get("context_ids", [])
+                    if context_ids:
+                        state.internal_context_ids.extend(context_ids)
+
+                    self.adapters.unread_adapter._upsert_pending_unread_payload(
+                        response=state.response,
+                        formatted_text=reminder_text,
+                    )
+                    _transition(
+                        state=state,
+                        to_phase=DefaultChatterSessionPhase.MODEL_TURN,
+                        session=self,
+                        reason=f"外部恢复事件: {current_resume_event.source}",
                     )
                     continue
 

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -9,8 +9,8 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import asyncio
 from datetime import datetime
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, Literal, cast
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, AsyncGenerator, Callable, cast
 
 from src.core.components.types import ChatType
 from src.core.components.base.action import BaseAction
@@ -48,12 +48,24 @@ class Wait:
 
 @dataclass(frozen=True)
 class WaitResumeEvent:
-    """Wait/Stop 结束后由框架送回生成器的恢复事件。"""
+    """Wait/Stop 结束后由框架送回生成器的恢复事件。
 
-    source: Literal["message", "timer", "sub_agent", "internal_context"]
+    框架内置 source 约定值（不是硬性限制）：
+    - ``"message"`` 新消息唤醒
+    - ``"timer"`` 定时器到期
+    - ``"sub_agent"`` 子代理完成
+    - ``"internal_context"`` 内部上下文到达
+
+    外部插件可以通过 ``trigger_external_resume()`` 注入任意 source 的事件，
+    通过 ``extra`` 字段传递自定义数据。
+    对未知 source 的处理由各 Chatter 自行决定。
+    """
+
+    source: str
     wait_time: float | int | None = None
     unread_count: int = 0
     context_key: str = ""
+    extra: dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
把WaitResumeEvent的完善，做成一个通用模式，不限制source

## Summary by Sourcery

Generalize WaitResumeEvent handling to support arbitrary sources and provide a default resume prompt for unknown sources.

New Features:
- Add generic resume prompt generation for WaitResumeEvent with unknown or custom sources.
- Allow WaitResumeEvent to carry arbitrary string sources and extra metadata for external plugins.

Enhancements:
- Reset conversation state and transition back to model turn when handling external resume events based on WaitResumeEvent.