### PR TITLE
fix(default_chatter): 修复 pass_and_wait 竞态导致执行期间新消息被忽略

### DIFF
--- a/plugins/default_chatter/session.py
+++ b/plugins/default_chatter/session.py
@@ -825,15 +825,26 @@ class DefaultChatterSession:
                     continue
 
                 if call_outcome.should_wait:
-                    _append_suspend_payload_if_tool_result_tail(
-                        response=llm_response,
-                        suspend_text=self.suspend_text,
-                        session=self,
-                    )
-                    resume_event = yield Wait(
-                        time=call_outcome.wait_seconds,
-                        step_data=_consume_actor_round_step_data(state),
-                    )
+                    # LLM 执行期间可能有新消息入队（竞态）：
+                    # 若此时已有新未读消息，跳过 yield Wait，直接回到 WAIT_USER，
+                    # 下一轮循环会正常读取并处理这些消息，不会被 Wait 基线吸收。
+                    _, fresh_unreads = await self.adapters.unread_adapter.fetch_unreads()
+                    if fresh_unreads:
+                        self.logger.debug(
+                            f"pass_and_wait 前检测到 {len(fresh_unreads)} 条新消息，"
+                            "跳过等待直接进入下一轮"
+                        )
+                        _consume_actor_round_step_data(state)
+                    else:
+                        _append_suspend_payload_if_tool_result_tail(
+                            response=llm_response,
+                            suspend_text=self.suspend_text,
+                            session=self,
+                        )
+                        resume_event = yield Wait(
+                            time=call_outcome.wait_seconds,
+                            step_data=_consume_actor_round_step_data(state),
+                        )
                 else:
                     _consume_actor_round_step_data(state)
                 _transition(


### PR DESCRIPTION
# fix(default_chatter): 修复 pass_and_wait 竞态导致 LLM 执行期间新消息被忽略

## 改动内容

在 `plugins/default_chatter/session.py` 的 `should_wait` 分支中，`yield Wait` 之前增加一次未读消息二次检查。

## 原因

当 chatter 的 LLM 因计时器或 silence 触发被唤醒，执行 MODEL_TURN 期间（通常 1~10 秒），用户恰好发来新消息，且 LLM 最终返回 `action-pass_and_wait` 时，消息会被 Wait 基线吸收而无法触发唤醒。

竞态链路：
1. Tick 开头 `fetch_unreads()` 读取未读（此时为空）
2. LLM 执行 1~10 秒，期间新消息入队 `context.unread_messages`
3. LLM 返回 `action-pass_and_wait` → `should_wait=True`
4. chatter 执行 `yield Wait`
5. 外部 loop 记录基线 `unread_count_at_yield = len(context.unread_messages)`（此时已包含竞态期间入队的消息）
6. 恢复条件 `unread_count_now <= unread_count_at_yield` 永远为 False
7. 消息被"吸收"，只能等 timer 到期

## 修复方案

在 `yield Wait` 之前调用 `fetch_unreads()` 二次检查：
- **有新消息**：跳过 `yield Wait`，不注入 SUSPEND 占位符，直接 `continue` 回循环开头正常处理
- **无新消息**：保持原逻辑，注入 SUSPEND + `yield Wait`

相比最初方案的改进：把 `_append_suspend_payload_if_tool_result_tail()` 移到 `else` 分支内，只在真正 Wait 时才注入 SUSPEND，避免跳过 Wait 时在上下文尾部留下孤立占位符。

## 影响范围

仅影响 `default_chatter` 插件的 `action-pass_and_wait` 控制流。不影响纯文本返回、force_reply、sub_agent 决策、冷却逻辑及其他插件。

## 测试

- `ruff check` 通过
- `pytest test/plugins/default_chatter/` 32 个测试全部通过
- 实际运行验证：日志确认 `pass_and_wait 前检测到 2 条新消息，跳过等待直接进入下一轮`，消息在下一轮被正常处理

## Summary by Sourcery

Handle race conditions in default_chatter when using pass_and_wait so that user messages arriving during LLM execution are not ignored.

Bug Fixes:
- Ensure messages that arrive while the LLM is executing and then returns pass_and_wait are correctly processed instead of being absorbed by the wait baseline.
- Skip waiting and suspension injection when fresh unread messages are detected before yielding Wait in the default_chatter session control flow.