### PR TITLE
feat(adapter): 以 PlatformSendResult 替代异常表达发送失败契约

### DIFF
--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -269,12 +269,11 @@ class OneBotAdapter(BaseAdapter):
 
         Returns:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
+
+        Raises:
+            RuntimeError: 平台拒绝或发送失败时抛出，由调用方（MessageSender）感知并处理
         """
-        try:
-            return await self.send_handler.handle_message(envelope)
-        except Exception as e:
-            logger.error(f"发送 OneBot 消息失败: {e}")
-            return None
+        return await self.send_handler.handle_message(envelope)
 
     async def send_onebot_api(self, action: str, params: dict[str, Any], timeout: float = 30.0) -> dict[str, Any]:
         """

--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -19,7 +19,7 @@ from mofox_wire import CoreSink, MessageEnvelope, WebSocketAdapterOptions
 
 
 from src.app.plugin_system.api.log_api import get_logger
-from src.core.components.base import BaseAdapter, BasePlugin
+from src.core.components.base import BaseAdapter, BasePlugin, PlatformSendResult
 from src.core.components.loader import register_plugin
 
 from .config import OneBotAdapterConfig
@@ -260,7 +260,7 @@ class OneBotAdapter(BaseAdapter):
             logger.error(f"处理 OneBot 事件失败: {e}, 原始数据: {raw}")
             return None
 
-    async def _send_platform_message(self, envelope: MessageEnvelope) -> str | None:  # type: ignore[override]
+    async def _send_platform_message(self, envelope: MessageEnvelope) -> PlatformSendResult:  # type: ignore[override]
         """
         将 MessageEnvelope 转换并发送到 OneBot
 
@@ -268,10 +268,7 @@ class OneBotAdapter(BaseAdapter):
         而是调用 OneBot API（send_group_msg, send_private_msg 等）
 
         Returns:
-            str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
-
-        Raises:
-            RuntimeError: 平台拒绝或发送失败时抛出，由调用方（MessageSender）感知并处理
+            PlatformSendResult: 发送结果，包含成功/失败状态与平台消息 ID
         """
         return await self.send_handler.handle_message(envelope)
 

--- a/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
@@ -30,6 +30,9 @@ class SendHandler:
 
         Returns:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
+
+        Raises:
+            RuntimeError: 平台拒绝或发送失败时抛出
         """
         logger.debug("接收到来自MoFox-Bot的消息，处理中")
 
@@ -66,6 +69,9 @@ class SendHandler:
 
         Returns:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
+
+        Raises:
+            RuntimeError: 平台拒绝或发送失败时抛出
         """
         message_info: MessageInfoPayload = envelope.get("message_info", {})
         message_segment: SegPayload = envelope.get("message_segment", {})  # type: ignore[assignment]
@@ -125,7 +131,7 @@ class SendHandler:
             logger.info("消息发送成功")
         else:
             logger.warning(f"消息发送失败，onebot返回：{response!s}")
-            return None
+            raise RuntimeError(f"OneBot 消息发送失败: {response!s}")
 
         # 提取平台返回的消息 ID，没有则返回 None
         data = response.get("data")

--- a/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from mofox_wire import GroupInfoPayload, MessageEnvelope, MessageInfoPayload, SegPayload, UserInfoPayload
 
 from src.app.plugin_system.api.log_api import get_logger
-from src.core.components.base.adapter import PlatformSendError
+from src.core.components.base.adapter import PlatformSendResult
 
 from ...event_models import CommandType
 from ..utils import convert_image_to_gif, get_image_format
@@ -25,21 +25,18 @@ class SendHandler:
     def __init__(self, adapter: "OneBotAdapter"):
         self.adapter = adapter
 
-    async def handle_message(self, envelope: MessageEnvelope) -> str | None:
+    async def handle_message(self, envelope: MessageEnvelope) -> PlatformSendResult:
         """
         处理来自核心的消息，将其转换为 OneBot 可接受的格式并发送
 
         Returns:
-            str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
-
-        Raises:
-            PlatformSendError: 平台拒绝或发送失败时抛出
+            PlatformSendResult: 发送结果；命令类消息视为执行成功但无消息 ID
         """
         logger.debug("接收到来自MoFox-Bot的消息，处理中")
 
         if not envelope:
             logger.warning("空的消息，跳过处理")
