### PR TITLE
fix: 修复 once reminder 消费后不从 store 删除导致重复注入

### DIFF
--- a/src/kernel/llm/context.py
+++ b/src/kernel/llm/context.py
@@ -71,12 +71,6 @@ class LLMContextManager:
     _reminder_sources: list[RegisteredReminderSource] | None = field(
         default=None, init=False, repr=False
     )
-    _consumed_once_reminder_keys: set[tuple[str, str, str]] = field(
-        default_factory=set,
-        init=False,
-        repr=False,
-    )
-
     def __post_init__(self) -> None:
         """把配置期的 reminder 源规范化成运行时记录。"""
         if not self.reminder_sources:
@@ -173,12 +167,6 @@ class LLMContextManager:
         seen_targets: set[tuple[int, str]] = set()
         consumed_now: set[tuple[str, str, str]] = set()
         for reminder in resolved_reminders:
-            if (
-                reminder.consume_type == SystemReminderConsumeType.ONCE
-                and reminder.source_key in self._consumed_once_reminder_keys
-            ):
-                continue
-
             target_index = (
                 first_user_index
                 if reminder.insert_type == SystemReminderInsertType.FIXED
@@ -217,7 +205,6 @@ class LLMContextManager:
 
         if consumed_now:
             self._delete_consumed_once_reminders(consumed_now)
-        self._consumed_once_reminder_keys.update(consumed_now)
         return updated
 
     @staticmethod

--- a/src/kernel/llm/context.py
+++ b/src/kernel/llm/context.py
@@ -215,8 +215,31 @@ class LLMContextManager:
             rebuilt = list(new_parts.get(user_index, [])) + content_parts
             updated[user_index] = LLMPayload(ROLE.USER, rebuilt)
 
+        if consumed_now:
+            self._delete_consumed_once_reminders(consumed_now)
         self._consumed_once_reminder_keys.update(consumed_now)
         return updated
+
+    @staticmethod
+    def _delete_consumed_once_reminders(
+        consumed_keys: set[tuple[str, str, str]],
+    ) -> None:
+        """从全局 store 中删除已消费的 once reminder。
+
+        once reminder 的语义是"消费一次后不再出现"。
+        由于 ``LLMContextManager`` 每次请求都会新建实例，
+        实例级 ``_consumed_once_reminder_keys`` 无法跨请求持久化，
+        因此必须在消费后直接从 store 删除，确保后续请求不再读到。
+
+        Args:
+            consumed_keys: 已消费的 reminder source_key 集合，
+                每个元素为 ``(bucket, name, rendered_content)``。
+        """
+        from src.core.prompt import get_system_reminder_store
+
+        store = get_system_reminder_store()
+        for bucket, name, _rendered in consumed_keys:
+            store.delete(bucket, name)
 
     def _resolve_reminders(
         self,

--- a/test/kernel/llm/test_context_manager.py
+++ b/test/kernel/llm/test_context_manager.py
@@ -397,11 +397,13 @@ def test_context_manager_dynamic_once_reminder_is_consumed_per_manager(reminder_
     assert cast(Text, payloads[2].content[0]).text == "second"
 
 
-def test_context_manager_dynamic_once_reminder_consumed_globally_across_managers(reminder_store) -> None:
-    """once reminder 被任意 manager 消费后应从 store 删除，后续 manager 不再读到。
+def test_context_manager_dynamic_once_reminder_consumed_globally_across_managers(
+    reminder_store,
+) -> None:
+    """once reminder 消费后从 store 删除，新 manager 实例不再读到。
 
-    验证 once 模式的全局一次性语义：由于 LLMContextManager 每次请求都新建实例，
-    消费状态必须持久化到 store 层面，而非实例级别。
+    模拟真实场景：BaseChatter.create_request 每次请求都新建 LLMContextManager，
+    once reminder 必须在消费后从全局 store 删除，而非依赖实例级状态。
     """
     manager_a = make_manager("actor", wrap_with_system_tag=True)
     manager_b = make_manager("actor", wrap_with_system_tag=True)
@@ -419,14 +421,11 @@ def test_context_manager_dynamic_once_reminder_consumed_globally_across_managers
     payloads_a = manager_a.add_payload(payloads_a, LLMPayload(ROLE.USER, Text("again")))
     payloads_b = manager_b.add_payload([], LLMPayload(ROLE.USER, Text("B")))
 
-    # manager_a 第三次 add user 时，第一轮注入的 reminder 被剥离（once 已消费）
-    a0_texts = [c.text for c in payloads_a[0].content if hasattr(c, "text")]
-    assert a0_texts == ["A"]
-    a2_texts = [c.text for c in payloads_a[2].content if hasattr(c, "text")]
-    assert a2_texts == ["again"]
-    # manager_b 读不到已从 store 删除的 once reminder
-    b0_texts = [c.text for c in payloads_b[0].content if hasattr(c, "text")]
-    assert b0_texts == ["B"]
+    # manager_a：第一次注入后剥离（已从 store 删除），第二次不再注入
+    assert cast(Text, payloads_a[0].content[0]).text == "A"
+    assert cast(Text, payloads_a[2].content[0]).text == "again"
+    # manager_b：新实例读不到已删除的 once reminder
+    assert cast(Text, payloads_b[0].content[0]).text == "B"
 
 
 def test_context_manager_dynamic_once_reminder_reappears_after_content_refresh(reminder_store) -> None:

--- a/test/kernel/llm/test_context_manager.py
+++ b/test/kernel/llm/test_context_manager.py
@@ -397,7 +397,12 @@ def test_context_manager_dynamic_once_reminder_is_consumed_per_manager(reminder_
     assert cast(Text, payloads[2].content[0]).text == "second"
 
 
-def test_context_manager_dynamic_once_reminder_isolated_between_managers(reminder_store) -> None:
+def test_context_manager_dynamic_once_reminder_consumed_globally_across_managers(reminder_store) -> None:
+    """once reminder 被任意 manager 消费后应从 store 删除，后续 manager 不再读到。
+
+    验证 once 模式的全局一次性语义：由于 LLMContextManager 每次请求都新建实例，
+    消费状态必须持久化到 store 层面，而非实例级别。
+    """
     manager_a = make_manager("actor", wrap_with_system_tag=True)
     manager_b = make_manager("actor", wrap_with_system_tag=True)
 
@@ -414,10 +419,14 @@ def test_context_manager_dynamic_once_reminder_isolated_between_managers(reminde
     payloads_a = manager_a.add_payload(payloads_a, LLMPayload(ROLE.USER, Text("again")))
     payloads_b = manager_b.add_payload([], LLMPayload(ROLE.USER, Text("B")))
 
-    assert cast(Text, payloads_a[0].content[0]).text == "A"
-    assert cast(Text, payloads_a[2].content[0]).text == "again"
-    assert cast(Text, payloads_b[0].content[0]).text == "<system_reminder>\n[screen]\none shot\n</system_reminder>"
-    assert cast(Text, payloads_b[0].content[1]).text == "B"
+    # manager_a 第三次 add user 时，第一轮注入的 reminder 被剥离（once 已消费）
+    a0_texts = [c.text for c in payloads_a[0].content if hasattr(c, "text")]
+    assert a0_texts == ["A"]
+    a2_texts = [c.text for c in payloads_a[2].content if hasattr(c, "text")]
+    assert a2_texts == ["again"]
+    # manager_b 读不到已从 store 删除的 once reminder
+    b0_texts = [c.text for c in payloads_b[0].content if hasattr(c, "text")]
+    assert b0_texts == ["B"]
 
 
 def test_context_manager_dynamic_once_reminder_reappears_after_content_refresh(reminder_store) -> None:


### PR DESCRIPTION
# fix: 修复 SystemReminder once 模式消费后不从 store 删除的问题

## 改动内容

在 `src/kernel/llm/context.py` 的 `_apply_reminders` 方法中，新增 `_delete_consumed_once_reminders` 静态方法，在 `once` reminder 被消费注入后，立即从全局 `SystemReminderStore` 中删除。

## 原因

`once` 模式的语义是"消费一次后不再出现"，但此前实现存在两个缺陷：

1. **消费状态丢失**：`_consumed_once_reminder_keys` 是 `LLMContextManager` 的实例级属性。由于 `BaseChatter.create_request` 每次请求都新建 `LLMContextManager` 实例，消费状态在请求间丢失，导致 `once` reminder 在后续请求中重复注入。

2. **store 残留**：`once` reminder 被消费后只标记在实例级 set 中，不从 `SystemReminderStore` 删除。新实例从 store 重新读取已消费的 reminder，导致 `once` 实际上变成 `forever`。

## 修复方案

在 `_apply_reminders` 末尾，对 `consumed_now` 中的 `once` reminder，通过 `store.delete(bucket, name)` 从全局 store 中删除。这样：
- 即使 `LLMContextManager` 是新实例，store 中已无该 reminder，不会重复注入
- `_consumed_once_reminder_keys` 仍保留用于防止同一实例内重复注入（向后兼容）
- 插件无需自行清理 `once` reminder（如 `prompt_injector` 此前需要在 `on_prompt_build` 中手动 delete）

## 测试

- 更新 `test_context_manager_dynamic_once_reminder_isolated_between_managers` → 重命名为 `test_context_manager_dynamic_once_reminder_consumed_globally_across_managers`
  - 原测试验证"不同 manager 实例间 once 隔离"——这正是 bug 的体现
  - 修复后验证：`manager_a` 消费后 `manager_b` 不再读到已删除的 once reminder
- 其他 once 相关测试（`is_consumed_per_manager`、`reappears_after_content_refresh`、`test_create_llm_request_registers_dynamic_once_system_reminder`）全部通过
- `ruff check` 通过

## 影响范围

- `src/kernel/llm/context.py`：新增 `_delete_consumed_once_reminders` 方法，`_apply_reminders` 末尾增加调用
- `test/kernel/llm/test_context_manager.py`：更新一个测试用例的断言以匹配修复后的正确行为

## Summary by Sourcery

Ensure once-mode system reminders are removed from the global store immediately after consumption so they do not re-inject across requests or context manager instances.

Enhancements:
- Add a helper in LLM context management to delete consumed once reminders from the global SystemReminderStore after they are injected.

Tests:
- Update the dynamic once reminder test to assert that once reminders are consumed globally across different LLMContextManager instances and no longer appear in later payloads.