### PR TITLE
fix: LLMContextManager 动态 reminder 重复注入

### DIFF
--- a/src/kernel/llm/context.py
+++ b/src/kernel/llm/context.py
@@ -197,6 +197,8 @@ class LLMContextManager:
             for texts in strip_texts_by_type.values()
             for text in texts
         }
+        if not new_parts and not strip_texts:
+            return updated
         for user_index in user_indices:
             user_payload = updated[user_index]
             content_parts = list(user_payload.content)

--- a/src/kernel/llm/context.py
+++ b/src/kernel/llm/context.py
@@ -155,7 +155,7 @@ class LLMContextManager:
 
 
     def _apply_reminders(self, payloads: list[LLMPayload]) -> list[LLMPayload]:
-        """把解析后的 reminder 注入到首个和/或最后一个 user payload。"""
+        """刷新 reminder，使 fixed 与 dynamic 分别只位于首尾 user。"""
         from src.core.prompt import SystemReminderConsumeType, SystemReminderInsertType
 
         updated = list(payloads)
@@ -166,9 +166,6 @@ class LLMContextManager:
             return updated
 
         resolved_reminders, strip_texts_by_type = self._resolve_reminders()
-        if not resolved_reminders:
-            return updated
-
         first_user_index = user_indices[0]
         last_user_index = user_indices[-1]
 
@@ -195,37 +192,25 @@ class LLMContextManager:
             if reminder.consume_type == SystemReminderConsumeType.ONCE:
                 consumed_now.add(reminder.source_key)
 
-        if not new_parts:
-            return updated
-
-        for user_index, prefix_parts in new_parts.items():
+        strip_texts = {
+            text
+            for texts in strip_texts_by_type.values()
+            for text in texts
+        }
+        for user_index in user_indices:
             user_payload = updated[user_index]
             content_parts = list(user_payload.content)
-            target_strip_set: set[str] = set()
 
-            if user_index == first_user_index:
-                target_strip_set.update(
-                    strip_texts_by_type[SystemReminderInsertType.FIXED]
-                )
-            if user_index == last_user_index:
-                target_strip_set.update(
-                    strip_texts_by_type[SystemReminderInsertType.FIXED]
-                )
-                target_strip_set.update(
-                    strip_texts_by_type[SystemReminderInsertType.DYNAMIC]
-                )
+            prefix_end = 0
+            while prefix_end < len(content_parts):
+                part = content_parts[prefix_end]
+                if not isinstance(part, Text) or part.text not in strip_texts:
+                    break
+                prefix_end += 1
+            if prefix_end > 0:
+                content_parts = content_parts[prefix_end:]
 
-            if target_strip_set:
-                prefix_end = 0
-                while prefix_end < len(content_parts):
-                    part = content_parts[prefix_end]
-                    if not isinstance(part, Text) or part.text not in target_strip_set:
-                        break
-                    prefix_end += 1
-                if prefix_end > 0:
-                    content_parts = content_parts[prefix_end:]
-
-            rebuilt = list(prefix_parts) + content_parts
+            rebuilt = list(new_parts.get(user_index, [])) + content_parts
             updated[user_index] = LLMPayload(ROLE.USER, rebuilt)
 
         self._consumed_once_reminder_keys.update(consumed_now)

--- a/test/core/test_components_base_chatter.py
+++ b/test/core/test_components_base_chatter.py
@@ -181,8 +181,7 @@ class TestBaseChatter:
         request.add_payload(LLMPayload(ROLE.ASSISTANT, Text("reply")))
         request.add_payload(LLMPayload(ROLE.USER, Text("again")))
 
-        assert cast(Text, request.payloads[0].content[0]).text == "<system_reminder>\n[goal]\nonly once\n</system_reminder>"
-        assert cast(Text, request.payloads[0].content[1]).text == "hello"
+        assert cast(Text, request.payloads[0].content[0]).text == "hello"
         assert cast(Text, request.payloads[2].content[0]).text == "again"
 
         reset_system_reminder_store()