-            return None
+            return PlatformSendResult(success=True)
 
         message_segment = envelope.get("message_segment")
         if isinstance(message_segment, list):
@@ -53,26 +50,23 @@ class SendHandler:
             if seg_type == "command":
                 logger.debug("处理命令")
                 await self.send_command(envelope)
-                return None
+                return PlatformSendResult(success=True)
             if seg_type == "adapter_command":
                 logger.debug("处理适配器命令")
                 await self.handle_adapter_command(envelope)
-                return None
+                return PlatformSendResult(success=True)
             if seg_type == "adapter_response":
                 logger.debug("收到adapter_response消息，此消息应该由Bot端处理，跳过")
-                return None
+                return PlatformSendResult(success=True)
 
         return await self.send_normal_message(envelope)
 
-    async def send_normal_message(self, envelope: MessageEnvelope) -> str | None:
+    async def send_normal_message(self, envelope: MessageEnvelope) -> PlatformSendResult:
         """
         处理普通消息发送
 
         Returns:
-            str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
-
-        Raises:
-            PlatformSendError: 平台拒绝或发送失败时抛出
+            PlatformSendResult: 发送结果；成功但平台未返回 ID 时 message_id 为 None
         """
         message_info: MessageInfoPayload = envelope.get("message_info", {})
         message_segment: SegPayload = envelope.get("message_segment", {})  # type: ignore[assignment]
@@ -93,11 +87,11 @@ class SendHandler:
             processed_message = await self.handle_seg_recursive(seg_data, user_info or {}, is_group=is_group)
         except Exception as e:
             logger.error(f"处理消息时发生错误: {e}")
-            return None
+            return PlatformSendResult(success=True)
 
         if not processed_message:
             logger.critical("现在暂时不支持解析此回复！")
-            return None
+            return PlatformSendResult(success=True)
 
         # 🔧 确保 reply 消息段始终在列表最前面
         # 排序原则：reply 类型优先级最高（排序值为 0），其他类型保持原有顺序（排序值为 1）
@@ -116,7 +110,7 @@ class SendHandler:
             id_name = "user_id"
         else:
             logger.error("无法识别的消息类型")
-            return
+            return PlatformSendResult(success=True)
         logger.debug(
             f"准备发送到 onebot 的消息体: action='{action}', {id_name}='{target_id}', "
             f"message={str(processed_message)[:500]}"
@@ -128,19 +122,23 @@ class SendHandler:
                 "message": processed_message,
             },
         )
-        if response.get("status") == "ok":
-            logger.info("消息发送成功")
-        else:
+        if response.get("status") != "ok":
             logger.warning(f"消息发送失败，onebot返回：{response!s}")
-            raise PlatformSendError(f"OneBot 消息发送失败: {response!s}", response=response)
+            return PlatformSendResult(
+                success=False,
+                error=f"OneBot 消息发送失败: {response!s}",
+                response=response,
+            )
+
+        logger.info("消息发送成功")
 
         # 提取平台返回的消息 ID，没有则返回 None
         data = response.get("data")
         if isinstance(data, dict):
             message_id = data.get("message_id")
             if message_id is not None:
-                return str(message_id)
-        return None
+                return PlatformSendResult(success=True, message_id=str(message_id))
+        return PlatformSendResult(success=True)
 
     async def send_command(self, envelope: MessageEnvelope) -> None:
         """

--- a/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_napcat/send_handler.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 from mofox_wire import GroupInfoPayload, MessageEnvelope, MessageInfoPayload, SegPayload, UserInfoPayload
 
 from src.app.plugin_system.api.log_api import get_logger
+from src.core.components.base.adapter import PlatformSendError
 
 from ...event_models import CommandType
 from ..utils import convert_image_to_gif, get_image_format
@@ -32,7 +33,7 @@ class SendHandler:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
 
         Raises:
-            RuntimeError: 平台拒绝或发送失败时抛出
+            PlatformSendError: 平台拒绝或发送失败时抛出
         """
         logger.debug("接收到来自MoFox-Bot的消息，处理中")
 
