### PR TITLE
feat(message_sender): 使用平台返回的消息 ID 写入已发送历史

### DIFF
--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -260,7 +260,7 @@ class OneBotAdapter(BaseAdapter):
             logger.error(f"处理 OneBot 事件失败: {e}, 原始数据: {raw}")
             return None
 
-    async def _send_platform_message(self, envelope: MessageEnvelope) -> None:  # type: ignore[override]
+    async def _send_platform_message(self, envelope: MessageEnvelope) -> dict[str, Any] | None:  # type: ignore[override]
         """
         将 MessageEnvelope 转换并发送到 OneBot
 
@@ -268,9 +268,10 @@ class OneBotAdapter(BaseAdapter):
         而是调用 OneBot API（send_group_msg, send_private_msg 等）
         """
         try:
-            await self.send_handler.handle_message(envelope)
+            return await self.send_handler.handle_message(envelope)
         except Exception as e:
             logger.error(f"发送 OneBot 消息失败: {e}")
+            return None
 
     async def send_onebot_api(self, action: str, params: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
         """

--- a/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
@@ -24,7 +24,7 @@ class SendHandler:
     def __init__(self, adapter: "OneBotAdapter"):
         self.adapter = adapter
 
-    async def handle_message(self, envelope: MessageEnvelope) -> None:
+    async def handle_message(self, envelope: MessageEnvelope) -> dict[str, Any] | None:
         """
         处理来自核心的消息，将其转换为 OneBot 可接受的格式并发送
         """
@@ -55,7 +55,7 @@ class SendHandler:
 
         return await self.send_normal_message(envelope)
 
-    async def send_normal_message(self, envelope: MessageEnvelope) -> None:
+    async def send_normal_message(self, envelope: MessageEnvelope) -> dict[str, Any] | None:
         """
         处理普通消息发送
         """
@@ -117,6 +117,7 @@ class SendHandler:
             logger.info("消息发送成功")
         else:
             logger.warning(f"消息发送失败，onebot返回：{response!s}")
+        return response
 
     async def send_command(self, envelope: MessageEnvelope) -> None:
         """

--- a/src/core/components/base/adapter.py
+++ b/src/core/components/base/adapter.py
@@ -245,7 +245,7 @@ class BaseAdapter(BaseComponent, AdapterBase):
         """
         ...
 
-    async def _send_platform_message(self, envelope: MessageEnvelope) -> None:
+    async def _send_platform_message(self, envelope: MessageEnvelope) -> dict[str, Any] | None:
         """发送消息到平台。
 
         如果使用了自动传输配置，此方法会自动处理。
@@ -254,12 +254,15 @@ class BaseAdapter(BaseComponent, AdapterBase):
         Args:
             envelope: 要发送的消息信封
 
+        Returns:
+            dict[str, Any] | None: 平台发送响应；未提供响应时返回 None
+
         Raises:
             NotImplementedError: 如果未配置自动传输且未重写此方法
         """
         # 如果配置了自动传输，调用父类方法
         if hasattr(self, "_transport_config") and self._transport_config:  # type: ignore
-            await super()._send_platform_message(envelope)  # type: ignore
+            return await super()._send_platform_message(envelope)  # type: ignore
         else:
             raise NotImplementedError(
                 f"适配器 {self.name} 未配置自动传输，必须重写 _send_platform_message 方法"

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -120,8 +120,9 @@ class MessageSender:
                 )
                 return True  # 返回成功，因为拦截是预期行为
 
-            # 6. 发送
-            await adapter._send_platform_message(envelope)
+            # 6. 发送，并使用平台返回的消息 ID 记录已发送消息。
+            response = await adapter._send_platform_message(envelope)
+            self._apply_platform_message_id(message, response)
 
             # 7. 写入历史消息
             await self._persist_sent_message_to_history(message)
@@ -153,6 +154,20 @@ class MessageSender:
                 exc_info=True,
             )
             return False
+
+    @staticmethod
+    def _apply_platform_message_id(message: "Message", response: Any) -> None:
+        """使用平台发送响应中的消息 ID 更新待持久化消息。"""
+        if not isinstance(response, dict) or response.get("status") != "ok":
+            return
+
+        data = response.get("data")
+        if not isinstance(data, dict):
+            return
+
+        platform_message_id = data.get("message_id")
+        if platform_message_id is not None:
+            message.message_id = str(platform_message_id)
 
     async def _apply_bot_sender_info(self, message: "Message", adapter: Any) -> None:
         """在发送前将消息发送者信息设置为 Bot 信息。"""

--- a/test/core/transport/test_message_sender_bot_sender.py
+++ b/test/core/transport/test_message_sender_bot_sender.py
@@ -56,3 +56,47 @@ async def test_send_message_overrides_sender_with_bot_info(monkeypatch: pytest.M
     adapter._send_platform_message.assert_awaited_once()
     fake_stream_manager.get_or_create_stream.assert_awaited_once()
     fake_stream_manager.add_sent_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_send_message_uses_platform_message_id_for_sent_history(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """平台返回消息 ID 后，应使用该 ID 写入已发送消息历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(
+            return_value={"status": "ok", "data": {"message_id": 123456789}}
+        ),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(return_value=SimpleNamespace()),
+        add_sent_message_to_history=AsyncMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is True
+    assert message.message_id == "123456789"
+    fake_stream_manager.add_sent_message_to_history.assert_awaited_once_with(message)


### PR DESCRIPTION
## 背景

当前 `MessageSender.send_message` 在调用 `adapter._send_platform_message` 发送消息后，直接使用消息原有的 `message_id`（通常是内部生成的占位 ID，如 `action_send_text_internal`）写入历史记录。

这导致 `Messages` 表中 bot 已发送消息的 `message_id` 与平台（如 OneBot/QQ）返回的真实消息 ID 不一致，后续无法通过平台消息 ID 进行撤回、引用、查询等操作。

## 改动内容

### 1. `_send_platform_message` 返回平台响应

- `BaseAdapter._send_platform_message` 返回类型由 `None` 改为 `dict[str, Any] | None`，表示平台发送响应；未提供响应时返回 `None`。
- - `OneBotAdapter._send_platform_message` 及 `SendHandler.handle_message` / `send_normal_message` 透传 OneBot API（如 `send_group_msg`）的响应字典。
- - 异常或发送失败时返回 `None`，保持向后兼容。
### 2. `MessageSender` 回写平台消息 ID

新增 `_apply_platform_message_id` 静态方法：发送成功后从响应中提取 `data.message_id`，覆盖到待持久化的 `Message.message_id`，随后再写入历史记录。

```python
# 6. 发送，并使用平台返回的消息 ID 记录已发送消息。
response = await adapter._send_platform_message(envelope)
self._apply_platform_message_id(message, response)

# 7. 写入历史消息
await self._persist_sent_message_to_history(message)
```

仅当响应为 `{"status": "ok", "data": {"message_id": ...}}` 时才覆盖，避免对未返回响应的适配器造成影响。

## 涉及文件

- `src/core/components/base/adapter.py` — 基类返回类型与文档
- - `plugins/onebot_adapter/plugin.py` — 透传响应
- - `plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py` — 透传响应
- - `src/core/transport/message_send/message_sender.py` — 回写逻辑
- - `test/core/transport/test_message_sender_bot_sender.py` — 新增平台消息 ID 回写测试
## 测试

- `test_send_message_uses_platform_message_id_for_sent_history`：验证平台返回 `message_id` 后，历史记录使用该 ID。
- - 原有 `test_send_message_overrides_sender_with_bot_info` 仍通过。
## 兼容性

- 返回类型由 `None` 扩展为 `dict | None`，原有不关心返回值的调用方（如 `adapter_manager` 发送 adapter_command）无需修改。
- - 未重写 `_send_platform_message` 或未返回响应的适配器，行为与原先一致（`response` 为 `None`，跳过覆盖）。

## Summary by Sourcery

Persist sent messages using the platform-returned message ID when available, while extending adapter send APIs to expose platform responses.

New Features:
- Update MessageSender to apply platform message IDs from adapter send responses before writing sent message history.

Enhancements:
- Extend BaseAdapter._send_platform_message and OneBot sending flow to return platform response data instead of only performing side effects.

Tests:
- Add a test ensuring MessageSender uses the platform message ID from the adapter response when recording sent message history.