--- a/test/kernel/llm/test_context_manager.py
+++ b/test/kernel/llm/test_context_manager.py
@@ -275,8 +275,7 @@ def test_context_manager_dynamic_bucket_moves_to_new_last_user(reminder_store) -
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("回复")))
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第二条")))
 
-    assert cast(Text, payloads[0].content[0]).text == "[recent]\n只跟最后一条"
-    assert cast(Text, payloads[0].content[1]).text == "第一条"
+    assert cast(Text, payloads[0].content[0]).text == "第一条"
     assert cast(Text, payloads[2].content[0]).text == "[recent]\n只跟最后一条"
     assert cast(Text, payloads[2].content[1]).text == "第二条"
 
@@ -297,8 +296,7 @@ def test_context_manager_fixed_and_dynamic_bucket_reminders_target_different_use
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第二条")))
 
     assert cast(Text, payloads[0].content[0]).text == "[goal]\n固定开头"
-    assert cast(Text, payloads[0].content[1]).text == "[recent]\n最近一条"
-    assert cast(Text, payloads[0].content[2]).text == "第一条"
+    assert cast(Text, payloads[0].content[1]).text == "第一条"
     assert cast(Text, payloads[2].content[0]).text == "[recent]\n最近一条"
     assert cast(Text, payloads[2].content[1]).text == "第二条"
 
@@ -317,8 +315,7 @@ def test_context_manager_reminder_bucket_refreshes_updated_dynamic_content() -> 
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("回复")))
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第二条")))
 
-    assert cast(Text, payloads[0].content[0]).text == "<system_reminder>\n[screen]\n第一次\n</system_reminder>"
-    assert cast(Text, payloads[0].content[1]).text == "第一条"
+    assert cast(Text, payloads[0].content[0]).text == "第一条"
     assert cast(Text, payloads[2].content[0]).text == "<system_reminder>\n[screen]\n第二次\n</system_reminder>"
     assert cast(Text, payloads[2].content[1]).text == "第二条"
 
@@ -342,10 +339,8 @@ def test_context_manager_dynamic_bucket_multiple_updates_do_not_accumulate() -> 
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("回复二")))
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第三条")))
 
-    assert cast(Text, payloads[0].content[0]).text == "<system_reminder>\n[screen]\n第一次\n</system_reminder>"
-    assert cast(Text, payloads[0].content[1]).text == "第一条"
-    assert cast(Text, payloads[2].content[0]).text == "<system_reminder>\n[screen]\n第二次\n</system_reminder>"
-    assert cast(Text, payloads[2].content[1]).text == "第二条"
+    assert cast(Text, payloads[0].content[0]).text == "第一条"
+    assert cast(Text, payloads[2].content[0]).text == "第二条"
     assert cast(Text, payloads[4].content[0]).text == "<system_reminder>\n[screen]\n第三次\n</system_reminder>"
     assert cast(Text, payloads[4].content[1]).text == "第三条"
     assert len(
@@ -353,7 +348,7 @@ def test_context_manager_dynamic_bucket_multiple_updates_do_not_accumulate() -> 
             part for payload in payloads if payload.role == ROLE.USER for part in payload.content
             if isinstance(part, Text) and part.text.startswith("<system_reminder>\n[screen]\n")
         ]
-    ) == 3
+    ) == 1
 
 
 def test_context_manager_dynamic_bucket_keeps_historical_prefix_stable(reminder_store) -> None:
@@ -377,8 +372,7 @@ def test_context_manager_dynamic_bucket_keeps_historical_prefix_stable(reminder_
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("回复")))
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第二条")))
 
-    assert cast(Text, payloads[0].content[0]).text == "[dynamic_a]\n动态前缀A"
-    assert cast(Text, payloads[0].content[1]).text == "第一条"
+    assert cast(Text, payloads[0].content[0]).text == "第一条"
     assert cast(Text, payloads[2].content[0]).text == "[dynamic_a]\n动态前缀A"
     assert cast(Text, payloads[2].content[1]).text == "[dynamic_b]\n动态前缀B"
     assert cast(Text, payloads[2].content[2]).text == "第二条"