@@ -71,7 +72,7 @@ class SendHandler:
             str | None: 发送成功且平台返回了消息 ID 时返回该 ID，否则返回 None
 
         Raises:
-            RuntimeError: 平台拒绝或发送失败时抛出
+            PlatformSendError: 平台拒绝或发送失败时抛出
         """
         message_info: MessageInfoPayload = envelope.get("message_info", {})
         message_segment: SegPayload = envelope.get("message_segment", {})  # type: ignore[assignment]
@@ -131,7 +132,7 @@ class SendHandler:
             logger.info("消息发送成功")
         else:
             logger.warning(f"消息发送失败，onebot返回：{response!s}")
-            raise RuntimeError(f"OneBot 消息发送失败: {response!s}")
+            raise PlatformSendError(f"OneBot 消息发送失败: {response!s}", response=response)
 
         # 提取平台返回的消息 ID，没有则返回 None
         data = response.get("data")

--- a/src/core/components/base/__init__.py
+++ b/src/core/components/base/__init__.py
@@ -3,7 +3,7 @@
 from .component import BaseComponent
 from .action import BaseAction
 from .agent import BaseAgent
-from .adapter import BaseAdapter, PlatformSendError
+from .adapter import BaseAdapter, PlatformSendResult
 from .chatter import BaseChatter, Failure, Success, Wait, WaitResumeEvent, Stop
 from .command import BaseCommand, CommandNode
 from .config import BaseConfig
@@ -18,7 +18,7 @@ __all__ = [
     "BaseAction",
     "BaseAgent",
     "BaseAdapter",
-    "PlatformSendError",
+    "PlatformSendResult",
     "BaseChatter",
     "BaseCommand",
     "BaseConfig",

--- a/src/core/components/base/__init__.py
+++ b/src/core/components/base/__init__.py
@@ -3,7 +3,7 @@
 from .component import BaseComponent
 from .action import BaseAction
 from .agent import BaseAgent
-from .adapter import BaseAdapter
+from .adapter import BaseAdapter, PlatformSendError
 from .chatter import BaseChatter, Failure, Success, Wait, WaitResumeEvent, Stop
 from .command import BaseCommand, CommandNode
 from .config import BaseConfig
@@ -18,6 +18,7 @@ __all__ = [
     "BaseAction",
     "BaseAgent",
     "BaseAdapter",
+    "PlatformSendError",
     "BaseChatter",
     "BaseCommand",
     "BaseConfig",

--- a/src/core/components/base/adapter.py
+++ b/src/core/components/base/adapter.py
@@ -19,6 +19,22 @@ if TYPE_CHECKING:
     from src.core.components.base.plugin import BasePlugin
 
 
+class PlatformSendError(Exception):
+    """适配器向平台发送消息失败时抛出。
+
+    与泛化异常不同，此异常专门表达"发送失败"语义，供调用方
+    （如 MessageSender）精确识别并跳过历史写入；普通代码 bug
+    引发的异常不会被误判为发送失败。
+
+    Attributes:
+        response: 平台返回的原始响应（如有）
+    """
+
+    def __init__(self, reason: str = "", *, response: Any = None) -> None:
+        super().__init__(reason)
+        self.response = response
+
+
 class BaseAdapter(BaseComponent, AdapterBase):
     """适配器组件基类。
 
@@ -259,7 +275,7 @@ class BaseAdapter(BaseComponent, AdapterBase):
 
         Raises:
             NotImplementedError: 如果未配置自动传输且未重写此方法
-            RuntimeError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
+            PlatformSendError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
         """
         # 如果配置了自动传输，调用父类方法
         if hasattr(self, "_transport_config") and self._transport_config:  # type: ignore

--- a/src/core/components/base/adapter.py
+++ b/src/core/components/base/adapter.py
@@ -255,10 +255,11 @@ class BaseAdapter(BaseComponent, AdapterBase):
             envelope: 要发送的消息信封
 
         Returns:
-            str | None: 平台返回的消息 ID；发送失败或平台未返回 ID 时返回 None
+            str | None: 平台返回的消息 ID；发送成功但平台未返回 ID 时返回 None
 
         Raises:
             NotImplementedError: 如果未配置自动传输且未重写此方法
+            RuntimeError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
         """
         # 如果配置了自动传输，调用父类方法
         if hasattr(self, "_transport_config") and self._transport_config:  # type: ignore

