### PR TITLE
feat(dfc): 修复原生多模态图片定位与消息归属错误

### DIFF
--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -40,8 +40,9 @@ from .components.config import DefaultChatterConfig
 from .components.service import DefaultChatterService
 from .utils.interest_gate import InterestGate
 from .utils.multimodal import (
-    extract_images_from_messages,
-    inline_images_into_text,
+    get_image_media_list,
+    inline_message_images_into_text,
+    tokenize_message_scoped_image_placeholders,
 )
 from .utils.prompt_builder import DefaultChatterPromptBuilder
 from .utils.prompts import system_prompt, user_prompt, sub_agent_system_prompt
@@ -141,16 +142,24 @@ class DefaultChatter(BaseChatter):
     ) -> None:
         """在未发送前合并未读消息到最后一个 USER payload。
 
-        当 ``native_multimodal`` 启用时，图片以 ``Image`` 对象内联到
-        ``formatted_text`` 中 ``[图片]`` 占位符的位置，使 LLM 能精确
-        将每张图片与其所属消息上下文对应。
+        当 ``native_multimodal`` 启用时，先将占位符转换为带消息序号和
+        消息内图片序号的标记，再依据标记从对应 Message 取图，避免跨消息
+        按全局图片顺序配对。
         """
         content_list: list[Content | LLMUsable]
         if native_multimodal and unread_msgs:
-            images = extract_images_from_messages(unread_msgs)
-            content_list = inline_images_into_text(formatted_text, images)
-            if images:
-                (logger_override or logger).debug(f"已内联 {len(images)} 张图片到占位符位置")
+            scoped_text = tokenize_message_scoped_image_placeholders(
+                formatted_text,
+                unread_msgs,
+            )
+            content_list = inline_message_images_into_text(scoped_text, unread_msgs)
+            image_count = sum(
+                len(get_image_media_list(message)) for message in unread_msgs
+            )
+            if image_count:
+                (logger_override or logger).debug(
+                    f"已按消息边界内联 {image_count} 张图片"
+                )
         else:
             content_list = [Text(formatted_text)]
         response.add_payload(LLMPayload(ROLE.USER, content_list))

--- a/plugins/default_chatter/utils/multimodal.py
+++ b/plugins/default_chatter/utils/multimodal.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from src.app.plugin_system.types import Content, Image, LLMUsable, Message, Text
 
 _IMAGE_PLACEHOLDER = "[图片]"
+_IMAGE_TOKEN_TEMPLATE = "[[DFC_IMAGE:{message_index}:{image_index}]]"
+_IMAGE_TOKEN_PATTERN = re.compile(r"\[\[DFC_IMAGE:(\d+):(\d+)\]\]")
 
 
 def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
