### PR TITLE
feat(media_manager): 新增全局默认跳过策略，修复原生多模态启动阶段 VLM 空转

### DIFF
--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -322,6 +322,18 @@ class DefaultChatterPlugin(BasePlugin):
             },
         )
 
+        # 原生多模态模式下，注册全局跳过图片 VLM 识别策略
+        # 使 MediaManager 在消息接收阶段就跳过图片识别，避免启动阶段空转
+        plugin_config = self.config
+        if isinstance(plugin_config, DefaultChatterConfig):
+            if plugin_config.plugin.native_multimodal:
+                from src.core.managers.media_manager import get_media_manager
+
+                get_media_manager().set_global_skip_media_types(["image"])
+                logger.info(
+                    "[原生多模态] 已注册全局跳过图片 VLM 识别策略"
+                )
+
         await self._maybe_start_semantic_training()
 
     async def _maybe_start_semantic_training(self) -> None:

--- a/src/core/managers/media_manager.py
+++ b/src/core/managers/media_manager.py
@@ -68,6 +68,9 @@ class MediaManager:
         self._vlm_model_set = None
         # stream_id -> 跳过的媒体类型集合；值为 None 表示跳过所有类型
         self._skip_recognition_streams: dict[str, frozenset[str] | None] = {}
+        # 全局默认跳过策略：对所有 stream 生效，优先级低于 stream 级规则
+        # None 表示跳过所有类型，frozenset() 表示不跳过任何类型
+        self._global_skip_media_types: frozenset[str] | None = frozenset()
         self._initialize_vlm()
         self._initialize_asr()
         self._register_default_recognition_handlers()
@@ -417,6 +420,34 @@ class MediaManager:
         self._skip_recognition_streams.pop(stream_id, None)
         logger.debug(f"已取消跳过识别: stream_id={stream_id[:8]}")
 
+    def set_global_skip_media_types(
+        self,
+        media_types: Iterable[str] | None = None,
+    ) -> None:
+        """设置全局默认跳过策略，对所有聊天流生效。
+
+        优先级低于 stream 级规则：若某 stream 已通过
+        ``skip_recognition_for_stream`` 注册了自己的跳过规则，
+        则该 stream 不受全局策略影响。
+
+        Args:
+            media_types: 要全局跳过的媒体类型集合（如 ``("image",)``）。
+                为 ``None`` 表示跳过所有类型。
+        """
+        if media_types is None:
+            self._global_skip_media_types = None
+            logger.debug("已设置全局跳过识别: 全部类型")
+            return
+        self._global_skip_media_types = frozenset(media_types)
+        logger.debug(
+            f"已设置全局跳过识别: 类型={sorted(self._global_skip_media_types)}"
+        )
+
+    def clear_global_skip_media_types(self) -> None:
+        """清除全局默认跳过策略。"""
+        self._global_skip_media_types = frozenset()
+        logger.debug("已清除全局跳过识别策略")
+
     def should_skip_recognition(
         self,
         stream_id: str,
@@ -424,22 +455,34 @@ class MediaManager:
     ) -> bool:
         """查询指定聊天流是否应跳过媒体识别。
 
+        查询优先级：stream 级规则 > 全局默认策略 > 默认行为（识别）。
+
         Args:
             stream_id: 聊天流 ID
             media_type: 待识别媒体的类型；省略时表示
-                ""该流是否对任意类型注册了跳过""，用于保留旧的整流粒度语义。
+                "该流是否对任意类型注册了跳过"，用于保留旧的整流粒度语义。
 
         Returns:
             True 表示该聊天流（针对给定媒体类型）应跳过识别
         """
-        if stream_id not in self._skip_recognition_streams:
-            return False
-        types = self._skip_recognition_streams[stream_id]
-        if types is None:
+        # 1. 先查 stream 级规则
+        if stream_id in self._skip_recognition_streams:
+            types = self._skip_recognition_streams[stream_id]
+            if types is None:
+                return True
+            if media_type is None:
+                return True
+            return media_type in types
+
+        # 2. stream 级未命中，回退到全局策略
+        # None 表示全局跳过所有类型；空 frozenset 表示不跳过任何类型
+        if self._global_skip_media_types is None:
             return True
+        if not self._global_skip_media_types:
+            return False
         if media_type is None:
             return True
-        return media_type in types
+        return media_type in self._global_skip_media_types
 
     # ──────────────────────────────────────────
     # 公共 API：媒体识别

--- a/test/core/managers/test_media_manager.py
+++ b/test/core/managers/test_media_manager.py
@@ -13,10 +13,12 @@
 
 from __future__ import annotations
 
-import pytest
+import base64
+from collections.abc import Iterator
 from contextlib import asynccontextmanager
 from unittest.mock import AsyncMock, MagicMock, patch
-import base64
+
+import pytest
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
@@ -140,6 +142,99 @@ class TestMediaManagerSkipRecognition:
 
             assert manager.should_skip_recognition("stream_dfc") is False
             assert manager.should_skip_recognition("stream_dfc", "image") is False