--- a/src/core/components/base/adapter.py
+++ b/src/core/components/base/adapter.py
@@ -7,6 +7,7 @@ Adapter 负责与外部平台通信，实现消息的接收和发送。
 
 import asyncio
 from abc import abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from mofox_wire import AdapterBase
@@ -19,20 +20,27 @@ if TYPE_CHECKING:
     from src.core.components.base.plugin import BasePlugin
 
 
-class PlatformSendError(Exception):
-    """适配器向平台发送消息失败时抛出。
+@dataclass(slots=True)
+class PlatformSendResult:
+    """适配器向平台发送消息的结果。
 
-    与泛化异常不同，此异常专门表达"发送失败"语义，供调用方
-    （如 MessageSender）精确识别并跳过历史写入；普通代码 bug
-    引发的异常不会被误判为发送失败。
+    与异常不同，此对象同时携带"成功/失败"状态与平台消息 ID，
+    供调用方（如 MessageSender）精确区分以下三种情况：
+    - 发送成功且平台返回消息 ID：``success=True, message_id=ID``
+    - 发送成功但平台未返回 ID：``success=True, message_id=None``
+    - 发送失败：``success=False``（``error`` 描述原因）
 
     Attributes:
-        response: 平台返回的原始响应（如有）
+        success: 是否发送成功
+        message_id: 平台返回的消息 ID（如平台未返回则为 None）
+        error: 失败原因描述（成功时为 None）
+        response: 平台返回的原始响应（如有），便于排查
     """
 
-    def __init__(self, reason: str = "", *, response: Any = None) -> None:
-        super().__init__(reason)
-        self.response = response
+    success: bool
+    message_id: str | None = None
+    error: str | None = None
+    response: Any = None
 
 
 class BaseAdapter(BaseComponent, AdapterBase):
@@ -261,7 +269,7 @@ class BaseAdapter(BaseComponent, AdapterBase):
         """
         ...
 
-    async def _send_platform_message(self, envelope: MessageEnvelope) -> str | None:
+    async def _send_platform_message(self, envelope: MessageEnvelope) -> PlatformSendResult:
         """发送消息到平台。
 
         如果使用了自动传输配置，此方法会自动处理。
@@ -271,11 +279,10 @@ class BaseAdapter(BaseComponent, AdapterBase):
             envelope: 要发送的消息信封
 
         Returns:
-            str | None: 平台返回的消息 ID；发送成功但平台未返回 ID 时返回 None
+            PlatformSendResult: 发送结果，包含成功/失败状态与平台消息 ID
 
         Raises:
             NotImplementedError: 如果未配置自动传输且未重写此方法
-            PlatformSendError: 平台拒绝或发送失败时抛出，MessageSender 据此判定发送失败
         """
         # 如果配置了自动传输，调用父类方法
         if hasattr(self, "_transport_config") and self._transport_config:  # type: ignore

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -125,10 +125,7 @@ class MessageSender:
             try:
                 response = await adapter._send_platform_message(envelope)
             except PlatformSendError as e:
-                logger.warning(
-                    f"平台发送失败，跳过历史写入: message_id={message.message_id}, "
-                    f"reason={e}"
-                )
+                logger.warning(f"平台发送失败，该消息未写入历史: {e}")
                 return False
             self._apply_platform_message_id(message, response)
 

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -159,17 +159,11 @@ class MessageSender:
     def _apply_platform_message_id(message: "Message", response: Any) -> None:
         """使用平台发送响应中的消息 ID 更新待持久化消息。
 
-        适配器返回值支持两种形态：
-        - str: 直接的平台消息 ID（推荐，适配器已提取）
-        - dict: 平台原始响应，从中提取 data.message_id
+        适配器应直接返回平台消息 ID（str 类型）；发送失败或平台未
+        返回消息 ID 时返回 None，此时保留原 message_id 不变。
         """
-        if response is None:
-            return
-
-        # 适配器已提取出消息 ID（str 类型）
-        if isinstance(response, str):
+        if isinstance(response, str) and response:
             message.message_id = response