@@ -399,8 +393,7 @@ def test_context_manager_dynamic_once_reminder_is_consumed_per_manager(reminder_
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("reply")))
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("second")))
 
-    assert cast(Text, payloads[0].content[0]).text == "<system_reminder>\n[screen]\nonly once\n</system_reminder>"
-    assert cast(Text, payloads[0].content[1]).text == "first"
+    assert cast(Text, payloads[0].content[0]).text == "first"
     assert cast(Text, payloads[2].content[0]).text == "second"
 
 
@@ -421,7 +414,7 @@ def test_context_manager_dynamic_once_reminder_isolated_between_managers(reminde
     payloads_a = manager_a.add_payload(payloads_a, LLMPayload(ROLE.USER, Text("again")))
     payloads_b = manager_b.add_payload([], LLMPayload(ROLE.USER, Text("B")))
 
-    assert cast(Text, payloads_a[0].content[0]).text == "<system_reminder>\n[screen]\none shot\n</system_reminder>"
+    assert cast(Text, payloads_a[0].content[0]).text == "A"
     assert cast(Text, payloads_a[2].content[0]).text == "again"
     assert cast(Text, payloads_b[0].content[0]).text == "<system_reminder>\n[screen]\none shot\n</system_reminder>"
     assert cast(Text, payloads_b[0].content[1]).text == "B"
@@ -450,7 +443,7 @@ def test_context_manager_dynamic_once_reminder_reappears_after_content_refresh(r
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("reply")))
     payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("two")))
 
-    assert cast(Text, payloads[0].content[0]).text == "<system_reminder>\n[screen]\nversion 1\n</system_reminder>"
+    assert cast(Text, payloads[0].content[0]).text == "one"
     assert cast(Text, payloads[2].content[0]).text == "<system_reminder>\n[screen]\nversion 2\n</system_reminder>"
     assert cast(Text, payloads[2].content[1]).text == "two"
 
@@ -571,3 +564,26 @@ def test_context_manager_allows_user_after_tool_result() -> None:
         ROLE.TOOL_RESULT,
         ROLE.USER,
     ]
+
+
+def test_context_manager_dynamic_reminder_removed_from_historical_user_when_deleted_from_store() -> None:
+    """动态 reminder 从 store 删除后，所有 USER 上的旧前缀都应被清理。"""
+    reset_system_reminder_store()
+    store = get_system_reminder_store()
+    store.set("actor", "screen", "初始版本", insert_type=SystemReminderInsertType.DYNAMIC)
+
+    manager = make_manager("actor", wrap_with_system_tag=True)
+    payloads: list[LLMPayload] = []
+
+    payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第一条")))
+    assert cast(Text, payloads[0].content[0]).text == "<system_reminder>\n[screen]\n初始版本\n</system_reminder>"
+
+    store.delete("actor", "screen")
+
+    payloads = manager.add_payload(payloads, LLMPayload(ROLE.ASSISTANT, Text("回复")))
+    payloads = manager.add_payload(payloads, LLMPayload(ROLE.USER, Text("第二条")))
+
+    assert cast(Text, payloads[0].content[0]).text == "第一条"
+    assert cast(Text, payloads[2].content[0]).text == "第二条"
+
+    reset_system_reminder_store()