@@ -56,6 +59,77 @@ def build_multimodal_content(
     content_list: list[Content | LLMUsable] = [Text(text)]
     for item in media_items:
         content_list.append(Image(str(item["data"])))
+    return content_list
+
+
+def tokenize_message_scoped_image_placeholders(
+    text: str,
+    messages: list[Message],
+) -> str:
+    """将图片占位符按未读消息顺序转换为带来源索引的标记。"""
+    message_image_indices = [0 for _ in messages]
+    message_index = 0
+
+    def replace_placeholder(match: re.Match[str]) -> str:
+        """替换一个图片占位符。"""
+        nonlocal message_index
+        del match
+        while message_index < len(messages):
+            images = get_image_media_list(messages[message_index])
+            image_index = message_image_indices[message_index]
+            if image_index < len(images):
+                message_image_indices[message_index] += 1
+                return _IMAGE_TOKEN_TEMPLATE.format(
+                    message_index=message_index,
+                    image_index=image_index,
+                )
+            message_index += 1
+        return _IMAGE_PLACEHOLDER
+
+    return re.sub(re.escape(_IMAGE_PLACEHOLDER), replace_placeholder, text)
+
+
+def inline_message_images_into_text(
+    text: str,
+    messages: list[Message],
+) -> list[Content | LLMUsable]:
+    """按消息级标记将图片内联到文本，而不是按全局图片序号配对。
+
+    每个标记只允许引用其对应消息中的图片。若标记损坏或超出该消息图片
+    数量，则保留标记文本并记录可由调用方观察到的结构异常，不会借用其他
+    消息的图片填补，从而避免一次错位扩散到后续消息。
+
+    Args:
+        text: 包含 ``[[DFC_IMAGE:消息序号:图片序号]]`` 标记的文本
+        messages: 与标记消息序号对应的消息列表
+
+    Returns:
+        Text/Image 交替排列的内容列表
+    """
+    content_list: list[Content | LLMUsable] = []
+    cursor = 0
+    for match in _IMAGE_TOKEN_PATTERN.finditer(text):
+        if match.start() > cursor:
+            content_list.append(Text(text[cursor:match.start()]))
+
+        message_index = int(match.group(1))
+        image_index = int(match.group(2))
+        image: dict[str, Any] | None = None
+        if 0 <= message_index < len(messages):
+            images = get_image_media_list(messages[message_index])
+            if 0 <= image_index < len(images):
+                image = images[image_index]
+
+        if image is None:
+            content_list.append(Text(match.group(0)))
+        else:
+            content_list.append(Image(str(image["data"])))
+        cursor = match.end()
+
+    if cursor < len(text):
+        content_list.append(Text(text[cursor:]))
+    if not content_list:
+        content_list.append(Text(text))
     return content_list
 
 

--- a/test/plugins/default_chatter/test_multimodal.py
+++ b/test/plugins/default_chatter/test_multimodal.py
@@ -11,6 +11,8 @@ from plugins.default_chatter.utils.multimodal import (
     build_multimodal_content,
     extract_images_from_messages,
     get_image_media_list,
+    inline_message_images_into_text,
+    tokenize_message_scoped_image_placeholders,
 )
 from src.kernel.llm import Image, Text
 
@@ -117,3 +119,101 @@ class TestBuildMultimodalContent:
         content = build_multimodal_content("hi", items)
         assert isinstance(content[0], Text)
         assert isinstance(content[1], Image)
+
+
+class TestMessageScopedImageBinding:
+    def test_tokens_bind_images_to_their_source_message(self) -> None:
+        first = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64}],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": "aGVsbG8="}],
+        )
+        text = "张三[m1]：[图片]\\n李四[m2]：[图片]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        content = inline_message_images_into_text(scoped_text, [first, second])
+
+        assert scoped_text == "张三[m1]：[[DFC_IMAGE:0:0]]\\n李四[m2]：[[DFC_IMAGE:1:0]]"
+        assert [type(item).__name__ for item in content] == ["Text", "Image", "Text", "Image"]
+
+    def test_one_message_can_bind_multiple_images_without_crossing_messages(self) -> None:
+        first = _make_msg(
+            message_id="m1",
+            media=[
+                {"type": "image", "data": _VALID_B64},
+                {"type": "image", "data": _VALID_B64},
+            ],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": _VALID_B64}],
+        )
+        text = "[图片][图片]\\n[图片]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        content = inline_message_images_into_text(scoped_text, [first, second])
+
+        assert scoped_text == "[[DFC_IMAGE:0:0]][[DFC_IMAGE:0:1]]\\n[[DFC_IMAGE:1:0]]"
+        assert [type(item).__name__ for item in content] == ["Image", "Image", "Text", "Image"]
+
+    def test_invalid_scoped_token_does_not_borrow_another_message_image(self) -> None:
+        first = _make_msg(media=[])
+        second = _make_msg(media=[{"type": "image", "data": _VALID_B64}])
+
+        content = inline_message_images_into_text(
+            "[[DFC_IMAGE:0:0]]",
+            [first, second],
+        )
+
+        assert len(content) == 1
+        assert isinstance(content[0], Text)
+        assert content[0].text == "[[DFC_IMAGE:0:0]]"
+
+    def test_excess_placeholders_degrade_gracefully(self) -> None:
+        """占位符多于实际图片时，多余的保留为文本 [图片]。"""
+        msg = _make_msg(media=[{"type": "image", "data": _VALID_B64}])
+        text = "[图片][图片]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
+        assert scoped_text == "[[DFC_IMAGE:0:0]][图片]"
+
+        content = inline_message_images_into_text(scoped_text, [msg])
+        assert [type(item).__name__ for item in content] == ["Image", "Text"]
+
+    def test_imageless_message_between_image_messages(self) -> None:
+        """无图消息夹在有图消息之间时，占位符正确跳过它。"""
+        m1 = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64}],
+        )
+        m2 = _make_msg(message_id="m2", media=[])  # 纯文本
+        m3 = _make_msg(
+            message_id="m3",
+            media=[{"type": "image", "data": "aGVsbG8="}],
+        )
+        text = "[图片]\\nhello\\n[图片]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(
+            text, [m1, m2, m3],
+        )
+        assert scoped_text == "[[DFC_IMAGE:0:0]]\\nhello\\n[[DFC_IMAGE:2:0]]"
+
+        content = inline_message_images_into_text(scoped_text, [m1, m2, m3])
+        types = [type(item).__name__ for item in content]
+        assert types == ["Image", "Text", "Image"]
+
+    def test_no_placeholders_returns_text_only(self) -> None:
+        """完全没有占位符时，返回纯文本。"""
+        msg = _make_msg(media=[{"type": "image", "data": _VALID_B64}])
+        text = "没有图片占位符的纯文本"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
+        assert scoped_text == text
+
+        content = inline_message_images_into_text(scoped_text, [msg])
+        assert len(content) == 1
+        assert isinstance(content[0], Text)
+        assert content[0].text == text


### PR DESCRIPTION
## 变更说明

修复 `default_chatter` 原生多模态模式下图片与消息归属错位的问题。

此前，多条未读消息中的图片会被提取为一个全局列表，再按照文本中 `[图片]` 占位符的整体顺序插入 LLM 请求。当多名用户连续发送图片、单条消息包含多张图片，或图片与文本混排时，图片可能被错误地关联到其他消息或发送者。

本次改为按消息边界绑定图片：每个图片占位符都对应具体消息和该消息中的具体图片。图片索引无效或占位符数量不一致时保留为文本，不会从其他消息借用图片。

## 修改范围

- 更新 `plugins/default_chatter/plugin.py`，接入消息级图片绑定逻辑。
- 更新 `plugins/default_chatter/utils/multimodal.py`，实现图片占位符标记与严格按消息取图。
- 更新 `test/plugins/default_chatter/test_multimodal.py`，补充相关回归测试。
- 未修改 `src/` 框架代码和其他插件。

## 验证结果

- `uv run pytest test/plugins/default_chatter/test_multimodal.py -q`：14 passed
- 相关 Ruff 检查通过
- 相关文件 `compileall` 检查通过
- `git diff --check` 通过