+
+
+class TestMediaManagerGlobalSkipRecognition:
+    """测试全局默认跳过策略。"""
+
+    @pytest.fixture(autouse=True)
+    def _mock_core_config(self) -> Iterator[MagicMock]:
+        """为所有测试 mock get_core_config，避免初始化依赖。"""
+        with patch('src.core.managers.media_manager.get_core_config') as mock:
+            mock.return_value = MagicMock()
+            yield mock
+
+    def test_global_skip_takes_effect_when_no_stream_rule(self) -> None:
+        """全局策略生效：未注册 stream 级规则时，全局策略命中。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.set_global_skip_media_types(("image",))
+
+            # 未注册 stream 级规则的 stream，回退到全局策略
+            assert manager.should_skip_recognition("any_stream", "image") is True
+            assert manager.should_skip_recognition("any_stream", "emoji") is False
+            assert manager.should_skip_recognition("any_stream", "voice") is False
+
+    def test_global_skip_all_types(self) -> None:
+        """全局策略设为 None 时跳过所有媒体类型。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.set_global_skip_media_types(None)
+
+            assert manager.should_skip_recognition("any_stream", "image") is True
+            assert manager.should_skip_recognition("any_stream", "emoji") is True
+            assert manager.should_skip_recognition("any_stream", "voice") is True
+            # 整流粒度查询也返回 True
+            assert manager.should_skip_recognition("any_stream") is True
+
+    def test_global_skip_without_media_type_param(self) -> None:
+        """全局策略注册后，省略 media_type 也返回 True。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.set_global_skip_media_types(("image",))
+
+            # 整流粒度查询：只要全局注册过任意类型，都视为跳过
+            assert manager.should_skip_recognition("any_stream") is True
+
+    def test_stream_level_overrides_global(self) -> None:
+        """stream 级规则优先于全局策略，不回退全局。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            # 全局跳过 image，stream 级跳过 voice
+            manager.set_global_skip_media_types(("image",))
+            manager.skip_recognition_for_stream("stream_42", ("voice",))
+
+            # stream 级规则已注册，不回退全局
+            assert manager.should_skip_recognition("stream_42", "image") is False
+            assert manager.should_skip_recognition("stream_42", "voice") is True
+            # 整流粒度：stream 级注册过任意类型
+            assert manager.should_skip_recognition("stream_42") is True
+
+    def test_clear_global_skip_restores_default(self) -> None:
+        """清除全局策略后恢复默认行为（识别）。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.set_global_skip_media_types(("image",))
+            assert manager.should_skip_recognition("any_stream", "image") is True
+
+            manager.clear_global_skip_media_types()
+            assert manager.should_skip_recognition("any_stream", "image") is False
+            assert manager.should_skip_recognition("any_stream") is False
+
+    def test_global_skip_default_is_empty(self) -> None:
+        """初始化后全局策略默认为空（不跳过任何类型）。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            assert manager.should_skip_recognition("any_stream", "image") is False
+            assert manager.should_skip_recognition("any_stream", "emoji") is False
+            assert manager.should_skip_recognition("any_stream") is False
+
+    def test_global_skip_does_not_affect_stream_with_its_own_rule(self) -> None:
+        """已注册 stream 级 all-type 跳过规则不受全局策略影响。"""
+        with patch('src.core.managers.media_manager.get_model_set_by_task'):
+            manager = MediaManager()
+
+            manager.set_global_skip_media_types(("image",))
+            manager.skip_recognition_for_stream("stream_kfc")  # 跳过所有类型
+
+            assert manager.should_skip_recognition("stream_kfc", "image") is True
+            assert manager.should_skip_recognition("stream_kfc", "emoji") is True
 
 
 class TestMediaManagerRecognizeMedia:


### PR DESCRIPTION
## 改动内容

在 `MediaManager` 中新增"全局默认跳过策略"层，解决原生多模态模式下启动阶段图片仍被 VLM 处理的问题。

### 背景

`DefaultChatterSession.execute_with_stream()` 在 session 创建后才注册 stream 级跳过规则（`skip_recognition_for_stream`），但 VLM 识别在 `MessageConverter.envelope_to_message()` 中已提前执行，导致启动阶段图片仍触发 VLM 空转。

### 改动

1. **`src/core/managers/media_manager.py`**（框架层）
   - `__init__` 新增 `_global_skip_media_types` 字段（`frozenset[str] | None`）
   - 新增 `set_global_skip_media_types()` 和 `clear_global_skip_media_types()` 公开 API
   - 修改 `should_skip_recognition()` 增加 stream 级未命中时回退到全局策略的逻辑
   - 优先级：stream 级规则 > 全局策略 > 默认行为（识别）

2. **`plugins/default_chatter/plugin.py`**（插件层）
   - `on_plugin_loaded()` 中检查 `native_multimodal=True` 时调用 `set_global_skip_media_types(["image"])`

3. **`test/core/managers/test_media_manager.py`**
   - 新增 `TestMediaManagerGlobalSkipRecognition` 测试类，7 个测试覆盖全局策略生效、stream 级优先、清除恢复默认等场景

### 设计要点

- 框架只提供 API，不感知插件配置结构
- 插件自己在 `on_plugin_loaded` 中根据自身配置决定是否注册全局策略
- 现有 3 个调用方（`session.py`、`framework_compat.py`、测试 mock）完全不需要改动
- `converter.py` 不需要改动，`should_skip_recognition()` 的回退逻辑自动生效

### 测试

- `ruff check`：全部通过
- `pytest TestMediaManagerGlobalSkipRecognition`：7/7 通过

## Summary by Sourcery

Introduce a global media recognition skip policy layer and integrate it with the default_chatter plugin to avoid unnecessary VLM processing during native multimodal startup.

New Features:
- Add a global default media skip policy in MediaManager that applies across streams with lower priority than per-stream rules.
- Register a global image-skip policy for VLM in native multimodal mode in the default_chatter plugin to avoid startup-stage image processing.

Bug Fixes:
- Prevent VLM from unnecessarily processing images during the startup phase in native multimodal mode by applying the global skip policy early.

Tests:
- Add a MediaManager global skip recognition test suite covering default behavior, global-all, stream override, and clearing of global policy scenarios.