--- a/test/kernel/llm/test_request_types.py
+++ b/test/kernel/llm/test_request_types.py
@@ -134,8 +134,7 @@ def test_create_llm_request_registers_dynamic_once_system_reminder(model_set: Mo
     request.add_payload(LLMPayload(ROLE.ASSISTANT, Text("reply")))
     request.add_payload(LLMPayload(ROLE.USER, Text("again")))
 
-    assert cast(Text, request.payloads[0].content[0]).text == "<system_reminder>\n[goal]\nonly once\n</system_reminder>"
-    assert cast(Text, request.payloads[0].content[1]).text == "hello"
+    assert cast(Text, request.payloads[0].content[0]).text == "hello"
     assert cast(Text, request.payloads[2].content[0]).text == "again"
 
     reset_system_reminder_store()


### PR DESCRIPTION
# 修复 LLMContextManager 动态 reminder 重复注入

## 问题

`cross_stream_relay` 插件的 `<system_reminder>` 块在同一个 LLM 请求上下文中出现两次，内容几乎完全相同（跨流摘要 + 核心指令 + 流列表）。

## 根因

[`LLMContextManager._apply_reminders()`](src/kernel/llm/context.py:157) 在刷新 reminder 时，仅从**首个**和**末个** USER payload 上剥离旧 reminder 前缀，中间历史 USER payload 上残留的旧动态 reminder 不被清理。当 KFC 跨轮持续追加 USER payload 后，旧的动态 reminder 前缀残留在历史 USER 上，与新注入的末尾 USER reminder 形成重复。

## 修复方案

修改 [`_apply_reminders()`](src/kernel/llm/context.py:157) 的剥离逻辑：遍历**所有** USER payload（而非仅首尾），从每个 USER 上剥离所有已知 reminder 文本前缀，然后重新注入——FIXED reminder 仅注入到首个 USER，DYNAMIC reminder 仅注入到末个 USER。

### 行为变化

| 场景 | 修复前 | 修复后 |
|------|--------|--------|
| 动态 reminder 内容更新 | 历史 USER 保留旧版本 | 所有 USER 旧版本被清除，仅末尾 USER 有最新版本 |
| ONCE reminder 消费后 | 历史 USER 保留已消费的 reminder | 所有 USER 上已消费的 reminder 被清除 |
| reminder 从 store 删除 | 历史 USER 保留已删除的 reminder | 所有 USER 上残留被清除 |

## 改动文件

| 文件 | 改动 |
|------|------|
| [`src/kernel/llm/context.py`](src/kernel/llm/context.py:157) | 核心修复：`_apply_reminders()` 剥离所有 USER 的旧 reminder 前缀 |
| [`test/kernel/llm/test_context_manager.py`](test/kernel/llm/test_context_manager.py:1) | 更新 6 个测试预期 + 新增 1 个删除场景测试 |
| [`test/kernel/llm/test_request_types.py`](test/kernel/llm/test_request_types.py:1) | 更新 1 个测试预期 |
| [`test/core/test_components_base_chatter.py`](test/core/test_components_base_chatter.py:1) | 更新 1 个测试预期 |

## 测试

```bash
uv run pytest test/kernel/llm/test_context_manager.py test/kernel/llm/test_request_types.py test/core/test_components_base_chatter.py -v
uv run ruff check src/kernel/llm/context.py
```

- 98 passed, 1 failed（pre-existing：`count_payload_tokens` monkeypatch 问题，与本次修复无关）
- Ruff: All checks passed

## 验证方式

1. 启动 bot，在跨聊天流场景下触发 `cross_stream_relay` 摘要同步
2. 检查 LLM 请求上下文中是否只有一个 `<system_reminder>` 块（位于末尾 USER）
3. 多轮对话后确认历史 USER 上不再残留旧 reminder

## Summary by Sourcery

Ensure LLMContextManager refreshes system reminders so fixed reminders only appear on the first USER message and dynamic reminders only on the last USER message in a request context.

Bug Fixes:
- Prevent dynamic system reminders from being duplicated across historical USER payloads when reminders are refreshed or updated.
- Clear once-consumed or deleted dynamic reminders from all historical USER payloads so they no longer appear in subsequent turns.

Enhancements:
- Unify reminder stripping logic to scan all USER payloads and rebuild their content with the correct reminder placement.

Tests:
- Update existing context manager, request-type, and chatter component tests to reflect the new reminder placement behavior and add coverage for deleting dynamic reminders from the store.