### PR TITLE
fix(message_sender): 发送失败时不再写入历史

### DIFF
--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -269,12 +269,11 @@ class OneBotAdapter(BaseAdapter):
 
         Returns:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
+
+        Raises:
+            RuntimeError: 平台拒绝或发送失败时抛出，由调用方（MessageSender）感知并处理
         """
-        try:
-            return await self.send_handler.handle_message(envelope)
-        except Exception as e:
-            logger.error(f"发送 OneBot 消息失败: {e}")
-            return None
+        return await self.send_handler.handle_message(envelope)
 
     async def send_onebot_api(self, action: str, params: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
         """

--- a/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
@@ -30,6 +30,9 @@ class SendHandler:
 
         Returns:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
+
+        Raises:
+            RuntimeError: 平台拒绝或发送失败时抛出
         """
         logger.debug("接收到来自MoFox-Bot的消息，处理中")
 
@@ -66,6 +69,9 @@ class SendHandler:
 
         Returns:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
+
+        Raises:
+            RuntimeError: 平台拒绝或发送失败时抛出
         """
         message_info: MessageInfoPayload = envelope.get("message_info", {})
         message_segment: SegPayload = envelope.get("message_segment", {})  # type: ignore[assignment]
@@ -125,7 +131,7 @@ class SendHandler:
             logger.info("消息发送成功")
         else:
             logger.warning(f"消息发送失败，onebot返回：{response!s}")
-            return None
+            raise RuntimeError(f"OneBot 消息发送失败: {response!s}")
 
         # 提取平台返回的消息 ID，没有则返回 None
         data = response.get("data")

--- a/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from mofox_wire import GroupInfoPayload, MessageEnvelope, MessageInfoPayload, SegPayload, UserInfoPayload
 
 from src.app.plugin_system.api.log_api import get_logger
+from src.core.components.base.adapter import PlatformSendError
 
 from ...event_models import CommandType
 from ..utils import convert_image_to_gif, get_image_format
@@ -32,7 +33,7 @@ class SendHandler:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
 
         Raises:
-            RuntimeError: 平台拒绝或发送失败时抛出
+            PlatformSendError: 平台拒绝或发送失败时抛出
         """
         logger.debug("接收到来自MoFox-Bot的消息，处理中")
 
@@ -71,7 +72,7 @@ class SendHandler:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
 
         Raises:
-            RuntimeError: 平台拒绝或发送失败时抛出
+            PlatformSendError: 平台拒绝或发送失败时抛出
         """
         message_info: MessageInfoPayload = envelope.get("message_info", {})
         message_segment: SegPayload = envelope.get("message_segment", {})  # type: ignore[assignment]
@@ -131,7 +132,7 @@ class SendHandler:
             logger.info("消息发送成功")
         else:
             logger.warning(f"消息发送失败，onebot返回：{response!s}")
-            raise RuntimeError(f"OneBot 消息发送失败: {response!s}")
+            raise PlatformSendError(f"OneBot 消息发送失败: {response!s}", response=response)
 
         # 提取平台返回的消息 ID，没有则返回 None
         data = response.get("data")

--- a/src/core/components/base/__init__.py
+++ b/src/core/components/base/__init__.py
@@ -3,7 +3,7 @@
 from .component import BaseComponent
 from .action import BaseAction
 from .agent import BaseAgent
-from .adapter import BaseAdapter
+from .adapter import BaseAdapter, PlatformSendError
 from .chatter import BaseChatter, Failure, Success, Wait, WaitResumeEvent, Stop
 from .command import BaseCommand, CommandNode
 from .config import BaseConfig
