### PR TITLE
fix: 回复预览补充发送者信息

### DIFF
--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -13,7 +13,7 @@
 from __future__ import annotations
 
 import time
-from typing import Any
+from typing import Any, cast
 
 from mofox_wire import MessageEnvelope, MessageInfoPayload, SegPayload
 
@@ -558,11 +558,14 @@ class MessageConverter:
         result.text_parts.append(f"@<{nickname}:{user_id}> ")
 
     async def _build_reply_preview(self, result: _ParseResult) -> None:
-        """从数据库获取被引用消息的 processed_plain_text，构建引用预览文本。
+        """从数据库获取被引用消息的 processed_plain_text 和发送者信息，构建引用预览文本。
 
         当适配器只返回 reply 段（data 为 message_id）时，由 converter 端
-        查数据库获取已识别的内容（含 VLM/ASR 识别结果），构建
-        ``[回复：引用内容]`` 文本注入 text_parts。
+        查数据库获取已识别的内容（含 VLM/ASR 识别结果），并通过 person_id
+        关联 PersonInfo 表获取被引用消息的发送者昵称和 ID，构建
+        ``[回复<昵称(ID)>：引用内容]`` 文本注入 text_parts。
+
+        Bot 发送的消息 person_id 为 ``"bot"``，显示为 ``你(bot_id)``。
 
         Args:
             result: 解析结果，需已包含 reply_to
@@ -570,19 +573,59 @@ class MessageConverter:
         if not result.reply_to:
             return
         try:
-            from src.core.models.sql_alchemy import Messages
+            from src.core.models.sql_alchemy import Messages, PersonInfo
             from src.kernel.db import QueryBuilder
 
-            msg_record = await (
+            msg_record = cast(Messages, await (
                 QueryBuilder(Messages)
                 .filter(message_id=result.reply_to)
                 .first()
-            )
+            ))
             if msg_record:
-                reply_text = getattr(msg_record, "processed_plain_text", None)
-                if reply_text:
-                    # 在 text_parts 最前面插入引用预览
-                    result.text_parts.insert(0, f"[回复：{reply_text}]")
+                reply_text = msg_record.processed_plain_text or ""
+
+                # 通过 person_id 关联 PersonInfo 表获取发送者昵称和 ID
+                # Messages.person_id 是 SHA256 哈希值；Bot 消息为字面量 "bot"
+                sender_display = ""
+                person_id = msg_record.person_id
+                if person_id == "bot":
+                    # Bot 自己发的消息，显示为"你(bot_id)"
+                    bot_id_str = ""
+                    try:
+                        from src.core.managers.stream_manager import get_stream_manager
+                        stream = get_stream_manager()._streams.get(msg_record.stream_id)
+                        if stream and stream.bot_id:
+                            bot_id_str = str(stream.bot_id)
+                    except Exception:
+                        pass
+                    sender_display = f"你({bot_id_str})" if bot_id_str else "你"
+                elif person_id:
+                    person_record = cast(PersonInfo, await (
+                        QueryBuilder(PersonInfo)
+                        .filter(person_id=person_id)
+                        .first()
+                    ))
+                    if person_record:
+                        nickname = person_record.nickname or ""
+                        cardname = person_record.cardname or ""
+                        user_id = person_record.user_id or ""
+                        if cardname and cardname != nickname:
+                            name_part = f"群名片:{cardname}$昵称:{nickname}"
+                        else:
+                            name_part = cardname or nickname
+                        if name_part and user_id:
+                            sender_display = f"{name_part}({user_id})"
+                        elif name_part:
+                            sender_display = name_part
+
+                # 构建引用预览：包含发送者信息
+                display_text = reply_text or "[消息内容为空]"
+                if sender_display:
+                    result.text_parts.insert(
+                        0, f"[回复<{sender_display}>：{display_text}]"
+                    )
+                else:
+                    result.text_parts.insert(0, f"[回复：{display_text}]")
         except Exception as e:
             logger.warning(f"查询被引用消息记录失败: {e!s}")
 


### PR DESCRIPTION
## 改动内容

修复 `MessageConverter._build_reply_preview` 方法，解决引用回复预览缺少发送者信息的问题：

1. **缺少发送者信息**：原版本只输出 `[回复：内容]`，现在通过 `Messages.person_id` 查询 `PersonInfo` 表，获取发送者昵称、群名片和 user_id，输出 `[回复<群名片:card$昵称:nickname(user_id)>：内容]`
2. **Bot 消息无标识**：`person_id == "bot"` 时，从 `ChatStream.bot_id` 获取 Bot ID，显示为 `[回复<你(bot_id)>：内容]`

## 原因

commit `864f3f4` 将引用预览构建从适配器移到 converter，但 converter 端只查了 `processed_plain_text` 内容，没有查发送者信息。

## 影响范围

- 仅修改 `src/core/transport/message_receive/converter.py` 的 `_build_reply_preview` 方法
- 不涉及适配器修改（两个适配器 `_handle_reply_message` 已一致，都只返回 reply 段）

## 技术要点

- `Messages.person_id` 是 SHA256 哈希值（由 `UserQueryHelper.generate_person_id()` 生成），不是 `platform:user_id` 格式
- Bot 消息的 `person_id` 为字面量 `"bot"`
- `PersonInfo.person_id` 存储相同的哈希值，通过 `QueryBuilder(PersonInfo).filter(person_id=...)` 查询
- 使用 `cast()` 进行类型标注，直接属性访问，不用 `getattr`

## Summary by Sourcery

Enhance reply preview generation to include sender information for referenced messages, with special handling for bot-sent messages.

Bug Fixes:
- Ensure reply previews for quoted messages include the sender’s display information instead of only the message content.
- Handle bot-authored messages in reply previews by showing an appropriate self-reference using the bot ID when available.

Enhancements:
- Retrieve and incorporate sender metadata from PersonInfo using person_id to build richer reply preview text.
- Improve type safety and clarity in database access by using typed casts for ORM query results.