### PR TITLE
fix: 概率直通在兴趣值过滤开启时被跳过

### DIFF
--- a/plugins/default_chatter/components/config.py
+++ b/plugins/default_chatter/components/config.py
@@ -289,7 +289,7 @@ class DefaultChatterConfig(BaseConfig):
                 hint="有效范围 0.0-1.0。值越大，群聊中越容易跳过 LLM sub-agent 直接响应。",
             )
             name_mention_bonus: float = Field(
-                default=1.0,
+                default=0.7,
                 description="未读消息存在强提及（被@或被回复）时叠加的放行概率加成。",
                 label="强提及加成",
                 tag="ai",

--- a/plugins/default_chatter/utils/interest_gate.py
+++ b/plugins/default_chatter/utils/interest_gate.py
@@ -50,8 +50,13 @@ class InterestGate:
     ) -> SubAgentDecision:
         """判断当前未读消息是否需要响应。
 
-        根据两个开关决定流程：都关闭时直接响应，仅启用一个时使用对应过滤器，
-        两个都启用时先进行兴趣值初筛，再交给 sub-agent 判断。
+        决策流程（按优先级从前到后）：
+
+        1. 概率直通：当 ``enable_programmatic_controller`` 和 ``enable_sub_agent``
+           同时开启时，先做本地概率判定。命中则直接放行，跳过所有后续过滤。
+        2. 未命中概率直通后，根据 ``enable_interest_filter`` 和 ``enable_sub_agent``
+           两个开关决定后续流程：都关闭时直接响应，仅启用一个时使用对应过滤器，
+           两个都启用时先进行兴趣值初筛，再交给 sub-agent 判断。
 
         Args:
             unreads_text: 格式化后的未读消息文本
@@ -87,7 +92,6 @@ class InterestGate:
             plugin_config is not None
             and plugin_config.plugin.enable_programmatic_controller
             and enable_sub_agent
-            and not enable_interest_filter
         ):
             bypassed, bypass_reason = should_bypass_via_probability(
                 unread_msgs,

--- a/test/plugins/test_default_chatter_sub_agent.py
+++ b/test/plugins/test_default_chatter_sub_agent.py
@@ -491,10 +491,10 @@ async def test_sub_agent_interest_only_skips_probability_gate(
 
 
 @pytest.mark.asyncio
-async def test_sub_agent_interest_then_sub_skips_probability_gate(
+async def test_sub_agent_interest_then_sub_uses_probability_gate_first(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """interest_then_sub 模式下不应触发概率直通，应走兴趣值初筛。"""
+    """interest_then_sub 模式下概率直通作为最前置门控，命中时直接放行。"""
     chatter = _build_chatter_with_config(
         {"enable_sub_agent": True, "enable_interest_filter": True, "enable_programmatic_controller": True}
     )
@@ -507,11 +507,48 @@ async def test_sub_agent_interest_then_sub_skips_probability_gate(
     setattr(stream.context, "_default_chatter_next_tick_bonus", 0.5)
     unread_msgs = [Message(content="hello", processed_plain_text="hello")]
 
-    probability_called = {"value": False}
+    async def _no_decide(**_kwargs: Any) -> dict[str, object]:
+        raise AssertionError("decide_should_respond should not be called when probability bypasses")
 
-    def _fail_bypass(*_args: Any, **_kwargs: Any) -> tuple[bool, str]:
-        probability_called["value"] = True
-        return False, "should not be consulted"
+    monkeypatch.setattr(
+        "plugins.default_chatter.utils.probability_gate.get_core_config",
+        lambda: SimpleNamespace(
+            personality=SimpleNamespace(
+                nickname="Neo",
+                alias_names=["小狐狸"],
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        "plugins.default_chatter.utils.interest_gate.decide_should_respond", _no_decide
+    )
+    monkeypatch.setattr(
+        "plugins.default_chatter.utils.probability_gate.random.random", lambda: 0.0
+    )
+
+    result = await chatter.sub_agent("group-msg", unread_msgs, stream)
+
+    assert result["should_respond"] is True
+    assert result.get("source") == "probability"
+    assert "概率直通响应" in result["reason"]
+
+
+@pytest.mark.asyncio
+async def test_sub_agent_interest_then_sub_falls_through_to_interest_when_probability_misses(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """interest_then_sub 模式下概率直通未命中时，应继续走兴趣值初筛。"""
+    chatter = _build_chatter_with_config(
+        {"enable_sub_agent": True, "enable_interest_filter": True, "enable_programmatic_controller": True}
+    )
+    stream = ChatStream(
+        stream_id="s_group",
+        platform="qq",
+        chat_type="group",
+        bot_nickname="Neo",
+    )
+    setattr(stream.context, "_default_chatter_next_tick_bonus", 0.5)
+    unread_msgs = [Message(content="hello", processed_plain_text="hello")]
 
     async def _no_decide(**_kwargs: Any) -> dict[str, object]:
         raise AssertionError("decide_should_respond should not be called when interest filter rejects")
@@ -526,22 +563,20 @@ async def test_sub_agent_interest_then_sub_skips_probability_gate(
         ),
     )
     monkeypatch.setattr(
-        "plugins.default_chatter.utils.interest_gate.should_bypass_via_probability",
-        _fail_bypass,
-    )
-    monkeypatch.setattr(
         "plugins.default_chatter.utils.interest_gate.decide_should_respond", _no_decide
     )
+    # random.random() 返回 0.99 > base_bypass_probability(0.1) → 概率直通未命中
+    # 不 mock should_bypass_via_probability，让真实逻辑运行以消耗 next_tick_bonus
     monkeypatch.setattr(
-        "plugins.default_chatter.utils.probability_gate.random.random", lambda: 0.0
+        "plugins.default_chatter.utils.probability_gate.random.random", lambda: 0.99
     )
 
     result = await chatter.sub_agent("group-msg", unread_msgs, stream)
 
-    assert probability_called["value"] is False
     assert result.get("source") == "interest"
     assert result["should_respond"] is False
-    assert getattr(stream.context, "_default_chatter_next_tick_bonus", None) == 0.5
+    # 概率门真实执行时会 consume next_tick_bonus，即使未命中也会消耗
+    assert getattr(stream.context, "_default_chatter_next_tick_bonus", None) == 0.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# Fix: 概率直通在兴趣值过滤开启时被跳过

## 改动内容

### 问题

`InterestGate.decide()` 中概率直通的触发条件包含 `not enable_interest_filter`，导致用户同时开启 `enable_programmatic_controller=true` 和 `enable_interest_filter=true` 时，概率直通分支被完全跳过，永远没有机会执行。

### 原因

`interest_gate.py` 第 86-91 行的原条件：

```python
if (
    plugin_config is not None
    and plugin_config.plugin.enable_programmatic_controller
    and enable_sub_agent
    and not enable_interest_filter  # ← 当兴趣值过滤开启时，概率直通被跳过
):
```

### 修复

移除 `not enable_interest_filter` 条件，使概率直通作为最前置的独立门控：

```python
if (
    plugin_config is not None
    and plugin_config.plugin.enable_programmatic_controller
    and enable_sub_agent
):
```

修复后的决策流程（按优先级）：

1. **私聊** → 直接响应（不变）
2. **概率直通**：命中 → 直接放行，跳过所有后续过滤
3. **概率未命中** → 继续走后续过滤：兴趣值过滤 → sub-agent / 直接 sub-agent / 直接响应

### 附带修改

- `name_mention_bonus` 默认值从 `1.0` 改为 `0.7`
- 更新 `decide()` 文档字符串，描述新的级联流程
- 重写 `test_sub_agent_interest_then_sub_skips_probability_gate` 为两个测试：
  - `test_sub_agent_interest_then_sub_uses_probability_gate_first`：验证概率直通命中时直接放行
  - `test_sub_agent_interest_then_sub_falls_through_to_interest_when_probability_misses`：验证概率未命中时继续走兴趣值初筛

## 影响范围

- `plugins/default_chatter/utils/interest_gate.py`
- `plugins/default_chatter/components/config.py`
- `test/plugins/test_default_chatter_sub_agent.py`

## 测试

```bash
pytest test/plugins/test_default_chatter_sub_agent.py -v
ruff check plugins/default_chatter/utils/interest_gate.py
```

## Summary by Sourcery

Ensure the probability gate runs as a front-door bypass before interest filtering in the default chatter sub-agent decision flow, even when interest filtering is enabled.

Bug Fixes:
- Fix probability bypass being skipped whenever interest filtering was enabled in the default chatter interest gate.

Enhancements:
- Adjust the default strong mention probability bonus from 1.0 to 0.7 in the programmatic probability configuration.
- Document the updated decision cascade for the interest gate, including the new probability-first behavior.
- Add repository rules and workflow guidelines under .roo/rules to standardize AI-assisted development practices.
- Add a PR plan document describing this fix and its context under plans/.

Documentation:
- Add a project rules and workflow guide file under .roo/rules/rules.md.
- Add a PR plan document for this change under plans/pr_fix_probability_gate_ignored.md.

Tests:
- Update and split sub-agent interest/probability interaction tests to cover both probability hits (direct bypass) and misses (fall-through to interest filtering), including next_tick_bonus consumption behavior.