### PR TITLE
fix(default_chatter): 修复 message 恢复事件误分类并将 filter_mode 改为布尔开关

### DIFF
--- a/plugins/default_chatter/components/actions/send_text.py
+++ b/plugins/default_chatter/components/actions/send_text.py
@@ -39,7 +39,7 @@ class SendTextAction(BaseAction):
 
     def _get_plugin_config(self) -> DefaultChatterConfig | None:
         """返回插件配置；配置类型不匹配时返回 None。"""
-        config = getattr(self.plugin, "config", None)
+        config = self.plugin.config
         return config if isinstance(config, DefaultChatterConfig) else None
 
     def _mark_sub_agent_bonus_on_success(self, success: bool) -> None:

--- a/plugins/default_chatter/components/config.py
+++ b/plugins/default_chatter/components/config.py
@@ -87,14 +87,19 @@ class DefaultChatterConfig(BaseConfig):
             hint="留空时回退为 actor；可配置为单独的子代理模型任务，例如 sub_agent_actor"
         )
 
-        filter_mode: str = Field(
-            default="sub_only",
-            description="消息过滤模式：sub_only=仅 sub-agent，interest_only=仅兴趣值，interest_then_sub=兴趣值初筛后执行 sub-agent",
-            label="过滤模式",
+        enable_sub_agent: bool = Field(
+            default=True,
+            description="是否启用 sub-agent 消息过滤。",
+            label="启用 Sub-Agent",
             tag="ai",
-            hint="选择群聊消息的响应决策流程",
-            input_type="select",
-            choices=["sub_only", "interest_only", "interest_then_sub"],
+            hint="关闭后不使用 sub-agent 判断消息是否需要回复。",
+        )
+        enable_interest_filter: bool = Field(
+            default=False,
+            description="是否启用兴趣值消息过滤。",
+            label="启用兴趣值过滤",
+            tag="ai",
+            hint="与 Sub-Agent 同时开启时，先通过兴趣值初筛，再交给 sub-agent 判断。",
         )
         enable_sub_agent_context: bool = Field(
             default=True,
@@ -222,7 +227,7 @@ class DefaultChatterConfig(BaseConfig):
             """语义兴趣度模型训练参数。
 
             控制自动训练流程中的数据采样、LLM 标注和关键词生成参数。
-            仅在 filter_mode 非 sub_only 时生效。
+            仅在启用兴趣值过滤时生效。
             """
 
             training_model_name: str = Field(

--- a/plugins/default_chatter/components/service.py
+++ b/plugins/default_chatter/components/service.py
@@ -76,7 +76,7 @@ class DefaultChatterService(BaseService):
 
     @staticmethod
     def _build_default_options(plugin: "BasePlugin") -> DefaultChatterSessionOptions:
-        config = getattr(plugin, "config", None)
+        config = plugin.config
         if not isinstance(config, DefaultChatterConfig):
             return DefaultChatterSessionOptions()
 
@@ -96,10 +96,11 @@ class DefaultChatterService(BaseService):
             native_multimodal=bool(config.plugin.native_multimodal),
             theme_guide=theme_guide,
             negative_behavior_reinforcement=bool(config.plugin.reinforce_negative_behaviors),
-            filter_mode=str(getattr(config.plugin, "filter_mode", "sub_only") or "sub_only"),
-            enable_sub_agent_context=bool(getattr(config.plugin, "enable_sub_agent_context", True)),
-            sub_agent_context_history_limit=int(getattr(config.plugin, "sub_agent_context_history_limit", 10)),
-            sub_agent_decision_history_limit=int(getattr(config.plugin, "sub_agent_decision_history_limit", 3)),
+            enable_sub_agent=bool(config.plugin.enable_sub_agent),
+            enable_interest_filter=bool(config.plugin.enable_interest_filter),
+            enable_sub_agent_context=bool(config.plugin.enable_sub_agent_context),
+            sub_agent_context_history_limit=int(config.plugin.sub_agent_context_history_limit),
+            sub_agent_decision_history_limit=int(config.plugin.sub_agent_decision_history_limit),
         )
 
     @staticmethod

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -87,8 +87,10 @@ class DefaultChatter(BaseChatter):
 
     def _build_negative_behaviors_extra(self) -> str:
         """构建负面行为约束文本；未启用或无内容时返回空字符串。"""
-        plugin_config = getattr(self.plugin, "config", None)
-        return DefaultChatterPromptBuilder.build_negative_behaviors_extra(plugin_config)
+        plugin_config = self.plugin.config
+        return DefaultChatterPromptBuilder.build_negative_behaviors_extra(
+            plugin_config if isinstance(plugin_config, DefaultChatterConfig) else None
+        )
 
     async def _build_system_prompt(self, chat_stream: ChatStream) -> str:
         """构建系统提示词。"""
@@ -323,19 +325,14 @@ class DefaultChatterPlugin(BasePlugin):
         await self._maybe_start_semantic_training()
 
     async def _maybe_start_semantic_training(self) -> None:
-        """根据过滤模式启动语义模型自动训练后台任务。
-
-        仅当 filter_mode 为 interest_only 或 interest_then_sub 时触发，
-        sub_only 模式下跳过以避免不必要的 LLM 调用。
-        """
-        plugin_config = getattr(self, "config", None)
-        if isinstance(plugin_config, DefaultChatterConfig):
-            mode_str = str(
-                getattr(plugin_config.plugin, "filter_mode", "sub_only") or "sub_only"
-            )
-            if mode_str == "sub_only":
-                logger.debug("[语义训练] 当前为 sub_only 模式，跳过自动训练")
-                return
+        """在启用兴趣值过滤时启动语义模型自动训练后台任务。"""
+        plugin_config = self.config
+        if not isinstance(plugin_config, DefaultChatterConfig):
+            logger.warning("[语义训练] 插件配置不可用，跳过自动训练")
+            return
+        if not plugin_config.plugin.enable_interest_filter:
+            logger.debug("[语义训练] 兴趣值过滤未启用，跳过自动训练")
+            return
 
         try:
             from src.kernel.concurrency import get_task_manager
@@ -367,17 +364,18 @@ class DefaultChatterPlugin(BasePlugin):
         try:
             from .semantic_interest.auto_trainer import get_auto_trainer
 
-            plugin_config = getattr(self, "config", None)
-            train_cfg = None
-            if isinstance(plugin_config, DefaultChatterConfig):
-                train_cfg = getattr(plugin_config.plugin, "semantic_training", None)
+            plugin_config = self.config
+            if not isinstance(plugin_config, DefaultChatterConfig):
+                logger.warning("[语义训练] 插件配置不可用，取消后台训练")
+                return
+            train_cfg = plugin_config.plugin.semantic_training
 
-            days = getattr(train_cfg, "training_days", 7) if train_cfg else 7
-            max_samples = getattr(train_cfg, "training_max_samples", 1000) if train_cfg else 1000
-            model_name = getattr(train_cfg, "training_model_name", None) if train_cfg else None
-            batch_size = getattr(train_cfg, "training_batch_size", 50) if train_cfg else 50
-            keyword_iters = getattr(train_cfg, "keyword_iterations", 3) if train_cfg else 3
-            min_interval = getattr(train_cfg, "min_train_interval_hours", 720) if train_cfg else 720
+            days = train_cfg.training_days
+            max_samples = train_cfg.training_max_samples
+            model_name = train_cfg.training_model_name
+            batch_size = train_cfg.training_batch_size
+            keyword_iters = train_cfg.keyword_iterations
+            min_interval = train_cfg.min_train_interval_hours
 
             trainer = get_auto_trainer(min_train_interval_hours=min_interval)
             trained, model_path = await trainer.auto_train_if_needed(

--- a/plugins/default_chatter/session.py
+++ b/plugins/default_chatter/session.py
@@ -541,6 +541,9 @@ class DefaultChatterSession:
                     )
                     continue
 
+                if current_resume_event is not None and current_resume_event.source == "message":
+                    current_resume_event = None
+
                 if current_resume_event is not None:
                     state.cross_round_seen_signatures.clear()
                     state.plain_text_retry_count = 0
@@ -828,7 +831,7 @@ class DefaultChatterSession:
                         session=self,
                     )
                     resume_event = yield Wait(
-                        time=getattr(call_outcome, "wait_seconds", None),
+                        time=call_outcome.wait_seconds,
                         step_data=_consume_actor_round_step_data(state),
                     )
                 else:

--- a/plugins/default_chatter/sub_agent_management.py
+++ b/plugins/default_chatter/sub_agent_management.py
@@ -20,7 +20,7 @@ from .sub_agent_collaboration import (
 
 def get_plugin_config(plugin: Any) -> DefaultChatterConfig | None:
     """返回插件配置；配置类型不匹配时返回 None。"""
-    config = getattr(plugin, "config", None)
+    config = plugin.config
     return config if isinstance(config, DefaultChatterConfig) else None
 
 

--- a/plugins/default_chatter/type_defs.py
+++ b/plugins/default_chatter/type_defs.py
@@ -23,14 +23,6 @@ from src.app.plugin_system.types import ChatStream, LLMPayload, Message, ToolCal
 from src.kernel.llm import StreamEvent
 
 
-class FilterMode(str, Enum):
-    """消息过滤模式枚举。"""
-
-    SUB_ONLY = "sub_only"
-    INTEREST_ONLY = "interest_only"
-    INTEREST_THEN_SUB = "interest_then_sub"
-
-
 class SubAgentDecision(TypedDict):
     """Sub-agent 返回的决策结果。"""
 
@@ -266,7 +258,8 @@ class DefaultChatterSessionOptions:
     theme_guide: dict[str, str] = field(default_factory=dict)
     negative_behavior_reinforcement: bool = True
     enable_llm_stream: bool = False
-    filter_mode: str = "sub_only"
+    enable_sub_agent: bool = True
+    enable_interest_filter: bool = False
     enable_sub_agent_context: bool = True
     sub_agent_context_history_limit: int = 10
     sub_agent_decision_history_limit: int = 3

--- a/plugins/default_chatter/utils/interest_gate.py
+++ b/plugins/default_chatter/utils/interest_gate.py
@@ -1,9 +1,7 @@
-"""Default Chatter 兴趣值决策门。
+"""Default Chatter 兴趣值与 sub-agent 决策门。
 
-封装三种过滤模式的决策逻辑：
-- sub_only: 程序化概率门 + LLM sub-agent 决策
-- interest_only: 纯兴趣值判断
-- interest_then_sub: 先兴趣值初筛，达标后进入 sub-agent 判断
+两个独立开关组合出四种流程：直接响应、仅 sub-agent、仅兴趣值，
+以及兴趣值初筛后进入 sub-agent。
 """
 
 from __future__ import annotations
@@ -19,7 +17,7 @@ from .decision_agent import decide_should_respond
 from .interest_calculator import InterestCalculator, InterestConfig, InterestResult
 from .prompts import sub_agent_system_prompt
 from .probability_gate import should_bypass_via_probability
-from ..type_defs import FilterMode, SubAgentDecision, SupportsRequestCreation
+from ..type_defs import SubAgentDecision, SupportsRequestCreation
 
 logger = get_logger("default_chatter")
 
@@ -52,10 +50,8 @@ class InterestGate:
     ) -> SubAgentDecision:
         """判断当前未读消息是否需要响应。
 
-        支持三种过滤模式：
-        - sub_only: 程序化概率门和 LLM 决策
-        - interest_only: 兴趣值判断
-        - interest_then_sub: 兴趣值初筛后执行 LLM 决策
+        根据两个开关决定流程：都关闭时直接响应，仅启用一个时使用对应过滤器，
+        两个都启用时先进行兴趣值初筛，再交给 sub-agent 判断。
 
         Args:
             unreads_text: 格式化后的未读消息文本
@@ -80,14 +76,18 @@ class InterestGate:
                 calculator.on_message_processed(chat_stream.stream_id, replied=True)
                 logger.debug("[兴趣值] 检测到上次回复成功，已重置 boost 状态")
 
-        filter_mode = self._get_filter_mode()
+        plugin_config = self._get_plugin_config()
+        enable_sub_agent = plugin_config is None or plugin_config.plugin.enable_sub_agent
+        enable_interest_filter = bool(
+            plugin_config is not None and plugin_config.plugin.enable_interest_filter
+        )
         decision: SubAgentDecision
 
-        plugin_config = self._get_plugin_config()
         if (
             plugin_config is not None
             and plugin_config.plugin.enable_programmatic_controller
-            and filter_mode == FilterMode.SUB_ONLY
+            and enable_sub_agent
+            and not enable_interest_filter
         ):
             bypassed, bypass_reason = should_bypass_via_probability(
                 unread_msgs,
@@ -101,9 +101,9 @@ class InterestGate:
                     "source": "probability",
                 }
 
-        if filter_mode == FilterMode.INTEREST_ONLY:
+        if enable_interest_filter and not enable_sub_agent:
             decision = await self._interest_only_decision(unread_msgs, chat_stream)
-        elif filter_mode == FilterMode.INTEREST_THEN_SUB:
+        elif enable_interest_filter and enable_sub_agent:
             interest_result, stats = await self._interest_filter(unread_msgs, chat_stream)
             if not interest_result:
                 decision = {
@@ -116,10 +116,15 @@ class InterestGate:
                 decision = await self._sub_agent_with_context(
                     unreads_text, chat_stream, history_text, decision_history
                 )
-        else:
+        elif enable_sub_agent:
             decision = await self._sub_agent_with_context(
                 unreads_text, chat_stream, history_text, decision_history
             )
+        else:
+            decision = {
+                "reason": "消息过滤均未启用，直接响应",
+                "should_respond": True,
+            }
 
         if not decision.get("should_respond", False):
             calculator = await self._get_interest_calculator()
@@ -133,28 +138,17 @@ class InterestGate:
 
     def _get_plugin_config(self) -> DefaultChatterConfig | None:
         """获取插件配置，类型不匹配时返回 None。"""
-        plugin_config = getattr(self._plugin, "config", None)
+        plugin_config = self._plugin.config
         if isinstance(plugin_config, DefaultChatterConfig):
             return plugin_config
         return None
-
-    def _get_filter_mode(self) -> FilterMode:
-        """读取当前过滤模式配置。"""
-        plugin_config = self._get_plugin_config()
-        if plugin_config is None:
-            return FilterMode.SUB_ONLY
-        mode_str = str(getattr(plugin_config.plugin, "filter_mode", "sub_only") or "sub_only")
-        try:
-            return FilterMode(mode_str)
-        except ValueError:
-            return FilterMode.SUB_ONLY
 
     def _is_sub_agent_context_enabled(self) -> bool:
         """读取 sub-agent 上下文感知开关。"""
         plugin_config = self._get_plugin_config()
         if plugin_config is None:
             return True
-        return bool(getattr(plugin_config.plugin, "enable_sub_agent_context", True))
+        return bool(plugin_config.plugin.enable_sub_agent_context)
 
     async def _interest_only_decision(
         self,

--- a/test/plugins/test_default_chatter_service.py
+++ b/test/plugins/test_default_chatter_service.py
@@ -151,6 +151,8 @@ def test_create_default_session_maps_plugin_config_into_options() -> None:
     assert session.options.enable_cooldown is False
     assert session.options.enable_action_suspend is False
     assert session.options.enable_programmatic_controller is False
+    assert session.options.enable_sub_agent is True
+    assert session.options.enable_interest_filter is False
     assert session.options.enable_sub_agent_collaboration is True
     assert session.options.enable_stop_direct_message_wake is True
     assert session.options.stop_direct_message_wake_probability == 0.25

--- a/test/plugins/test_default_chatter_sub_agent.py
+++ b/test/plugins/test_default_chatter_sub_agent.py
@@ -442,7 +442,7 @@ async def test_sub_agent_interest_only_skips_probability_gate(
 ) -> None:
     """interest_only 模式下不应触发概率直通，应走兴趣值判断。"""
     chatter = _build_chatter_with_config(
-        {"filter_mode": "interest_only", "enable_programmatic_controller": True}
+        {"enable_sub_agent": False, "enable_interest_filter": True, "enable_programmatic_controller": True}
     )
     stream = ChatStream(
         stream_id="s_group",
@@ -496,7 +496,7 @@ async def test_sub_agent_interest_then_sub_skips_probability_gate(
 ) -> None:
     """interest_then_sub 模式下不应触发概率直通，应走兴趣值初筛。"""
     chatter = _build_chatter_with_config(
-        {"filter_mode": "interest_then_sub", "enable_programmatic_controller": True}
+        {"enable_sub_agent": True, "enable_interest_filter": True, "enable_programmatic_controller": True}
     )
     stream = ChatStream(
         stream_id="s_group",
@@ -550,7 +550,7 @@ async def test_sub_agent_sub_only_still_uses_probability_gate(
 ) -> None:
     """sub_only 模式下概率直通仍应生效。"""
     chatter = _build_chatter_with_config(
-        {"filter_mode": "sub_only", "enable_programmatic_controller": True}
+        {"enable_sub_agent": True, "enable_interest_filter": False, "enable_programmatic_controller": True}
     )
     stream = ChatStream(
         stream_id="s_group",


### PR DESCRIPTION
## 改动内容

### 1. 修复 `source="message"` 恢复事件被误分类为未知外部事件

**问题**：停止对话后收到新消息时，框架生成 `source="message"` 的 [`WaitResumeEvent`](src/core/components/base/chatter.py:50)，但 [`DefaultChatterSession`](plugins/default_chatter/session.py:544) 只显式识别 `timer`、`sub_agent` 和 `internal_context`，导致 `message` 落入 [`_build_unknown_resume_prompt()`](plugins/default_chatter/session.py:242)，模型反复看到「收到来自 message 的恢复请求」这类神秘提示词，并可能因此重复调用 `stop_conversation`。

**修复**：让 `source="message"` 跳过未知事件分支，继续走普通未读消息读取和决策流程。

### 2. 将 `filter_mode` 字符串配置改为两个布尔开关

**问题**：原 `filter_mode` 使用字符串枚举（`sub_only` / `interest_only` / `interest_then_sub`），不够直观，且各处通过 `getattr` 读取。

**修复**：
- 新增 [`enable_sub_agent`](plugins/default_chatter/components/config.py:90) 和 [`enable_interest_filter`](plugins/default_chatter/components/config.py:97) 两个布尔开关
- 四种组合语义：
  - 两者关闭：直接响应
  - 仅开启 Sub-Agent：仅由 Sub-Agent 判断
  - 仅开启兴趣值：仅由兴趣值判断
  - 两者同时开启：兴趣值初筛后进入 Sub-Agent
- 删除 [`FilterMode`](plugins/default_chatter/type_defs.py:26) 枚举
- 同步更新 [`InterestGate.decide()`](plugins/default_chatter/utils/interest_gate.py:45) 决策逻辑

### 3. 修正语义兴趣模型自动训练条件

**问题**：原实现通过旧 `filter_mode` 判断是否训练，配置改成布尔开关后如果不更新，兴趣值过滤可能已启用但自动训练仍会错误跳过。

**修复**：只有 `enable_interest_filter=true` 时才启动 [`_maybe_start_semantic_training()`](plugins/default_chatter/plugin.py:327)。

### 4. 清理配置读取中的 `getattr`

按代码规范要求，将所有访问明确类型配置字段的 `getattr` 改为直接属性访问：
- [`DefaultChatterService._build_default_options()`](plugins/default_chatter/components/service.py:78)
- [`DefaultChatter._build_negative_behaviors_extra()`](plugins/default_chatter/plugin.py:88)
- [`DefaultChatterPlugin._maybe_start_semantic_training()`](plugins/default_chatter/plugin.py:327)
- [`DefaultChatterPlugin._background_auto_train()`](plugins/default_chatter/plugin.py:357)
- [`InterestGate._get_plugin_config()`](plugins/default_chatter/utils/interest_gate.py:139)
- [`SendTextAction._get_plugin_config()`](plugins/default_chatter/components/actions/send_text.py:40)
- [`get_plugin_config()`](plugins/default_chatter/sub_agent_management.py:21)

### 5. 同步更新测试

- [`test_default_chatter_sub_agent.py`](test/plugins/test_default_chatter_sub_agent.py)：将 `filter_mode` 测试数据改为 `enable_sub_agent` + `enable_interest_filter` 组合
- [`test_default_chatter_service.py`](test/plugins/test_default_chatter_service.py)：补充新开关的断言

## 影响范围

仅涉及 `default_chatter` 插件，不修改框架代码。

## 已知未纳入本 PR 的问题

`pass_and_wait` 进入等待时吞掉 LLM 执行期间并发到达的新消息的竞态问题，根因在流循环的 Wait 基线记录逻辑（[`src/core/transport/distribution`](src/core/transport/distribution/loop.py:379)），需要单独修复框架代码，不纳入本 PR。

## Summary by Sourcery

Fix default_chatter message resume handling and replace the filter_mode string configuration with explicit boolean switches while aligning related training logic and config access.

New Features:
- Introduce enable_sub_agent and enable_interest_filter switches to control sub-agent and interest-based message filtering combinations.

Bug Fixes:
- Ensure source="message" resume events bypass unknown resume handling and follow the normal unread message decision flow.
- Correct semantic interest model auto-training to run only when interest-based filtering is enabled.

Enhancements:
- Simplify interest_gate decision logic to use the new boolean switches instead of the FilterMode enum and string configuration.
- Remove the FilterMode enum and update DefaultChatterSessionOptions to store boolean flags for sub-agent and interest filtering.
- Replace getattr-based config access patterns with direct, typed attribute access across default_chatter components.

Tests:
- Update default_chatter sub-agent tests to cover the new enable_sub_agent and enable_interest_filter combinations and probability gate behavior.
- Extend default_chatter service tests to assert mapping of the new filtering switches into session options.