### PR TITLE
Revert "fix(onebot_adapter): 引用消息中媒体识别内容丢失"

### DIFF
--- a/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
@@ -29,6 +29,7 @@ from ..utils import (
     get_group_info,
     get_image_base64,
     get_member_info,
+    get_message_detail,
     get_record_detail,
     get_self_info,
     sanitize_text,
@@ -294,9 +295,9 @@ class MessageHandler:
     async def _handle_reply_message(self, segment: dict, raw_message: dict, in_reply: bool) -> Seg | None:
         """处理回复消息。
 
-        只返回 ``reply`` 段（data 为被引用消息 ID），引用内容的文本预览
-        由框架 ``MessageConverter`` 查数据库 ``processed_plain_text`` 构建，
-        避免适配器重新解析原始段导致识别内容丢失。
+        返回的 seglist 会前置一个 ``reply`` 段（data 为被引用消息 ID），
+        以便框架 ``MessageConverter`` 解析出 ``Message.reply_to``；其后保留
+        可读的 ``[回复<昵称(QQ号)>：...]`` 文本预览。
         """
         if in_reply:
             return None
@@ -309,7 +310,46 @@ class MessageHandler:
         if not message_id:
             return None
 
-        return {"type": "reply", "data": str(message_id)}
+        message_detail = await get_message_detail(message_id)
+        if not message_detail:
+            logger.warning("获取被引用的消息详情失败")
+            return {"type": "text", "data": "[无法获取被引用的消息]"}
+
+        # 递归处理被引用的消息
+        reply_segments: list[Seg] = []
+        for reply_seg in message_detail.get("message", []):
+            if isinstance(reply_seg, dict):
+                reply_result = await self.handle_single_segment(reply_seg, raw_message, in_reply=True)
+                if reply_result:
+                    reply_segments.append(reply_result)
+
+        sender_info = message_detail.get("sender", {})
+        sender_id = sender_info.get("user_id")
+        self_id = raw_message.get("self_id")
+
+        # 若被引用的是 bot 自己发的消息，昵称用 "你"，避免协议端不填昵称时回退成 "未知用户"
+        if sender_id and self_id and str(sender_id) == str(self_id):
+            sender_nickname = "你"
+        else:
+            sender_nickname = sender_info.get("nickname") or "未知用户"
+
+        prefix_text = f"[回复<{sender_nickname}({sender_id})>：" if sender_id else f"[回复<{sender_nickname}>："
+        suffix_text = "]，说："
+
+        # 将被引用的消息段落转换为可读的文本占位，避免嵌套的 base64 污染
+        brief_segments = [
+            {"type": seg.get("type", "text"), "data": seg.get("data", "")} for seg in reply_segments
+        ] or [{"type": "text", "data": "[无法获取被引用的消息]"}]
+
+        return {
+            "type": "seglist",
+            "data": [
+                {"type": "reply", "data": str(message_id)},
+                {"type": "text", "data": prefix_text},
+                *brief_segments,
+                {"type": "text", "data": suffix_text},
+            ],
+        }
 
     async def _handle_record_message(self, segment: dict) -> Seg | None:
         """处理语音消息"""

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -172,10 +172,6 @@ class MessageConverter:
         # 保证 VLM 跳过/早退时 image_id 仍存在，便于后续按哈希回查 Images 表。
         result = self._parse_segments(segments, depth=0)
 
-        # 如果有引用消息，从数据库获取已识别的 processed_plain_text 构建引用预览
-        if result.reply_to:
-            await self._build_reply_preview(result)
-
         # 如果解析过程中发现有媒体资源，则后续需要考虑是否运行视觉语言模型识别
         if result.media:
             # 提前提取 stream_id 以供逐项过滤 VLM
@@ -556,35 +552,6 @@ class MessageConverter:
 
         result.at_users.append({"nickname": nickname, "user_id": user_id})
         result.text_parts.append(f"@<{nickname}:{user_id}> ")
-
-    async def _build_reply_preview(self, result: _ParseResult) -> None:
-        """从数据库获取被引用消息的 processed_plain_text，构建引用预览文本。
-
-        当适配器只返回 reply 段（data 为 message_id）时，由 converter 端
-        查数据库获取已识别的内容（含 VLM/ASR 识别结果），构建
-        ``[回复：引用内容]`` 文本注入 text_parts。
-
-        Args:
-            result: 解析结果，需已包含 reply_to
-        """
-        if not result.reply_to:
-            return
-        try:
-            from src.core.models.sql_alchemy import Messages
-            from src.kernel.db import QueryBuilder
-
-            msg_record = await (
-                QueryBuilder(Messages)
-                .filter(message_id=result.reply_to)
-                .first()
-            )
-            if msg_record:
-                reply_text = getattr(msg_record, "processed_plain_text", None)
-                if reply_text:
-                    # 在 text_parts 最前面插入引用预览
-                    result.text_parts.insert(0, f"[回复：{reply_text}]")
-        except Exception as e:
-            logger.warning(f"查询被引用消息记录失败: {e!s}")
 
     def _handle_reply(
         self,


### PR DESCRIPTION
Reverts MoFox-Studio/Neo-MoFox#109

## Summary by Sourcery

Revert the previous database-driven reply preview logic by restoring adapter-side construction of reply segments and inline reply text for quoted messages.

Enhancements:
- Update OneBot adapter reply message handling to include both a reply segment and a readable inline preview built from the quoted message content.
- Simplify core message converter by removing the database lookup and processed_plain_text-based reply preview construction.