@@ -18,6 +18,7 @@ __all__ = [
     "BaseAction",
     "BaseAgent",
     "BaseAdapter",
+    "PlatformSendError",
     "BaseChatter",
     "BaseCommand",
     "BaseConfig",

--- a/src/core/components/base/adapter.py
+++ b/src/core/components/base/adapter.py
@@ -19,6 +19,22 @@ if TYPE_CHECKING:
     from src.core.components.base.plugin import BasePlugin
 
 
+class PlatformSendError(Exception):
+    """适配器向平台发送消息失败时抛出。
+
+    与泛化异常不同，此异常专门表达"发送失败"语义，供调用方
+    （如 MessageSender）精确识别并跳过历史写入；普通代码 bug
+    引发的异常不会被误判为发送失败。
+
+    Attributes:
+        response: 平台返回的原始响应（如有）
+    """
+
+    def __init__(self, reason: str = "", *, response: Any = None) -> None:
+        super().__init__(reason)
+        self.response = response
+
+
 class BaseAdapter(BaseComponent, AdapterBase):
     """适配器组件基类。
 
@@ -259,7 +275,7 @@ class BaseAdapter(BaseComponent, AdapterBase):
 
         Raises:
             NotImplementedError: 如果未配置自动传输且未重写此方法
-            RuntimeError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
+            PlatformSendError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
         """
         # 如果配置了自动传输，调用父类方法
         if hasattr(self, "_transport_config") and self._transport_config:  # type: ignore

--- a/src/core/components/base/adapter.py
+++ b/src/core/components/base/adapter.py
@@ -255,10 +255,11 @@ class BaseAdapter(BaseComponent, AdapterBase):
             envelope: 要发送的消息信封
 
         Returns:
-            str | None: 平台返回的消息 ID；发送失败或平台未返回 ID 时返回 None
+            str | None: 平台返回的消息 ID；发送成功但平台未返回 ID 时返回 None
 
         Raises:
             NotImplementedError: 如果未配置自动传输且未重写此方法
+            RuntimeError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
         """
         # 如果配置了自动传输，调用父类方法
         if hasattr(self, "_transport_config") and self._transport_config:  # type: ignore

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -125,10 +125,7 @@ class MessageSender:
             try:
                 response = await adapter._send_platform_message(envelope)
             except PlatformSendError as e:
-                logger.warning(
-                    f"平台发送失败，跳过历史写入: message_id={message.message_id}, "
-                    f"reason={e}"
-                )
+                logger.warning(f"平台发送失败，该消息未写入历史: {e}")
                 return False
             self._apply_platform_message_id(message, response)
 

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -159,17 +159,11 @@ class MessageSender:
     def _apply_platform_message_id(message: "Message", response: Any) -> None:
         """使用平台发送响应中的消息 ID 更新待持久化消息。
 
-        适配器返回值支持两种形态：
-        - str: 直接的平台消息 ID（推荐，适配器已提取）
-        - dict: 平台原始响应，从中提取 data.message_id
+        适配器应直接返回平台消息 ID（str 类型）；发送失败或平台未
+        返回消息 ID 时返回 None，此时保留原 message_id 不变。
         """
-        if response is None:
-            return
-
-        # 适配器已提取出消息 ID（str 类型）
-        if isinstance(response, str):
+        if isinstance(response, str) and response:
             message.message_id = response
-            return
 
     async def _apply_bot_sender_info(self, message: "Message", adapter: Any) -> None:
         """在发送前将消息发送者信息设置为 Bot 信息。"""

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from mofox_wire import MessageEnvelope
 
+from src.core.components.base.adapter import PlatformSendError
 from src.kernel.logger import get_logger
 
 if TYPE_CHECKING:
@@ -121,7 +122,14 @@ class MessageSender:
                 return True  # 返回成功，因为拦截是预期行为
 
             # 6. 发送，并使用平台返回的消息 ID 记录已发送消息。
-            response = await adapter._send_platform_message(envelope)
+            try:
+                response = await adapter._send_platform_message(envelope)
+            except PlatformSendError as e:
+                logger.warning(
+                    f"平台发送失败，跳过历史写入: message_id={message.message_id}, "
+                    f"reason={e}"
+                )
+                return False
             self._apply_platform_message_id(message, response)
 
             # 7. 写入历史消息

--- a/test/core/transport/test_message_sender_bot_sender.py
+++ b/test/core/transport/test_message_sender_bot_sender.py
@@ -67,9 +67,7 @@ async def test_send_message_uses_platform_message_id_for_sent_history(
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
-        _send_platform_message=AsyncMock(
-            return_value={"status": "ok", "data": {"message_id": 123456789}}
-        ),
+        _send_platform_message=AsyncMock(return_value="123456789"),
     )
     sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
     sender._converter = SimpleNamespace(  # type: ignore[assignment]
@@ -100,3 +98,87 @@ async def test_send_message_uses_platform_message_id_for_sent_history(
     assert ok is True
     assert message.message_id == "123456789"
     fake_stream_manager.add_sent_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_send_message_keeps_placeholder_id_when_platform_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """平台未返回消息 ID 时，应保留原 message_id 写入历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(return_value=None),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(return_value=SimpleNamespace()),
+        add_sent_message_to_history=AsyncMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is True
+    assert message.message_id == "action_send_text_internal"
+    fake_stream_manager.add_sent_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_and_skips_history_when_send_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """适配器发送失败抛异常时，应返回 False 且不写入历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(side_effect=RuntimeError("OneBot 消息发送失败")),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(),
+        add_sent_message_to_history=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is False
+    fake_stream_manager.get_or_create_stream.assert_not_awaited()
+    fake_stream_manager.add_sent_message_to_history.assert_not_awaited()

--- a/test/core/transport/test_message_sender_bot_sender.py
+++ b/test/core/transport/test_message_sender_bot_sender.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.core.models.message import Message, MessageType
+from src.core.components.base.adapter import PlatformSendError
 from src.core.transport.message_send.message_sender import MessageSender
 
 
@@ -151,7 +152,53 @@ async def test_send_message_returns_false_and_skips_history_when_send_fails(
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
-        _send_platform_message=AsyncMock(side_effect=RuntimeError("OneBot 消息发送失败")),
+        _send_platform_message=AsyncMock(
+            side_effect=PlatformSendError(
+                "OneBot 消息发送失败: {'status': 'error'}", response={"status": "error"}
+            )
+        ),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(),
+        add_sent_message_to_history=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is False
+    fake_stream_manager.get_or_create_stream.assert_not_awaited()
+    fake_stream_manager.add_sent_message_to_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """非 PlatformSendError 的异常（如代码 bug）走外层兜底，同样不写历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(side_effect=KeyError("some_bug")),
     )
     sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
     sender._converter = SimpleNamespace(  # type: ignore[assignment]


### PR DESCRIPTION
## 背景

OneBot 明确返回发送失败时，适配器此前会将失败转换为 `None`。`MessageSender` 无法区分“发送成功但平台未返回消息 ID”和“发送失败”，因此可能继续写入历史并返回成功。

## 改动

- OneBot 返回非 `ok` 状态时抛出 `RuntimeError`
- 移除 `OneBotAdapter` 对发送异常的吞没，让 `MessageSender` 感知失败
- 保持成功但无平台消息 ID 时返回 `None` 的兼容行为
- 简化平台消息 ID 的应用逻辑，仅接受非空字符串
- 增加成功无 ID 和发送失败时跳过历史写入的测试

## 行为变化

- 发送成功并返回消息 ID：使用平台 ID 写入历史
- 发送成功但没有消息 ID：保留原 ID 写入历史
- 平台明确发送失败：返回 `False`，不写入历史

## 验证

- `git diff HEAD --check` 通过
- 当前环境未提供可执行的 `pytest` 命令，因此未在本地运行测试

## Summary by Sourcery

Handle OneBot send failures explicitly so MessageSender can distinguish failed sends from successful sends without a platform message ID and avoid writing failed messages to history.

Bug Fixes:
- Avoid writing send history entries when the adapter send operation fails by surfacing exceptions instead of converting them to successful None responses.

Enhancements:
- Standardize adapter send behavior so platform message IDs are passed back as non-empty strings and missing IDs are represented as None.
- Document and enforce that OneBot send handlers raise RuntimeError on platform-level failures instead of returning falsy responses.

Tests:
- Add tests to verify that successful sends without a platform message ID keep the placeholder message_id when writing history.
- Add tests to verify that failed sends return False and do not create stream history entries.