### PR TITLE
fix(onebot_adapter): 引用消息中媒体识别内容丢失

### DIFF
--- a/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
@@ -29,7 +29,6 @@ from ..utils import (
     get_group_info,
     get_image_base64,
     get_member_info,
-    get_message_detail,
     get_record_detail,
     get_self_info,
     sanitize_text,
@@ -295,9 +294,9 @@ class MessageHandler:
     async def _handle_reply_message(self, segment: dict, raw_message: dict, in_reply: bool) -> Seg | None:
         """处理回复消息。
 
-        返回的 seglist 会前置一个 ``reply`` 段（data 为被引用消息 ID），
-        以便框架 ``MessageConverter`` 解析出 ``Message.reply_to``；其后保留
-        可读的 ``[回复<昵称(QQ号)>：...]`` 文本预览。
+        只返回 ``reply`` 段（data 为被引用消息 ID），引用内容的文本预览
+        由框架 ``MessageConverter`` 查数据库 ``processed_plain_text`` 构建，
+        避免适配器重新解析原始段导致识别内容丢失。
         """
         if in_reply:
             return None
@@ -310,46 +309,7 @@ class MessageHandler:
         if not message_id:
             return None
 
-        message_detail = await get_message_detail(message_id)
-        if not message_detail:
-            logger.warning("获取被引用的消息详情失败")
-            return {"type": "text", "data": "[无法获取被引用的消息]"}
-
-        # 递归处理被引用的消息
-        reply_segments: list[Seg] = []
-        for reply_seg in message_detail.get("message", []):
-            if isinstance(reply_seg, dict):
-                reply_result = await self.handle_single_segment(reply_seg, raw_message, in_reply=True)
-                if reply_result:
-                    reply_segments.append(reply_result)
-
-        sender_info = message_detail.get("sender", {})
-        sender_id = sender_info.get("user_id")
-        self_id = raw_message.get("self_id")
-
-        # 若被引用的是 bot 自己发的消息，昵称用 "你"，避免协议端不填昵称时回退成 "未知用户"
-        if sender_id and self_id and str(sender_id) == str(self_id):
-            sender_nickname = "你"
-        else:
-            sender_nickname = sender_info.get("nickname") or "未知用户"
-
-        prefix_text = f"[回复<{sender_nickname}({sender_id})>：" if sender_id else f"[回复<{sender_nickname}>："
-        suffix_text = "]，说："
-
-        # 将被引用的消息段落转换为可读的文本占位，避免嵌套的 base64 污染
-        brief_segments = [
-            {"type": seg.get("type", "text"), "data": seg.get("data", "")} for seg in reply_segments
-        ] or [{"type": "text", "data": "[无法获取被引用的消息]"}]
-
-        return {
-            "type": "seglist",
-            "data": [
-                {"type": "reply", "data": str(message_id)},
-                {"type": "text", "data": prefix_text},
-                *brief_segments,
-                {"type": "text", "data": suffix_text},
-            ],
-        }
+        return {"type": "reply", "data": str(message_id)}
 
     async def _handle_record_message(self, segment: dict) -> Seg | None:
         """处理语音消息"""

--- a/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
@@ -336,10 +336,24 @@ class MessageHandler:
         prefix_text = f"[回复<{sender_nickname}({sender_id})>：" if sender_id else f"[回复<{sender_nickname}>："
         suffix_text = "]，说："
 
-        # 将被引用的消息段落转换为可读的文本占位，避免嵌套的 base64 污染
-        brief_segments = [
-            {"type": seg.get("type", "text"), "data": seg.get("data", "")} for seg in reply_segments
-        ] or [{"type": "text", "data": "[无法获取被引用的消息]"}]
+        # 优先从数据库获取已识别的 processed_plain_text（含 media_id 和描述），
+        # 避免重新解析原始段导致识别内容丢失
+        brief_segments: list[dict[str, Any]] = []
+        try:
+            from src.app.plugin_system.api.database_api import get_by
+            from src.core.models.sql_alchemy import Messages
+
+            msg_record = await get_by(Messages, message_id=str(message_id))
+            if msg_record and msg_record.processed_plain_text:
+                brief_segments = [{"type": "text", "data": msg_record.processed_plain_text}]
+        except Exception as e:
+            logger.warning(f"查询被引用消息记录失败: {e}")
+
+        # 数据库没查到则 fallback 到重新解析原始段
+        if not brief_segments:
+            brief_segments = [
+                {"type": seg.get("type", "text"), "data": seg.get("data", "")} for seg in reply_segments
+            ] or [{"type": "text", "data": "[无法获取被引用的消息]"}]
 
         return {
             "type": "seglist",

--- a/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
@@ -336,24 +336,10 @@ class MessageHandler:
         prefix_text = f"[回复<{sender_nickname}({sender_id})>：" if sender_id else f"[回复<{sender_nickname}>："
         suffix_text = "]，说："
 
-        # 优先从数据库获取已识别的 processed_plain_text（含 media_id 和描述），
-        # 避免重新解析原始段导致识别内容丢失
-        brief_segments: list[dict[str, Any]] = []
-        try:
-            from src.app.plugin_system.api.database_api import get_by
-            from src.core.models.sql_alchemy import Messages
-
-            msg_record = await get_by(Messages, message_id=str(message_id))
-            if msg_record and msg_record.processed_plain_text:
-                brief_segments = [{"type": "text", "data": msg_record.processed_plain_text}]
-        except Exception as e:
-            logger.warning(f"查询被引用消息记录失败: {e}")
-
-        # 数据库没查到则 fallback 到重新解析原始段
-        if not brief_segments:
-            brief_segments = [
-                {"type": seg.get("type", "text"), "data": seg.get("data", "")} for seg in reply_segments
-            ] or [{"type": "text", "data": "[无法获取被引用的消息]"}]
+        # 将被引用的消息段落转换为可读的文本占位，避免嵌套的 base64 污染
+        brief_segments = [
+            {"type": seg.get("type", "text"), "data": seg.get("data", "")} for seg in reply_segments
+        ] or [{"type": "text", "data": "[无法获取被引用的消息]"}]
 
         return {
             "type": "seglist",

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -157,6 +157,10 @@ class MessageConverter:
         # 递归解析段列表
         result = self._parse_segments(segments, depth=0)
 
+        # 如果有引用消息，从数据库获取已识别的 processed_plain_text 构建引用预览
+        if result.reply_to:
+            await self._build_reply_preview(result)
+
         # 为二进制媒体项注入 image_id（哈希），便于后续按哈希从 Images 表回查图片信息。
         # 必须在 _recognize_media_with_manager 之前执行，保证 VLM 跳过/早退时 image_id 仍注入。
         if result.media:
@@ -538,6 +542,35 @@ class MessageConverter:
 
         result.at_users.append({"nickname": nickname, "user_id": user_id})
         result.text_parts.append(f"@<{nickname}:{user_id}> ")
+
+    async def _build_reply_preview(self, result: _ParseResult) -> None:
+        """从数据库获取被引用消息的 processed_plain_text，构建引用预览文本。
+
+        当适配器只返回 reply 段（data 为 message_id）时，由 converter 端
+        查数据库获取已识别的内容（含 VLM/ASR 识别结果），构建
+        ``[回复：引用内容]`` 文本注入 text_parts。
+
+        Args:
+            result: 解析结果，需已包含 reply_to
+        """
+        if not result.reply_to:
+            return
+        try:
+            from src.core.models.sql_alchemy import Messages
+            from src.kernel.db import QueryBuilder
+
+            msg_record = await (
+                QueryBuilder(Messages)
+                .filter(message_id=result.reply_to)
+                .first()
+            )
+            if msg_record:
+                reply_text = getattr(msg_record, "processed_plain_text", None)
+                if reply_text:
+                    # 在 text_parts 最前面插入引用预览
+                    result.text_parts.insert(0, f"[回复：{reply_text}]")
+        except Exception as e:
+            logger.warning(f"查询被引用消息记录失败: {e!s}")
 
     def _handle_reply(
         self,


### PR DESCRIPTION
## 重构：引用消息由 converter 端构建引用预览

### 改动内容

将引用消息的文本预览构建从适配器端移到框架 converter 端。

### 修改文件

1. **`src/core/transport/message_receive/converter.py`**（框架）
   - 新增 `_build_reply_preview` 方法：当 `result.reply_to` 存在时，从数据库查 `Messages.processed_plain_text`（含 VLM/ASR 识别结果），构建 `[回复：引用内容]` 文本注入 `text_parts`
   - 在 `envelope_to_message` 中 `_parse_segments` 之后调用

2. **`plugins/onebot_adapter/src/handlers/to_core/message_handler.py`**（适配器）
   - `_handle_reply_message` 简化为只返回 `{"type": "reply", "data": str(message_id)}`
   - 不再构建 seglist 前缀/后缀和 brief_segments
   - 不再调用 `get_message_detail` 重新解析原始消息段

### 解决的问题

之前适配器在处理引用消息时，调用 `get_message_detail` 获取被引用消息的**原始消息段**（base64 数据），然后重新解析这些段。导致：

1. 被引用的图片/表情包/语音被重新解析成 `[图片]`/`[表情包]`/`[语音]` 占位符
2. 框架 converter 的 `_handle_seglist` 对引用内容只合并文本，不合并 media → 占位符不会被识别处理
3. 最终 AI 看到的是 `[回复<xxx>：[表情包]]` — 丢失了 VLM/ASR 识别结果

### 效果

- 修改前：`[回复<昵称(QQ号)>：[表情包]]，说：...`
- 修改后：`[回复：[表情包:描述]]...`（引用内容来自数据库已识别的 `processed_plain_text`）

### 优势

- 适配器只需返回 reply 段，逻辑大幅简化
- 引用内容直接复用数据库已识别的文本，不重新解析原始段
- 框架统一处理引用预览，所有适配器受益
- ruff check 通过