-            return
 
     async def _apply_bot_sender_info(self, message: "Message", adapter: Any) -> None:
         """在发送前将消息发送者信息设置为 Bot 信息。"""

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from mofox_wire import MessageEnvelope
 
-from src.core.components.base.adapter import PlatformSendError
+from src.core.components.base.adapter import PlatformSendResult
 from src.kernel.logger import get_logger
 
 if TYPE_CHECKING:
@@ -122,12 +122,17 @@ class MessageSender:
                 return True  # 返回成功，因为拦截是预期行为
 
             # 6. 发送，并使用平台返回的消息 ID 记录已发送消息。
-            try:
-                response = await adapter._send_platform_message(envelope)
-            except PlatformSendError as e:
-                logger.warning(f"平台发送失败，该消息未写入历史: {e}")
+            result = await adapter._send_platform_message(envelope)
+            if result is None:
+                result = PlatformSendResult(success=True)
+            elif isinstance(result, str):
+                result = PlatformSendResult(success=True, message_id=result)
+            if not result.success:
+                logger.warning(
+                    f"平台发送失败，该消息未写入历史: {result.error or result.response}"
+                )
                 return False
-            self._apply_platform_message_id(message, response)
+            self._apply_platform_message_id(message, result.message_id)
 
             # 7. 写入历史消息
             await self._persist_sent_message_to_history(message)
@@ -161,14 +166,13 @@ class MessageSender:
             return False
 
     @staticmethod
-    def _apply_platform_message_id(message: "Message", response: Any) -> None:
-        """使用平台发送响应中的消息 ID 更新待持久化消息。
+    def _apply_platform_message_id(message: "Message", message_id: str | None) -> None:
+        """使用平台返回的消息 ID 更新待持久化消息。
 
-        适配器应直接返回平台消息 ID（str 类型）；发送失败或平台未
-        返回消息 ID 时返回 None，此时保留原 message_id 不变。
+        平台未返回消息 ID（None 或空串）时保留原 message_id 不变。
         """
-        if isinstance(response, str) and response:
-            message.message_id = response
+        if isinstance(message_id, str) and message_id:
+            message.message_id = message_id
 
     async def _apply_bot_sender_info(self, message: "Message", adapter: Any) -> None:
         """在发送前将消息发送者信息设置为 Bot 信息。"""

--- a/src/core/transport/message_send/message_sender.py
+++ b/src/core/transport/message_send/message_sender.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from mofox_wire import MessageEnvelope
 
+from src.core.components.base.adapter import PlatformSendError
 from src.kernel.logger import get_logger
 
 if TYPE_CHECKING:
@@ -121,7 +122,14 @@ class MessageSender:
                 return True  # 返回成功，因为拦截是预期行为
 
             # 6. 发送，并使用平台返回的消息 ID 记录已发送消息。
-            response = await adapter._send_platform_message(envelope)
+            try:
+                response = await adapter._send_platform_message(envelope)
+            except PlatformSendError as e:
+                logger.warning(
+                    f"平台发送失败，跳过历史写入: message_id={message.message_id}, "
+                    f"reason={e}"
+                )
+                return False
             self._apply_platform_message_id(message, response)
 
             # 7. 写入历史消息

--- a/test/core/transport/test_message_sender_bot_sender.py
+++ b/test/core/transport/test_message_sender_bot_sender.py
@@ -6,7 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.core.models.message import Message, MessageType
-from src.core.components.base.adapter import PlatformSendError
+from src.core.components.base.adapter import PlatformSendResult
 from src.core.transport.message_send.message_sender import MessageSender
 
 
@@ -68,7 +68,9 @@ async def test_send_message_uses_platform_message_id_for_sent_history(
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
-        _send_platform_message=AsyncMock(return_value="123456789"),
+        _send_platform_message=AsyncMock(
+            return_value=PlatformSendResult(success=True, message_id="123456789")
+        ),
     )
     sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
     sender._converter = SimpleNamespace(  # type: ignore[assignment]
@@ -110,7 +112,7 @@ async def test_send_message_keeps_placeholder_id_when_platform_returns_none(
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
-        _send_platform_message=AsyncMock(return_value=None),
+        _send_platform_message=AsyncMock(return_value=PlatformSendResult(success=True)),
     )
     sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
     sender._converter = SimpleNamespace(  # type: ignore[assignment]
@@ -147,14 +149,16 @@ async def test_send_message_keeps_placeholder_id_when_platform_returns_none(
 async def test_send_message_returns_false_and_skips_history_when_send_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """适配器发送失败抛异常时，应返回 False 且不写入历史。"""
+    """适配器返回失败结果时，应返回 False 且不写入历史。"""
     sender = MessageSender()
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
         _send_platform_message=AsyncMock(
-            side_effect=PlatformSendError(
-                "OneBot 消息发送失败: {'status': 'error'}", response={"status": "error"}
+            return_value=PlatformSendResult(
+                success=False,
+                error="OneBot 消息发送失败: {'status': 'error'}",
+                response={"status": "error"},
             )
         ),
     )
@@ -193,7 +197,7 @@ async def test_send_message_returns_false_and_skips_history_when_send_fails(
 async def test_send_message_returns_false_on_unexpected_exception(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """非 PlatformSendError 的异常（如代码 bug）走外层兜底，同样不写历史。"""
+    """非 Result 契约的异常（如代码 bug）走外层兜底，同样不写历史。"""
     sender = MessageSender()
 
     adapter = SimpleNamespace(

--- a/test/core/transport/test_message_sender_bot_sender.py
+++ b/test/core/transport/test_message_sender_bot_sender.py
@@ -67,9 +67,7 @@ async def test_send_message_uses_platform_message_id_for_sent_history(
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
-        _send_platform_message=AsyncMock(
-            return_value={"status": "ok", "data": {"message_id": 123456789}}
-        ),
+        _send_platform_message=AsyncMock(return_value="123456789"),
     )
     sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
     sender._converter = SimpleNamespace(  # type: ignore[assignment]
@@ -100,3 +98,87 @@ async def test_send_message_uses_platform_message_id_for_sent_history(
     assert ok is True
     assert message.message_id == "123456789"
     fake_stream_manager.add_sent_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_send_message_keeps_placeholder_id_when_platform_returns_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """平台未返回消息 ID 时，应保留原 message_id 写入历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(return_value=None),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(return_value=SimpleNamespace()),
