### PR TITLE
feat(schema_utils): 支持 TypedDict 参数生成 Tool Schema

### DIFF
--- a/src/core/components/utils/schema_utils.py
+++ b/src/core/components/utils/schema_utils.py
@@ -9,6 +9,8 @@ import types
 from enum import Enum
 from typing import Any, Callable, Literal, get_args, get_origin, get_type_hints
 
+from pydantic import BaseModel
+
 
 # Python 类型到 JSON Schema 类型的映射
 _TYPE_MAPPING: dict[type, str] = {
@@ -65,6 +67,16 @@ def build_type_schema(type_hint: Any) -> dict[str, Any]:
 
     if normalized is type(None):
         return {"type": "null"}
+
+    if inspect.isclass(normalized) and issubclass(normalized, BaseModel):
+        model_schema = normalized.model_json_schema()
+        schema: dict[str, Any] = {
+            "type": "object",
+            "properties": model_schema.get("properties", {}),
+        }
+        if model_schema.get("required"):
+            schema["required"] = model_schema["required"]
+        return schema
 
     origin = get_origin(normalized)
     if origin is Literal:

--- a/src/core/components/utils/schema_utils.py
+++ b/src/core/components/utils/schema_utils.py
@@ -9,8 +9,6 @@ import types
 from enum import Enum
 from typing import Any, Callable, Literal, get_args, get_origin, get_type_hints
 
-from pydantic import BaseModel
-
 
 # Python 类型到 JSON Schema 类型的映射
 _TYPE_MAPPING: dict[type, str] = {
@@ -52,6 +50,66 @@ def _unwrap_optional_type(type_hint: Any) -> Any:
     return type_hint
 
 
+def _is_typed_dict(type_hint: Any) -> bool:
+    """判断类型注解是否为 ``TypedDict``。
+
+    ``TypedDict`` 在运行时是 ``dict`` 的子类，且带有 ``__required_keys__``
+    / ``__optional_keys__`` 属性，据此与普通 ``dict`` 区分。
+
+    Args:
+        type_hint: 待检测的类型注解。
+
+    Returns:
+        bool: 是否为 ``TypedDict``。
+    """
+    return (
+        inspect.isclass(type_hint)
+        and issubclass(type_hint, dict)
+        and hasattr(type_hint, "__required_keys__")
+        and hasattr(type_hint, "__optional_keys__")
+    )
+
+
+def _build_typed_dict_schema(typed_dict: type) -> dict[str, Any]:
+    """将 ``TypedDict`` 转换为 JSON Schema 对象片段。
+
+    通过 ``get_type_hints(include_extras=True)`` 解析字段，保留
+    ``Annotated`` 元数据中的描述字符串；``__required_keys__`` 决定
+    ``required`` 列表。
+
+    Args:
+        typed_dict: ``TypedDict`` 类型。
+
+    Returns:
+        dict[str, Any]: JSON Schema 对象片段，含 ``type``/``properties``/
+        ``required``。
+    """
+    try:
+        hints = get_type_hints(typed_dict, include_extras=True)
+    except Exception:
+        hints = getattr(typed_dict, "__annotations__", {})
+
+    properties: dict[str, Any] = {}
+    for field_name, field_type in hints.items():
+        field_schema = build_type_schema(field_type)
+        # 提取 Annotated[..., "描述"] 中的描述字符串
+        metadata = getattr(field_type, "__metadata__", None)
+        if metadata:
+            for meta in metadata:
+                if isinstance(meta, str):
+                    field_schema["description"] = meta
+                    break
+        properties[field_name] = field_schema
+
+    schema: dict[str, Any] = {"type": "object", "properties": properties}
+
+    required_keys = getattr(typed_dict, "__required_keys__", frozenset())
+    if required_keys:
+        schema["required"] = sorted(required_keys)
+
+    return schema
+
+
 def build_type_schema(type_hint: Any) -> dict[str, Any]:
     """将 Python 类型注解转换为 JSON Schema 片段。"""
     annotated_origin = getattr(type_hint, "__origin__", None)
@@ -68,15 +126,8 @@ def build_type_schema(type_hint: Any) -> dict[str, Any]:
     if normalized is type(None):
         return {"type": "null"}
 
-    if inspect.isclass(normalized) and issubclass(normalized, BaseModel):
-        model_schema = normalized.model_json_schema()
-        schema: dict[str, Any] = {
-            "type": "object",
-            "properties": model_schema.get("properties", {}),
-        }
-        if model_schema.get("required"):
-            schema["required"] = model_schema["required"]
-        return schema
+    if _is_typed_dict(normalized):
+        return _build_typed_dict_schema(normalized)
 
     origin = get_origin(normalized)
     if origin is Literal:

--- a/test/core/components/utils/test_schema_utils.py
+++ b/test/core/components/utils/test_schema_utils.py
@@ -4,12 +4,21 @@ from __future__ import annotations
 
 from typing import Annotated
 
+from pydantic import BaseModel
 
 from src.core.components.utils.schema_utils import (
     extract_description_from_docstring,
     map_type_to_json,
     parse_function_signature,
 )
+
+
+class ForwardNodeSchemaTestModel(BaseModel):
+    """用于验证 Tool Schema 的合并转发节点。"""
+
+    uin: str
+    nick: str
+    content: str
 
 
 class TestMapTypeToJson:
@@ -516,3 +525,19 @@ class TestSchemaUtilsEdgeCases:
 
         # 返回类型不应该在 schema 中
         assert "return" not in schema["function"]["parameters"]
+
+
+def test_parse_function_with_pydantic_model_list() -> None:
+    """Pydantic 列表参数应在 Tool Schema 中展开节点字段。"""
+    def send_forward(messages: list[ForwardNodeSchemaTestModel]) -> None:
+        """发送合并转发消息。"""
+
+    schema = parse_function_signature(send_forward, "send_forward", "发送合并转发消息")
+    items = schema["function"]["parameters"]["properties"]["messages"]["items"]
+
+    assert items["type"] == "object"
+    assert set(items["properties"]) == {"uin", "nick", "content"}
+    assert items["properties"]["uin"]["type"] == "string"
+    assert items["properties"]["nick"]["type"] == "string"
+    assert items["properties"]["content"]["type"] == "string"
+    assert items["required"] == ["uin", "nick", "content"]

--- a/test/core/components/utils/test_schema_utils.py
+++ b/test/core/components/utils/test_schema_utils.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Annotated
-
-from pydantic import BaseModel
+from typing import Annotated, TypedDict
 
 from src.core.components.utils.schema_utils import (
     extract_description_from_docstring,
@@ -13,12 +11,12 @@ from src.core.components.utils.schema_utils import (
 )
 
 
-class ForwardNodeSchemaTestModel(BaseModel):
+class ForwardNodeSchemaTestModel(TypedDict):
     """用于验证 Tool Schema 的合并转发节点。"""
 
-    uin: str
-    nick: str
-    content: str
+    uin: Annotated[str, "原消息发送者的 QQ 号"]
+    nick: Annotated[str, "原消息发送者的昵称"]
+    content: Annotated[str, "原消息文本"]
 
 
 class TestMapTypeToJson:
@@ -527,8 +525,8 @@ class TestSchemaUtilsEdgeCases:
         assert "return" not in schema["function"]["parameters"]
 
 
-def test_parse_function_with_pydantic_model_list() -> None:
-    """Pydantic 列表参数应在 Tool Schema 中展开节点字段。"""
+def test_parse_function_with_typed_dict_list() -> None:
+    """TypedDict 列表参数应在 Tool Schema 中展开节点字段与描述。"""
     def send_forward(messages: list[ForwardNodeSchemaTestModel]) -> None:
         """发送合并转发消息。"""
 
@@ -538,6 +536,9 @@ def test_parse_function_with_pydantic_model_list() -> None:
     assert items["type"] == "object"
     assert set(items["properties"]) == {"uin", "nick", "content"}
     assert items["properties"]["uin"]["type"] == "string"
+    assert items["properties"]["uin"]["description"] == "原消息发送者的 QQ 号"
     assert items["properties"]["nick"]["type"] == "string"
+    assert items["properties"]["nick"]["description"] == "原消息发送者的昵称"
     assert items["properties"]["content"]["type"] == "string"
-    assert items["required"] == ["uin", "nick", "content"]
+    assert items["properties"]["content"]["description"] == "原消息文本"
+    assert items["required"] == ["content", "nick", "uin"]


### PR DESCRIPTION
## 背景

`schema_utils.build_type_schema` 负责将 Python 类型注解转换为 JSON Schema 片段，供 Action / Tool 组件生成 LLM Tool Schema 使用。

此前它支持基础类型、`Literal`、`list`/`dict`、`Optional` 等，但**不支持 `TypedDict`**。当 Tool/Action 的函数签名使用 `list[SomeTypedDict]` 这类参数时，生成的 Schema 会退化为通用类型，LLM 无法得知节点应有的字段结构。

典型场景：合并转发节点等结构化参数。

## 改动内容

在 `build_type_schema` 中新增对 `TypedDict` 的识别：

- `_is_typed_dict`：通过 `__required_keys__`/`__optional_keys__` 属性区分 TypedDict 与普通 dict
- `_build_typed_dict_schema`：通过 `get_type_hints(include_extras=True)` 解析字段，提取 `Annotated` 元数据中的描述字符串，`__required_keys__` 决定 `required` 列表

```python
if _is_typed_dict(normalized):
    return _build_typed_dict_schema(normalized)
```

配合既有的 `list` 分支，`list[SomeTypedDict]` 会自动展开为 `{"type": "array", "items": {"type": "object", ...}}`。

## 为什么用 TypedDict 而非 BaseModel

TypedDict 运行时就是 dict，与 LLM 返回的 JSON dict 参数类型一致，注解名副其实。BaseModel 当注解但运行时收 dict，名不副实。且 TypedDict 是标准库，零依赖。

## 涉及文件

- `src/core/components/utils/schema_utils.py` — 新增 TypedDict 支持
- `test/core/components/utils/test_schema_utils.py` — 测试同步改为 TypedDict

## 测试

新增测试验证：函数签名 `def send_forward(messages: list[ForwardNodeSchemaTestModel])` 经 `parse_function_signature` 后，`messages.items` 应包含 `uin`/`nick`/`content` 三个 string 字段及描述，且 `required` 列表完整。

全部 51 项 schema_utils 测试通过。

## 兼容性

- 纯增量改动，不影响原有类型分支的处理逻辑。
- 仅当参数类型确实是 `TypedDict` 时才走新分支，其余类型保持原行为。