### PR TITLE
feat(converter): 媒体占位符注入 media_id，解决多模态长上下文错位

### DIFF
--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -747,16 +747,23 @@ class MessageConverter:
                         voice_texts.append((i, None))
 
             # 将识别结果应用回 text_parts，替换占位符
+            # 占位符格式：[图片(media_id):description] / [表情包(media_id):description] / [语音(media_id):text]
+            # media_id 为该媒体的 sha256 哈希，AI 可据此精确引用历史媒体
             new_text_parts = []
             media_idx = 0
             voice_idx = 0
             for part in result.text_parts:
                 if part in ("[图片]", "[表情包]"):
                     if media_idx < len(descriptions):
-                        _, description = descriptions[media_idx]
+                        media_i, description = descriptions[media_idx]
                         media_idx += 1
-                        if description:
-                            label = "图片" if part == "[图片]" else "表情包"
+                        label = "图片" if part == "[图片]" else "表情包"
+                        media_id = result.media[media_i].get("image_id", "")
+                        if media_id and description:
+                            new_text_parts.append(f"[{label}({media_id}):{description}]")
+                        elif media_id:
+                            new_text_parts.append(f"[{label}({media_id})]")
+                        elif description:
                             new_text_parts.append(f"[{label}:{description}]")
                         else:
                             new_text_parts.append(part)
@@ -764,9 +771,14 @@ class MessageConverter:
                         new_text_parts.append(part)
                 elif part == "[语音]":
                     if voice_idx < len(voice_texts):
-                        _, text = voice_texts[voice_idx]
+                        voice_i, text = voice_texts[voice_idx]
                         voice_idx += 1
-                        if text:
+                        media_id = result.media[voice_i].get("image_id", "")
+                        if media_id and text:
+                            new_text_parts.append(f"[语音({media_id}):{text}]")
+                        elif media_id:
+                            new_text_parts.append(f"[语音({media_id})]")
+                        elif text:
                             new_text_parts.append(f"[语音:{text}]")
                         else:
                             new_text_parts.append(part)


### PR DESCRIPTION
## 增强：媒体占位符注入 media_id，解决多模态长上下文错位问题

### 改动内容

修改 `src/core/transport/message_receive/converter.py` 的 `_recognize_media_with_manager` 方法中的占位符替换逻辑。

### 问题描述

AI 上下文中媒体消息的占位符格式为 `[图片:描述]`、`[表情包:描述]`、`[语音:文字]`，不包含 media_id（sha256 哈希）。这导致：

1. **多模态模式长上下文图片错位**：当上下文中有多个图片时，AI 无法区分哪张图片对应哪个描述，尤其在长上下文后图片被压缩/丢弃时，描述和实际图片会错位
2. **认错发送者**：不同用户发的相似图片，AI 无法精确区分
3. **无法精确引用历史媒体**：AI 想发送用户之前发过的图片时，需要额外调用 `list_media` 工具查询 media_id，且描述和 ID 的对应关系容易出错

### 修复方案

在占位符替换时，从 `result.media[media_i]` 获取 `image_id`（在 `_enrich_media_image_ids` 中已注入），注入到占位符中：

| 类型 | 修改前 | 修改后 |
|------|--------|--------|
| 图片 | `[图片:描述]` 或 `[图片]` | `[图片(media_id):描述]` 或 `[图片(media_id)]` |
| 表情包 | `[表情包:描述]` 或 `[表情包]` | `[表情包(media_id):描述]` 或 `[表情包(media_id)]` |
| 语音 | `[语音:文字]` 或 `[语音]` | `[语音(media_id):文字]` 或 `[语音(media_id)]` |

### 设计要点

- `image_id` 在 `_enrich_media_image_ids()` 中已注入到 `result.media[i]`，占位符替换时直接获取
- 沿用原有索引对齐逻辑（`descriptions` 存的 `media_i` 就是 `result.media` 的正确索引）
- 即使 VLM/ASR 识别失败（description 为空），也注入 media_id
- 不影响现有逻辑（image_id 为空时降级为旧格式）

### 影响范围

- 仅修改 `src/core/transport/message_receive/converter.py` 一个文件
- ruff check 通过
- 不影响现有测试（6 个失败测试在修改前就已存在）

## Summary by Sourcery

Inject media_id into recognized media placeholders in message conversion to enable precise multimodal context alignment and media referencing.

New Features:
- Include media_id hashes in image, emoji, and voice placeholders within AI message text parts to uniquely identify media items.

Enhancements:
- Preserve existing placeholder behavior when media_id is unavailable by falling back to the previous format.