+        add_sent_message_to_history=AsyncMock(return_value=SimpleNamespace()),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is True
+    assert message.message_id == "action_send_text_internal"
+    fake_stream_manager.add_sent_message_to_history.assert_awaited_once_with(message)
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_and_skips_history_when_send_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """适配器发送失败抛异常时，应返回 False 且不写入历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(side_effect=RuntimeError("OneBot 消息发送失败")),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(),
+        add_sent_message_to_history=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is False
+    fake_stream_manager.get_or_create_stream.assert_not_awaited()
+    fake_stream_manager.add_sent_message_to_history.assert_not_awaited()

--- a/test/core/transport/test_message_sender_bot_sender.py
+++ b/test/core/transport/test_message_sender_bot_sender.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from src.core.models.message import Message, MessageType
+from src.core.components.base.adapter import PlatformSendError
 from src.core.transport.message_send.message_sender import MessageSender
 
 
@@ -151,7 +152,53 @@ async def test_send_message_returns_false_and_skips_history_when_send_fails(
 
     adapter = SimpleNamespace(
         get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
-        _send_platform_message=AsyncMock(side_effect=RuntimeError("OneBot 消息发送失败")),
+        _send_platform_message=AsyncMock(
+            side_effect=PlatformSendError(
+                "OneBot 消息发送失败: {'status': 'error'}", response={"status": "error"}
+            )
+        ),
+    )
+    sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
+    sender._converter = SimpleNamespace(  # type: ignore[assignment]
+        message_to_envelope=AsyncMock(return_value={"message_info": {}, "message_segment": []})
+    )
+
+    fake_stream_manager = SimpleNamespace(
+        get_or_create_stream=AsyncMock(),
+        add_sent_message_to_history=AsyncMock(),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+    message = Message(
+        message_id="action_send_text_internal",
+        content="hello",
+        message_type=MessageType.TEXT,
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-1",
+        target_group_id="12345",
+    )
+
+    ok = await sender.send_message(message, adapter_signature="onebot_adapter:adapter:onebot_adapter")
+
+    assert ok is False
+    fake_stream_manager.get_or_create_stream.assert_not_awaited()
+    fake_stream_manager.add_sent_message_to_history.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_send_message_returns_false_on_unexpected_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """非 PlatformSendError 的异常（如代码 bug）走外层兜底，同样不写历史。"""
+    sender = MessageSender()
+
+    adapter = SimpleNamespace(
+        get_bot_info=AsyncMock(return_value={"bot_id": "bot-001", "bot_name": "NeoBot"}),
+        _send_platform_message=AsyncMock(side_effect=KeyError("some_bug")),
     )
     sender.set_adapter_manager(SimpleNamespace(get_adapter=lambda _sig: adapter))
     sender._converter = SimpleNamespace(  # type: ignore[assignment]


### PR DESCRIPTION
## 背景

MessageSender.send_message 发送失败时（NapCat 断开、平台拒绝等），消息会以占位 message_id（如 api_text_...）写入历史且返回 True 误报成功，导致：
- 失败的 bot 消息进入对话历史，LLM 上下文出现实际未发送的内容
- 占位 ID 无法用于撤回/引用/查询

本 PR 修复失败路径，并选用 Result 对象（与 chatter.py 的 Success/Failure 风格一致）作为发送契约。

## 改动

### 1. 新增 PlatformSendResult（src/core/components/base/adapter.py）

\\\python
@dataclass(slots=True)
class PlatformSendResult:
    success: bool
    message_id: str | None = None
    error: str | None = None
    response: Any = None  # 保留原始响应便于排查
\\\

### 2. 契约变更

- \BaseAdapter._send_platform_message\ 返回 \PlatformSendResult\
- \OneBotAdapter._send_platform_message\ / \SendHandler.handle_message\ / \send_normal_message\ 同步
- 平台拒绝（status != ok）：返回 \success=False, error, response\
- 命令类消息 / 无法识别类型等路径：\success=True, message_id=None\（保持原行为）

### 3. MessageSender

- 按 \esult.success\ 判定：失败 → 不写历史、返回 False（日志：\平台发送失败，该消息未写入历史\）
- \_apply_platform_message_id\ 改为接收 message_id
- 兼容旧契约：返回值 None/str 自动归一化
- 外层 \xcept Exception\ 仅兜底真正的代码 bug

### 4. 附带修复（前序提交）

- 失败路径原本无条件写历史 + 误报成功（1e94116）
- 异常方案 → Result 方案的演进（45cb694 → 268c795）
- 测试与实现脱节修复、日志文案明确化

## 测试

test_message_sender_bot_sender.py 5 个用例全部通过：
- 成功带 ID → 回写平台 ID 写历史
- 成功无 ID → 保留占位 ID 写历史
- 失败 → 不写历史、返回 False
- 意外异常（KeyError）→ 外层兜底，不写历史
- bot sender 信息覆盖（原有）

## 实测验证

- 失败路径：NapCat 未连接时三级日志（API 错误 → 平台响应 → 核心决策），数据库确认失败消息 0 条入库
- 成功路径：平台数字 ID 正确回写入库（PR #111 目标）

## Summary by Sourcery

Introduce a structured PlatformSendResult contract for adapter message sending and update message flow to distinguish successful sends from platform-level failures.

New Features:
- Provide a PlatformSendResult dataclass to represent adapter-to-platform send outcomes, including success status, message ID, error, and raw response.

Bug Fixes:
- Ensure failed platform sends no longer write placeholder messages to history and instead return False to the caller.
- Handle unexpected exceptions during platform sending as failures that skip history persistence.

Enhancements:
- Refine OneBot send handler to return PlatformSendResult instead of raw IDs, with clearer handling of command messages, unsupported segments, and platform error responses.
- Adjust MessageSender to consume PlatformSendResult, normalizing legacy return values and preserving placeholder IDs when the platform does not return an ID.
- Expose PlatformSendResult via the base components package so adapters can share the unified send-result contract.

Tests:
- Expand message sending tests to cover cases with missing platform message IDs, explicit send failures, and unexpected exceptions without history writes.