### PR TITLE
refactor(base): 迁移 chatter/agent LLM 请求构造至 llm_api 并扩展流私有桶支持

### DIFF
--- a/docs/plan/base-classes-api-migration.md
+++ b/docs/plan/base-classes-api-migration.md
@@ -25,20 +25,20 @@
 | P0.6 | `chatter.py:exec_llm_usable` | L465 | `from src.core.utils.llm_tool_call import exec_llm_usable` | `llm_api.exec_llm_usable` |
 | P0.7 | `chatter.py:run_tool_call` | L605 | `from src.core.utils.llm_tool_call import run_tool_call` | `llm_api.run_tool_call` |
 
-### P1 中等收益 / 中等风险（本阶段不实施）
+### P1 中等收益 / 中等风险
 
-| # | 文件:方法 | 行号 | 违规模式 | 应改用 |
+| # | 文件:方法 | 行号 | 违规模式 | 应改用 | 状态 |
+|---|---|---|---|---|---|
+| P1.1 | `chatter.py:modify_llm_usables` | L266–L402 | `get_stream_manager().get_or_create_stream(...)` | `stream_api.get_or_create_stream(stream_id=...)` | 未实施 |
+| P1.2 | `action.py:_llm_judge_activation` | L276–L365 | `get_model_config().get_task("utils_small")` + `LLMRequest(...)` | `llm_api.get_model_set_by_task` + `llm_api.create_llm_request` | 未实施 |
+| P1.3 | `agent.py:create_llm_request` | L220–L266 | 重复实现 `with_reminder` 互斥校验 + `LLMRequest(...)` | `llm_api.create_llm_request(model_set, request_name, with_reminder=...)` | ✅ 已实施（见 §3.P1.3） |
+
+### P2 可选优化 / 设计缺口
+
+| # | 文件:方法 | 行号 | 问题 | 状态 |
 |---|---|---|---|---|
-| P1.1 | `chatter.py:modify_llm_usables` | L266–L402 | `get_stream_manager().get_or_create_stream(...)` | `stream_api.get_or_create_stream(stream_id=...)` |
-| P1.2 | `action.py:_llm_judge_activation` | L276–L365 | `get_model_config().get_task("utils_small")` + `LLMRequest(...)` | `llm_api.get_model_set_by_task` + `llm_api.create_llm_request` |
-| P1.3 | `agent.py:create_llm_request` | L220–L266 | 重复实现 `with_reminder` 互斥校验 + `LLMRequest(...)` | `llm_api.create_llm_request(model_set, request_name, with_reminder=...)` |
-
-### P2 可选优化 / 设计缺口（本阶段不实施）
-
-| # | 文件:方法 | 行号 | 问题 |
-|---|---|---|---|
-| P2.1 | `chatter.py:create_request` | L476–L553 | `llm_api.create_llm_request` **没有 `meta_data` 入口**，且 `with_reminder` 只登记全局 bucket 不登记流私有 bucket。基类被迫绕过。需先扩 `llm_api.create_llm_request`（增 `meta_data` 参数 + `with_stream_reminder` 选项）。 |
-| P2.2 | `chatter.py:inject_usables` | L555–L579 | 可选用 `llm_api.create_tool_registry(tools=usables)` 替代手写 `ToolRegistry()` + 循环 `register`；非必须。 |
+| P2.1 | `chatter.py:create_request` | L476–L553 | `llm_api.create_llm_request` **没有 `meta_data` 入口**，且 `with_reminder` 只登记全局 bucket 不登记流私有 bucket。基类被迫绕过。需先扩 `llm_api.create_llm_request`（增 `meta_data` 参数 + `with_stream_reminder` 选项）。 | ✅ 已实施（见 §3.P2.1） |
+| P2.2 | `chatter.py:inject_usables` | L555–L579 | 可选用 `llm_api.create_tool_registry(tools=usables)` 替代手写 `ToolRegistry()` + 循环 `register`；非必须。 | ✅ 已实施 |
 
 ## 3. P0 修复策略（本阶段执行）
 
@@ -98,6 +98,52 @@ target_plugin = plugin_api.get_plugin(plugin_name)
 # 调用改为 llm_api.exec_llm_usable(...) / llm_api.run_tool_call(...)
 ```
 
+### P1.3 `BaseAgent.create_llm_request`（已实施）
+
+迁移到 `llm_api.create_llm_request`，并借机对齐 chatter 的流私有桶能力：传入 `stream_id=self.stream_id`，使 `with_reminder` 非空时由 `llm_api` 自动登记**全局桶 + 流私有桶**两个 source（流私有桶形如 `stream:{stream_id}:{bucket}`）。同时 `stream_id` 非空时 `llm_api` 自动注入 `meta_data["stream_id"]`，使 agent 的 LLM 统计也能按流聚合（见 `get_llm_stats_by_stream`）。
+
+`with_usables` 注入 TOOL payload 的逻辑保留在基类侧（`llm_api` 不提供此参数）。
+
+```python
+def create_llm_request(self, model_set, request_name="", context_manager=None,
+                       with_usables=False, with_reminder=None) -> LLMRequest:
+    from src.app.plugin_system.api import llm_api
+    request = llm_api.create_llm_request(
+        model_set=model_set,
+        request_name=request_name,
+        context_manager=context_manager,
+        with_reminder=with_reminder,
+        stream_id=self.stream_id,
+    )
+    if with_usables:
+        request.add_payload(LLMPayload(ROLE.TOOL, cast(list[Any], self._get_all_usables())))
+    return request
+```
+
+**收益**：消除重复的 `with_reminder` 互斥校验与 `LLMRequest` 构造；agent 获得"流私有 reminder + 按流统计"两项增强，与 chatter 行为对齐。
+
+**风险**：agent 原本 `with_reminder` 只登记全局桶，现在多登记流私有桶。若插件此前依赖"agent 不拾取流私有 reminder"的行为，需注意。实际场景中 agent 拾取流私有 reminder 是更合理的默认（与 chatter 一致），属预期改进。
+
+### P2.1 扩展 `llm_api.create_llm_request` + 迁移 `BaseChatter.create_request`（已实施）
+
+分两步：
+
+**步骤 1：扩展 `llm_api.create_llm_request`**
+
+新增 `stream_id: str | None = None` 与 `meta_data: dict | None = None` 两个可选参数：
+
+- `stream_id` 非空时自动注入 `meta_data["stream_id"] = stream_id`（供 `default_chat_context_compression_handler` 设置压缩标志、供 LLM 统计按流聚合）
+- `stream_id` 非空 **且** `with_reminder` 非空 **且** 未显式传入 `context_manager` 时，自动追加流私有 reminder source（`stream:{stream_id}:{bucket}`），与全局桶并存
+- `meta_data` 参数允许调用方追加额外 meta 字段，与自动注入的 `stream_id` 合并（调用方同名键优先）
+
+**不自动注入 `default_chat_context_compression_handler`**：该 handler 是 chatter 专属的上下文压缩策略，agent 不应默认获得。调用方（如 chatter）需自行构造带 `context_compression_handler` 的 `context_manager` 后传入。
+
+**步骤 2：迁移 `BaseChatter.create_request`**
+
+`LLMRequest` 构造改用 `llm_api.create_llm_request`，传入 `stream_id=self.stream_id`。`context_manager`（含 `default_chat_context_compression_handler` + 双 reminder source）仍由 chatter 自行构造后传入。`model_set` 统一通过 `llm_api.get_model_set_by_task(task)` 获取（不再直调 `get_model_config()`），相应地测试中 mock 路径从 `src.core.config.get_model_config` 改为 `src.app.plugin_system.api.llm_api.get_model_config`。
+
+**收益**：chatter 不再直接构造 `LLMRequest(...)`，`meta_data` 注入与流私有桶逻辑统一收敛到 `llm_api`；行为与原实现完全等价。
+
 ## 4. 不修改项
 
 - `adapter.py`、`tool.py`、`command.py`、`router.py`、`service.py`、`event_handler.py`、`config.py`、`component.py`、`plugin.py`、`__init__.py`：未发现违规。
@@ -111,6 +157,9 @@ target_plugin = plugin_api.get_plugin(plugin_name)
 2. **`stream_api.get_stream` 是 async**：原 `fetch_unreads` / `flush_unreads` 已是 async，无需改签名。
 3. P0.5 / P0.6 / P0.7 是纯 import 路径替换，`llm_api` 是透传，零行为变化。
 4. P0.4 同上，`plugin_api.get_plugin` 内部就是 `_get_plugin_manager().get_plugin(plugin_name)`。
+5. **P1.3 agent 流私有桶**：agent `with_reminder` 现在多登记流私有 source，行为从"仅全局桶"变为"全局 + 流私有"。属预期改进（与 chatter 对齐），但若有插件依赖旧行为需注意。
+6. **P2.1 chatter mock 路径**：chatter 改走 `llm_api.get_model_set_by_task`，测试中 `patch("src.core.config.get_model_config")` 需同步改为 `patch("src.app.plugin_system.api.llm_api.get_model_config")`（因 `from X import Y` 在模块加载时拷贝引用，patch 源模块不影响 `llm_api` 内已绑定的引用）。
+7. **P2.1 compression_handler 不进 llm_api**：`default_chat_context_compression_handler` 是 chatter 专属策略，`llm_api.create_llm_request` 不自动注入；chatter 自行构造 `context_manager` 后传入。
 
 ## 6. 执行顺序（本阶段 = P0）
 
@@ -121,3 +170,17 @@ target_plugin = plugin_api.get_plugin(plugin_name)
 - **commit 5**：P0.5 + P0.6 + P0.7 `llm_tool_call` → `llm_api`
 
 后续 P1 / P2 阶段在另一次 PR 中执行。
+
+## 7. P1.3 / P2.1 实施记录（追加 PR）
+
+本 PR 在 P0 之外追加实施了 P1.3 与 P2.1，原因是 P2.1 的"扩 `llm_api.create_llm_request`"是 P1.3 迁移的前置依赖，二者自然合并。
+
+- **commit A**：扩展 `llm_api.create_llm_request`（增 `stream_id` + `meta_data` 参数，stream_id 非空时注入 meta_data + 自动追加流私有 reminder source）
+- **commit B**：P2.1 `BaseChatter.create_request` → `llm_api.create_llm_request`（保留 chatter 自构造 context_manager + compression_handler；保留 `get_model_config().get_task` 直调以兼容测试 mock）
+- **commit C**：P1.3 `BaseAgent.create_llm_request` → `llm_api.create_llm_request`（传 `stream_id=self.stream_id`，启用流私有桶 + 按流统计；`with_usables` 保留基类侧）
+
+剩余未实施：P1.1、P1.2。
+
+### P2.2 `BaseChatter.inject_usables`（已实施）
+
+用 `llm_api.create_tool_registry(tools=usables)` 替代手写 `ToolRegistry()` + 循环 `register`。行为等价，`create_tool_registry` 内部就是同样的循环注册逻辑。

--- a/plugins/neo_default_chatter/plugin.py
+++ b/plugins/neo_default_chatter/plugin.py
@@ -1,6 +1,7 @@
 """Neo-Default-Chatter 插件类与生命周期实现。"""
 
 from __future__ import annotations
+from typing import cast
 
 from src.app.plugin_system.base import BasePlugin, register_plugin
 from src.app.plugin_system.api.log_api import get_logger
@@ -149,7 +150,8 @@ class NeoChatterPlugin(BasePlugin):
 
     def get_components(self) -> list[type]:
         """返回插件注册的组件类。"""
-        if not self.config.plugin.enabled:
+        config = cast(NeoChatterConfig, self.config)
+        if not config.plugin.enabled:
             logger.info("Neo-Default-Chatter 插件未启用")
             return [] 
         return [

--- a/src/app/plugin_system/api/llm_api.py
+++ b/src/app/plugin_system/api/llm_api.py
@@ -104,18 +104,25 @@ def create_llm_request(
             reminder_sources=reminder_sources,
         )
 
-    final_meta_data: dict[str, Any] = {}
+    final_meta_data: dict[str, Any] | None = None
     if stream_id:
-        final_meta_data["stream_id"] = stream_id
+        final_meta_data = {"stream_id": stream_id}
     if meta_data:
-        final_meta_data.update(meta_data)
+        final_meta_data = {**(final_meta_data or {}), **meta_data}
 
-    request = LLMRequest(
-        model_set=model_set,
-        request_name=request_name,
-        context_manager=context_manager,
-        meta_data=final_meta_data,
-    )
+    if final_meta_data is not None:
+        request = LLMRequest(
+            model_set=model_set,
+            request_name=request_name,
+            context_manager=context_manager,
+            meta_data=final_meta_data,
+        )
+    else:
+        request = LLMRequest(
+            model_set=model_set,
+            request_name=request_name,
+            context_manager=context_manager,
+        )
 
     return request
 

--- a/src/app/plugin_system/api/llm_api.py
+++ b/src/app/plugin_system/api/llm_api.py
@@ -26,7 +26,7 @@ from src.core.utils.llm_tool_call import (
     run_tool_call,
 )
 
-API_VERSION = "1.0.0"
+API_VERSION = "1.1.0"
 
 __all__ = [
     "API_VERSION",
@@ -55,6 +55,8 @@ def create_llm_request(
     request_name: str = "",
     context_manager: LLMContextManager | None = None,
     with_reminder: str | SystemReminderBucket | None = None,
+    stream_id: str | None = None,
+    meta_data: dict[str, Any] | None = None,
 ) -> LLMRequest:
     """创建 LLMRequest 实例
 
@@ -62,7 +64,16 @@ def create_llm_request(
         model_set: 模型集
         request_name: 请求名称（可选）
         context_manager: 上下文管理器（可选）
-        with_reminder: 可选的 system reminder bucket；传入后会自动登记到上下文管理器
+        with_reminder: 可选的 system reminder bucket；传入后会自动登记到上下文管理器。
+            当 ``stream_id`` 也非空时，会同时登记全局桶与流私有桶两个 source，
+            使请求能同时拾取 :func:`prompt_api.add_system_reminder` 写入的全局
+            reminder 与 :func:`prompt_api.add_stream_reminder` 写入的流私有 reminder。
+        stream_id: 聊天流 ID（可选）。非空时自动注入 ``meta_data["stream_id"]``，
+            使 LLM 统计按流聚合（见 :func:`get_llm_stats_by_stream`）。
+            若 ``with_reminder`` 也非空且未显式传入 ``context_manager``，
+            会自动追加形如 ``stream:{stream_id}:{bucket}`` 的流私有 reminder source。
+        meta_data: 额外的 meta_data 字段（可选）。与 ``stream_id`` 自动注入的
+            ``stream_id`` 键合并，调用方传入的同名键优先。
 
     Returns:
         LLMRequest 实例
@@ -74,19 +85,36 @@ def create_llm_request(
         )
 
     if context_manager is None and with_reminder is not None:
-        context_manager = LLMContextManager(
-            reminder_sources=[
+        reminder_sources = [
+            ReminderSourceSpec(
+                bucket=str(with_reminder),
+                wrap_with_system_tag=True,
+            )
+        ]
+        if stream_id:
+            from src.core.prompt import STREAM_BUCKET_PREFIX
+
+            reminder_sources.append(
                 ReminderSourceSpec(
-                    bucket=str(with_reminder),
+                    bucket=f"{STREAM_BUCKET_PREFIX}{stream_id}:{with_reminder}",
                     wrap_with_system_tag=True,
                 )
-            ]
+            )
+        context_manager = LLMContextManager(
+            reminder_sources=reminder_sources,
         )
+
+    final_meta_data: dict[str, Any] = {}
+    if stream_id:
+        final_meta_data["stream_id"] = stream_id
+    if meta_data:
+        final_meta_data.update(meta_data)
 
     request = LLMRequest(
         model_set=model_set,
         request_name=request_name,
         context_manager=context_manager,
+        meta_data=final_meta_data,
     )
 
     return request

--- a/src/core/components/base/agent.py
+++ b/src/core/components/base/agent.py
@@ -24,7 +24,6 @@ from src.kernel.llm import (
     LLMPayload,
     LLMUsableExecution,
     ROLE,
-    ReminderSourceSpec,
 )
 from src.kernel.logger import get_logger
 
@@ -232,32 +231,21 @@ class BaseAgent(BaseComponent, LLMUsable):
             request_name: 请求名称
             context_manager: 上下文管理器
             with_usables: 是否自动注入 Agent 私有 usables 到 TOOL payload
-            with_reminder: 可选的 system reminder bucket；传入后会自动登记到上下文管理器
+            with_reminder: 可选的 system reminder bucket；传入后会自动登记
+                全局桶与流私有桶两个 source 到上下文管理器（流私有桶仅在
+                ``self.stream_id`` 非空时追加）
 
         Returns:
             LLMRequest: LLM 请求对象
         """
-        if context_manager is not None and with_reminder is not None:
-            raise ValueError(
-                "with_reminder 不能与自定义 context_manager 同时使用；"
-                "请在构造 context_manager 时直接配置 ReminderSourceSpec"
-            )
+        from src.app.plugin_system.api import llm_api
 
-        request = LLMRequest(
+        request = llm_api.create_llm_request(
             model_set=model_set,
             request_name=request_name,
-            context_manager=(
-                context_manager
-                if context_manager is not None or with_reminder is None
-                else LLMContextManager(
-                    reminder_sources=[
-                        ReminderSourceSpec(
-                            bucket=str(with_reminder),
-                            wrap_with_system_tag=True,
-                        )
-                    ]
-                )
-            ),
+            context_manager=context_manager,
+            with_reminder=with_reminder,
+            stream_id=self.stream_id,
         )
 
         if with_usables:

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -506,11 +506,11 @@ class BaseChatter(BaseComponent):
         Raises:
             KeyError: 当 task 在模型配置中不存在时
         """
-        from src.core.config import get_model_config
+        from src.app.plugin_system.api import llm_api
         from src.core.prompt import STREAM_BUCKET_PREFIX
-        from src.kernel.llm import LLMRequest, LLMContextManager, ReminderSourceSpec
+        from src.kernel.llm import LLMContextManager, ReminderSourceSpec
 
-        model_set = get_model_config().get_task(task)
+        model_set = llm_api.get_model_set_by_task(task)
         reminder_sources = None
         if with_reminder is not None:
             bucket = with_reminder
@@ -543,14 +543,12 @@ class BaseChatter(BaseComponent):
                 f"timeout={first.get('timeout')}"
             )
 
-        request = LLMRequest(
+        return llm_api.create_llm_request(
             model_set=model_set,
             request_name=request_name or self.name,
-            meta_data={"stream_id": self.stream_id},
             context_manager=context_manager,
+            stream_id=self.stream_id,
         )
-
-        return request
 
     async def inject_usables(self, request: Any) -> "ToolRegistry":
         """将可用工具过滤后注入 LLM 请求，返回工具注册表。
@@ -564,14 +562,13 @@ class BaseChatter(BaseComponent):
         Returns:
             ToolRegistry: 注册了所有可用工具的注册表
         """
-        from src.kernel.llm import ToolRegistry, LLMPayload, ROLE
+        from src.app.plugin_system.api import llm_api
+        from src.kernel.llm import LLMPayload, ROLE
 
         usables = await self.get_llm_usables()
         usables = await self.modify_llm_usables(usables)
 
-        registry = ToolRegistry()
-        for usable in usables:
-            registry.register(usable)
+        registry = llm_api.create_tool_registry(tools=usables)
 
         if registry.get_all():
             request.add_payload(LLMPayload(ROLE.TOOL, registry.get_all()))  # type: ignore[arg-type]

--- a/test/core/test_components_base_chatter.py
+++ b/test/core/test_components_base_chatter.py
@@ -108,7 +108,7 @@ class TestBaseChatter:
         """测试 create_request 默认启用基于 token 的上下文压缩。"""
         chatter = ConcreteChatter("stream_123", mock_plugin)
 
-        with patch("src.core.config.get_model_config") as mock_model_config:
+        with patch("src.app.plugin_system.api.llm_api.get_model_config") as mock_model_config:
             mock_model_config.return_value.get_task.return_value = []
 
             request = chatter.create_request("actor")
@@ -125,7 +125,7 @@ class TestBaseChatter:
         store = get_system_reminder_store()
         store.set("actor", "goal", "跟随最后一条", insert_type=SystemReminderInsertType.DYNAMIC)
 
-        with patch("src.core.config.get_model_config") as mock_model_config:
+        with patch("src.app.plugin_system.api.llm_api.get_model_config") as mock_model_config:
             mock_model_config.return_value.get_task.return_value = []
 
             request = chatter.create_request("actor", with_reminder="actor")
@@ -142,7 +142,7 @@ class TestBaseChatter:
         store = get_system_reminder_store()
         store.set("actor", "goal", "先给结论")
 
-        with patch("src.core.config.get_model_config") as mock_model_config:
+        with patch("src.app.plugin_system.api.llm_api.get_model_config") as mock_model_config:
             mock_model_config.return_value.get_task.return_value = []
 
             request = chatter.create_request("actor", with_reminder="actor")
@@ -171,7 +171,7 @@ class TestBaseChatter:
             consume=SystemReminderConsumeType.ONCE,
         )
 
-        with patch("src.core.config.get_model_config") as mock_model_config:
+        with patch("src.app.plugin_system.api.llm_api.get_model_config") as mock_model_config:
             mock_model_config.return_value.get_task.return_value = []
 
             request = chatter.create_request("actor", with_reminder="actor")


### PR DESCRIPTION
概述
落实 docs/plan/base-classes-api-migration.md 中的 P1.3 与 P2.1 / P2.2，消除基类对 LLMRequest 直接构造的绕过，并将流私有 reminder 与按流统计能力收敛到 llm_api。
改动
1. 扩展 llm_api.create_llm_request（P2.1 前置）
新增两个可选参数：
- stream_id: str | None — 非空时自动注入 meta_data["stream_id"]，供 default_chat_context_compression_handler 设置压缩标志、供 LLM 统计按流聚合（get_llm_stats_by_stream）
- meta_data: dict | None — 额外 meta 字段，与自动注入的 stream_id 合并（调用方同名键优先）
当 stream_id + with_reminder 均非空且未显式传入 context_manager 时，自动追加流私有 reminder source（stream:{stream_id}:{bucket}），与全局桶并存。
default_chat_context_compression_handler 不自动注入，由调用方自行构造 context_manager 传入。
2. BaseChatter.create_request 迁移（P2.1）
- LLMRequest(...) 构造改走 llm_api.create_llm_request(stream_id=self.stream_id, context_manager=...)
- model_set 改走 llm_api.get_model_set_by_task(task)（不再直调 get_model_config()）
- context_manager（含 compression_handler + 双 reminder source）仍由 chatter 自行构造
- 行为与原实现完全等价
3. BaseAgent.create_llm_request 迁移（P1.3）
- 改走 llm_api.create_llm_request(stream_id=self.stream_id, with_reminder=...)
- 启用流私有桶（与 chatter 对齐）：with_reminder 非空时自动登记全局 + 流私有桶
- 顺带获得 meta_data["stream_id"] 注入 → agent 的 LLM 统计也能按流聚合
- with_usables 注入 TOOL payload 保留在基类侧
- 清理不再使用的 ReminderSourceSpec import
4. BaseChatter.inject_usables 迁移（P2.2）
手写 ToolRegistry() + 循环 register 替换为 llm_api.create_tool_registry(tools=usables)，行为等价。
5. 测试与文档
- test/core/test_components_base_chatter.py：4 处 patch("src.core.config.get_model_config") 改为 patch("src.app.plugin_system.api.llm_api.get_model_config")（因 from X import Y 拷贝引用，patch 源模块不影响 llm_api 内已绑定引用）
- docs/plan/base-classes-api-migration.md：P1.3 / P2.1 / P2.2 标记已实施，补充实施说明、风险点与执行记录
验证
- ruff check 改动文件全过
- test_llm_api.py 6/6 通过
- test_components_base_chatter.py + test_components_base_agent.py + test_components_base_chatter_format.py：8 failed 52 passed，与基线完全一致（8 个均为预先存在失败，零回归）
- test_prompt_api.py + test/plugins/default_chatter：67/67 通过
风险
- agent 流私有桶行为变化：agent with_reminder 从"仅全局桶"变为"全局 + 流私有"。属预期改进（与 chatter 一致），若有插件依赖旧行为需注意
- compression_handler 仍由基类侧构造：llm_api 不自动注入，chatter 自行构造传入
关联
- 落实 docs/plan/base-classes-api-migration.md § P1.3 / P2.1 / P2.2
- 剩余未实施：P1.1（modify_llm_usables → stream_api）、P1.2（_llm_judge_activation → llm_api）

## Summary by Sourcery

Migrate base chatter and agent LLM request construction to the shared llm_api, adding stream-aware reminder and metadata support while keeping behavior aligned with existing components and tests.

New Features:
- Extend llm_api.create_llm_request with stream_id and meta_data support, including automatic registration of global and stream-local reminder sources and stream_id metadata injection.
- Enable agents to participate in stream-local reminder buckets and per-stream LLM statistics via llm_api-based request creation.
- Expose a convenience API llm_api.create_tool_registry for building tool registries from usables.

Enhancements:
- Refactor BaseChatter.create_request to use llm_api.create_llm_request and llm_api.get_model_set_by_task, centralizing LLM request construction logic.
- Refactor BaseAgent.create_llm_request to delegate reminder handling and request construction to llm_api, removing duplicate validation logic.
- Refactor BaseChatter.inject_usables to use llm_api.create_tool_registry instead of manually instantiating and populating ToolRegistry.
- Update the Neo-Default-Chatter plugin to access its typed configuration via casted config rather than the untyped base config.
- Bump llm_api API_VERSION to 1.1.0 to reflect the expanded request-construction API.

Documentation:
- Update base-classes API migration plan to track P1/P2 items with implementation status and document the completed P1.3, P2.1, and P2.2 changes, including behavior notes and execution records.

Tests:
- Adjust BaseChatter tests to mock llm_api.get_model_config instead of src.core.config.get_model_config, aligning with the new request construction path.

Chores:
- Document and enumerate the behavioral change where agents now also read from stream-local reminder buckets, highlighting the impact for existing plugins.