### PR TITLE
fix(default_chatter): 多模态图片按 media_id 精确匹配，避免顺序错位

### DIFF
--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -144,9 +144,9 @@ class DefaultChatter(BaseChatter):
     ) -> None:
         """在未发送前合并未读消息到最后一个 USER payload。
 
-        当 ``native_multimodal`` 启用时，先将占位符转换为带消息序号和
-        消息内图片序号的标记，再依据标记从对应 Message 取图，避免跨消息
-        按全局图片顺序配对。
+        当 ``native_multimodal`` 启用时，先将 ``[图片(media_id)]`` 占位符
+        转换为内部标记，再按 media_id 在消息列表中精确查找对应图片并内联，
+        避免全局顺序匹配导致的多模态错位。
         """
         content_list: list[Content | LLMUsable]
         if native_multimodal and unread_msgs:

--- a/plugins/default_chatter/utils/multimodal.py
+++ b/plugins/default_chatter/utils/multimodal.py
@@ -1,4 +1,10 @@
-"""Default Chatter 图片提取与多模态内容构建函数。"""
+"""Default Chatter 图片提取与多模态内容构建函数。
+
+多模态模式下（``native_multimodal=True``），框架 converter 跳过 VLM 识别，
+占位符格式为 ``[图片(media_id)]``，其中 ``media_id`` 是媒体数据的 SHA256 哈希。
+DFC 通过 ``media_id`` 在消息的 media 列表中精确定位图片 base64，避免全局
+顺序匹配导致的多模态错位。
+"""
 
 from __future__ import annotations
 
@@ -8,8 +14,10 @@ from typing import Any
 from src.app.plugin_system.types import Content, Image, LLMUsable, Message, Text
 
 _IMAGE_PLACEHOLDER = "[图片]"
-_IMAGE_TOKEN_TEMPLATE = "[[DFC_IMAGE:{message_index}:{image_index}]]"
-_IMAGE_TOKEN_PATTERN = re.compile(r"\[\[DFC_IMAGE:(\d+):(\d+)\]\]")
+_IMAGE_TOKEN_TEMPLATE = "[[DFC_IMAGE:{media_id}]]"
+_IMAGE_TOKEN_PATTERN = re.compile(r"\[\[DFC_IMAGE:([0-9a-fA-F]+)\]\]")
+# 匹配 [图片(media_id)] 格式占位符，media_id 为 64 字符 SHA256 哈希
+_MEDIA_ID_PLACEHOLDER_PATTERN = re.compile(r"\[图片\(([0-9a-fA-F]+)\)\]")
 
 
 def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
@@ -66,63 +74,64 @@ def tokenize_message_scoped_image_placeholders(
     text: str,
     messages: list[Message],
 ) -> str:
-    """将图片占位符按未读消息顺序转换为带来源索引的标记。"""
-    message_image_indices = [0 for _ in messages]
-    message_index = 0
+    """将 ``[图片(media_id)]`` 占位符替换为内部标记 ``[[DFC_IMAGE:media_id]]``。
+
+    通过 media_id 精确关联占位符与消息中的图片，不依赖全局顺序匹配，
+    彻底消除历史消息占位符与未读消息占位符相互干扰导致的错位问题。
+
+    Args:
+        text: 包含 ``[图片(media_id)]`` 占位符的完整文本
+        messages: 未读消息列表（用于建立 media_id 到图片数据的索引）
+
+    Returns:
+        占位符已被 ``[[DFC_IMAGE:media_id]]`` 标记替换的文本
+    """
+    del messages  # media_id 已编码在占位符中，无需按消息顺序匹配
 
     def replace_placeholder(match: re.Match[str]) -> str:
-        """替换一个图片占位符。"""
-        nonlocal message_index
-        del match
-        while message_index < len(messages):
-            images = get_image_media_list(messages[message_index])
-            image_index = message_image_indices[message_index]
-            if image_index < len(images):
-                message_image_indices[message_index] += 1
-                return _IMAGE_TOKEN_TEMPLATE.format(
-                    message_index=message_index,
-                    image_index=image_index,
-                )
-            message_index += 1
-        return _IMAGE_PLACEHOLDER
+        """提取 media_id 并生成内部标记。"""
+        media_id = match.group(1)
+        return _IMAGE_TOKEN_TEMPLATE.format(media_id=media_id)
 
-    return re.sub(re.escape(_IMAGE_PLACEHOLDER), replace_placeholder, text)
+    return _MEDIA_ID_PLACEHOLDER_PATTERN.sub(replace_placeholder, text)
 
 
 def inline_message_images_into_text(
     text: str,
     messages: list[Message],
 ) -> list[Content | LLMUsable]:
-    """按消息级标记将图片内联到文本，而不是按全局图片序号配对。
+    """按 media_id 标记将图片内联到文本。
 
-    每个标记只允许引用其对应消息中的图片。若标记损坏或超出该消息图片
-    数量，则保留标记文本并记录可由调用方观察到的结构异常，不会借用其他
-    消息的图片填补，从而避免一次错位扩散到后续消息。
+    每个 ``[[DFC_IMAGE:media_id]]`` 标记通过 media_id 在所有消息的
+    media 列表中精确查找 ``image_id == media_id`` 的图片：
+
+    - 找到：在标记位置插入 ``[图片(media_id)]`` 文本 + ``Image(base64)``，
+      AI 可据此文本标记与图片的邻接关系建立关联。
+    - 找不到（如历史消息中的占位符在未读消息中无对应图片）：还原为
+      ``[图片(media_id)]`` 文本，不暴露内部标记给 LLM。
 
     Args:
-        text: 包含 ``[[DFC_IMAGE:消息序号:图片序号]]`` 标记的文本
-        messages: 与标记消息序号对应的消息列表
+        text: 包含 ``[[DFC_IMAGE:media_id]]`` 标记的文本
+        messages: 用于查找图片的消息列表
 
     Returns:
         Text/Image 交替排列的内容列表
     """
+    media_index = _build_media_id_index(messages)
+
     content_list: list[Content | LLMUsable] = []
     cursor = 0
     for match in _IMAGE_TOKEN_PATTERN.finditer(text):
         if match.start() > cursor:
             content_list.append(Text(text[cursor:match.start()]))
 
-        message_index = int(match.group(1))
-        image_index = int(match.group(2))
-        image: dict[str, Any] | None = None
-        if 0 <= message_index < len(messages):
-            images = get_image_media_list(messages[message_index])
-            if 0 <= image_index < len(images):
-                image = images[image_index]
+        media_id = match.group(1)
+        image = media_index.get(media_id)
 
         if image is None:
-            content_list.append(Text(match.group(0)))
+            content_list.append(Text(f"[图片({media_id})]"))
         else:
+            content_list.append(Text(f"[图片({media_id})]"))
             content_list.append(Image(str(image["data"])))
         cursor = match.end()
 
@@ -131,6 +140,19 @@ def inline_message_images_into_text(
     if not content_list:
         content_list.append(Text(text))
     return content_list
+
+
+def _build_media_id_index(
+    messages: list[Message],
+) -> dict[str, dict[str, Any]]:
+    """构建 media_id → 图片媒体字典的索引。"""
+    index: dict[str, dict[str, Any]] = {}
+    for msg in messages:
+        for item in get_image_media_list(msg):
+            image_id = item.get("image_id")
+            if isinstance(image_id, str) and image_id:
+                index[image_id] = item
+    return index
 
 
 def inline_images_into_text(

--- a/plugins/default_chatter/utils/multimodal.py
+++ b/plugins/default_chatter/utils/multimodal.py
@@ -1,9 +1,11 @@
 """Default Chatter 图片提取与多模态内容构建函数。
 
-多模态模式下（``native_multimodal=True``），框架 converter 跳过 VLM 识别，
-占位符格式为 ``[图片(media_id)]``，其中 ``media_id`` 是媒体数据的 SHA256 哈希。
-DFC 通过 ``media_id`` 在消息的 media 列表中精确定位图片 base64，避免全局
-顺序匹配导致的多模态错位。
+多模态模式下（``native_multimodal=True``），框架 converter 生成两种占位符格式：
+- ``[图片(media_id):description]`` — VLM 识别成功，带描述
+- ``[图片(media_id)]`` — VLM 跳过/早退，无描述
+
+其中 ``media_id`` 是媒体数据的 SHA256 哈希。DFC 通过 ``media_id`` 在消息的
+media 列表中精确定位图片 base64，避免全局顺序匹配导致的多模态错位。
 """
 
 from __future__ import annotations
@@ -16,8 +18,11 @@ from src.app.plugin_system.types import Content, Image, LLMUsable, Message, Text
 _IMAGE_PLACEHOLDER = "[图片]"
 _IMAGE_TOKEN_TEMPLATE = "[[DFC_IMAGE:{media_id}]]"
 _IMAGE_TOKEN_PATTERN = re.compile(r"\[\[DFC_IMAGE:([0-9a-fA-F]+)\]\]")
-# 匹配 [图片(media_id)] 格式占位符，media_id 为 64 字符 SHA256 哈希
-_MEDIA_ID_PLACEHOLDER_PATTERN = re.compile(r"\[图片\(([0-9a-fA-F]+)\)\]")
+# 匹配 [图片(media_id)] 或 [图片(media_id):description] 格式占位符，
+# media_id 为 64 字符 SHA256 哈希，description 为 VLM 识别后的图片描述
+_MEDIA_ID_PLACEHOLDER_PATTERN = re.compile(
+    r"\[图片\(([0-9a-fA-F]+)\)(?::([^]]*))?\]"
+)
 
 
 def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
@@ -74,13 +79,18 @@ def tokenize_message_scoped_image_placeholders(
     text: str,
     messages: list[Message],
 ) -> str:
-    """将 ``[图片(media_id)]`` 占位符替换为内部标记 ``[[DFC_IMAGE:media_id]]``。
+    """将 ``[图片(media_id)]`` 或 ``[图片(media_id):description]`` 占位符
+    替换为内部标记 ``[[DFC_IMAGE:media_id]]``。
 
     通过 media_id 精确关联占位符与消息中的图片，不依赖全局顺序匹配，
     彻底消除历史消息占位符与未读消息占位符相互干扰导致的错位问题。
+    带描述的占位符（VLM 识别成功）和不带描述的占位符（VLM 跳过）统一处理，
+    描述信息在替换时丢弃——native_multimodal 模式下图片以 Image 形式
+    直接传给 LLM，无需文本描述。
 
     Args:
-        text: 包含 ``[图片(media_id)]`` 占位符的完整文本
+        text: 包含 ``[图片(media_id)]`` 或 ``[图片(media_id):description]``
+            占位符的完整文本
         messages: 未读消息列表（用于建立 media_id 到图片数据的索引）
 
     Returns:
@@ -89,7 +99,7 @@ def tokenize_message_scoped_image_placeholders(
     del messages  # media_id 已编码在占位符中，无需按消息顺序匹配
 
     def replace_placeholder(match: re.Match[str]) -> str:
-        """提取 media_id 并生成内部标记。"""
+        """提取 media_id 并生成内部标记，忽略可选的描述部分。"""
         media_id = match.group(1)
         return _IMAGE_TOKEN_TEMPLATE.format(media_id=media_id)
 

--- a/test/plugins/default_chatter/test_multimodal.py
+++ b/test/plugins/default_chatter/test_multimodal.py
@@ -18,6 +18,10 @@ from src.kernel.llm import Image, Text
 
 # 一个最小可解码的合法 base64 字符串（Image 构造时会做 b64decode 校验）
 _VALID_B64 = "aGVsbG8="  # b"hello"
+# 两个不同的 64 字符十六进制哈希，模拟 converter 输出的 image_id
+_HASH_A = "a" * 64
+_HASH_B = "b" * 64
+_HASH_C = "c" * 64
 
 
 def _make_msg(
@@ -121,93 +125,96 @@ class TestBuildMultimodalContent:
         assert isinstance(content[1], Image)
 
 
-class TestMessageScopedImageBinding:
-    def test_tokens_bind_images_to_their_source_message(self) -> None:
+class TestMediaIdImageBinding:
+    """基于 media_id 精确匹配的图片内联测试。"""
+
+    def test_two_users_images_bound_by_media_id(self) -> None:
+        """两个用户各发一张图，按 media_id 精确匹配，不会错位。"""
         first = _make_msg(
             message_id="m1",
-            media=[{"type": "image", "data": _VALID_B64}],
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
         )
         second = _make_msg(
             message_id="m2",
-            media=[{"type": "image", "data": "aGVsbG8="}],
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
         )
-        text = "张三[m1]：[图片]\\n李四[m2]：[图片]"
+        text = f"张三[m1]：[图片({_HASH_A})]\\n李四[m2]：[图片({_HASH_B})]"
 
         scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
         content = inline_message_images_into_text(scoped_text, [first, second])
 
-        assert scoped_text == "张三[m1]：[[DFC_IMAGE:0:0]]\\n李四[m2]：[[DFC_IMAGE:1:0]]"
-        assert [type(item).__name__ for item in content] == ["Text", "Image", "Text", "Image"]
+        assert scoped_text == f"张三[m1]：[[DFC_IMAGE:{_HASH_A}]]\\n李四[m2]：[[DFC_IMAGE:{_HASH_B}]]"
+        # 每个图片标记位置输出 Text("[图片(media_id)]") + Image(base64)
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image", "Text", "Text", "Image",
+        ]
 
-    def test_one_message_can_bind_multiple_images_without_crossing_messages(self) -> None:
+    def test_multiple_images_in_one_message_bound_independently(self) -> None:
+        """同一条消息多张图，每张按自己的 media_id 独立匹配。"""
         first = _make_msg(
             message_id="m1",
             media=[
-                {"type": "image", "data": _VALID_B64},
-                {"type": "image", "data": _VALID_B64},
+                {"type": "image", "data": _VALID_B64, "image_id": _HASH_A},
+                {"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B},
             ],
         )
         second = _make_msg(
             message_id="m2",
-            media=[{"type": "image", "data": _VALID_B64}],
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_C}],
         )
-        text = "[图片][图片]\\n[图片]"
+        text = f"[图片({_HASH_A})][图片({_HASH_B})]\\n[图片({_HASH_C})]"
 
         scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
         content = inline_message_images_into_text(scoped_text, [first, second])
 
-        assert scoped_text == "[[DFC_IMAGE:0:0]][[DFC_IMAGE:0:1]]\\n[[DFC_IMAGE:1:0]]"
-        assert [type(item).__name__ for item in content] == ["Image", "Image", "Text", "Image"]
+        assert (
+            scoped_text
+            == f"[[DFC_IMAGE:{_HASH_A}]][[DFC_IMAGE:{_HASH_B}]]\\n[[DFC_IMAGE:{_HASH_C}]]"
+        )
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Image", "Text", "Image", "Text", "Text", "Image",
+        ]
 
-    def test_invalid_scoped_token_does_not_borrow_another_message_image(self) -> None:
-        first = _make_msg(media=[])
-        second = _make_msg(media=[{"type": "image", "data": _VALID_B64}])
+    def test_unknown_media_id_restored_as_placeholder(self) -> None:
+        """media_id 在消息列表中找不到时，还原为 [图片(media_id)] 文本。"""
+        msg = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
 
         content = inline_message_images_into_text(
-            "[[DFC_IMAGE:0:0]]",
-            [first, second],
+            f"[[DFC_IMAGE:{_HASH_B}]]",
+            [msg],
         )
 
         assert len(content) == 1
         assert isinstance(content[0], Text)
-        assert content[0].text == "[[DFC_IMAGE:0:0]]"
-
-    def test_excess_placeholders_degrade_gracefully(self) -> None:
-        """占位符多于实际图片时，多余的保留为文本 [图片]。"""
-        msg = _make_msg(media=[{"type": "image", "data": _VALID_B64}])
-        text = "[图片][图片]"
-
-        scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
-        assert scoped_text == "[[DFC_IMAGE:0:0]][图片]"
-
-        content = inline_message_images_into_text(scoped_text, [msg])
-        assert [type(item).__name__ for item in content] == ["Image", "Text"]
+        assert content[0].text == f"[图片({_HASH_B})]"
 
     def test_imageless_message_between_image_messages(self) -> None:
-        """无图消息夹在有图消息之间时，占位符正确跳过它。"""
+        """无图消息夹在有图消息之间时，按 media_id 仍能精确匹配。"""
         m1 = _make_msg(
             message_id="m1",
-            media=[{"type": "image", "data": _VALID_B64}],
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
         )
         m2 = _make_msg(message_id="m2", media=[])  # 纯文本
         m3 = _make_msg(
             message_id="m3",
-            media=[{"type": "image", "data": "aGVsbG8="}],
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_C}],
         )
-        text = "[图片]\\nhello\\n[图片]"
+        text = f"[图片({_HASH_A})]\\nhello\\n[图片({_HASH_C})]"
 
-        scoped_text = tokenize_message_scoped_image_placeholders(
-            text, [m1, m2, m3],
-        )
-        assert scoped_text == "[[DFC_IMAGE:0:0]]\\nhello\\n[[DFC_IMAGE:2:0]]"
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [m1, m2, m3])
+        assert scoped_text == f"[[DFC_IMAGE:{_HASH_A}]]\\nhello\\n[[DFC_IMAGE:{_HASH_C}]]"
 
         content = inline_message_images_into_text(scoped_text, [m1, m2, m3])
         types = [type(item).__name__ for item in content]
-        assert types == ["Image", "Text", "Image"]
+        assert types == ["Text", "Image", "Text", "Text", "Image"]
 
     def test_no_placeholders_returns_text_only(self) -> None:
         """完全没有占位符时，返回纯文本。"""
-        msg = _make_msg(media=[{"type": "image", "data": _VALID_B64}])
+        msg = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
         text = "没有图片占位符的纯文本"
 
         scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
@@ -217,3 +224,21 @@ class TestMessageScopedImageBinding:
         assert len(content) == 1
         assert isinstance(content[0], Text)
         assert content[0].text == text
+
+    def test_image_from_second_message_found_across_all_messages(self) -> None:
+        """media_id 在第二条消息中，即使文本顺序不与消息顺序一致也能匹配。"""
+        first = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        # 文本中第二条消息的图片占位符在前面，但按 media_id 仍能精确匹配
+        text = f"[图片({_HASH_B})]\\n[图片({_HASH_A})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        content = inline_message_images_into_text(scoped_text, [first, second])
+
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Image", "Text", "Text", "Image",
+        ]

--- a/test/plugins/default_chatter/test_multimodal.py
+++ b/test/plugins/default_chatter/test_multimodal.py
@@ -242,3 +242,42 @@ class TestMediaIdImageBinding:
         assert [type(item).__name__ for item in content] == [
             "Text", "Image", "Text", "Text", "Image",
         ]
+
+    def test_placeholder_with_description_is_tokenized(self) -> None:
+        """带描述的占位符 [图片(media_id):description] 也能被正确 tokenize。"""
+        msg = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        text = f"张三[m1]：[图片({_HASH_A}):一只猫]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
+        assert scoped_text == f"张三[m1]：[[DFC_IMAGE:{_HASH_A}]]"
+
+        content = inline_message_images_into_text(scoped_text, [msg])
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image",
+        ]
+
+    def test_mixed_described_and_undescribed_placeholders(self) -> None:
+        """混合带描述和不带描述的占位符，均按 media_id 精确匹配。"""
+        first = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        # 第一张带描述（VLM 识别成功），第二张不带描述（VLM 跳过）
+        text = f"张三[m1]：[图片({_HASH_A}):一只猫]\\n李四[m2]：[图片({_HASH_B})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        assert scoped_text == (
+            f"张三[m1]：[[DFC_IMAGE:{_HASH_A}]]"
+            f"\\n李四[m2]：[[DFC_IMAGE:{_HASH_B}]]"
+        )
+
+        content = inline_message_images_into_text(scoped_text, [first, second])
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image", "Text", "Text", "Image",
+        ]


### PR DESCRIPTION
# fix(default_chatter): 多模态图片改为按 media_id 精确匹配

## 改动内容

`default_chatter` 多模态模式下，图片与占位符的绑定机制从「按未读消息顺序 + 消息内图片序号」改为「按 `media_id`（SHA256 哈希）精确匹配」，从根本上消除全局顺序匹配导致的多模态错位。

### 涉及文件

- `plugins/default_chatter/plugin.py`：更新 `_merge_unread_into_last_user` 的 docstring，说明占位符为 `[图片(media_id)]` 且按 media_id 精确匹配。
- `plugins/default_chatter/utils/multimodal.py`：
  - 占位符模板由 `[[DFC_IMAGE:{message_index}:{image_index}]]` 改为 `[[DFC_IMAGE:{media_id}]]`；
  - 新增 `[图片(media_id)]` 占位符匹配与提取逻辑；
  - `tokenize_message_scoped_image_placeholders` 不再依赖消息顺序，直接替换为内部标记；
  - `inline_message_images_into_text` 通过新增的 `_build_media_id_index` 在全部消息 media 列表中按 `image_id == media_id` 精确查找图片；
  - 找不到对应图片时还原为 `[图片(media_id)]` 文本，不向 LLM 暴露内部标记，也不会借用其他消息的图片填补。
- `test/plugins/default_chatter/test_multimodal.py`：测试类 `TestMessageScopedImageBinding` 重构为 `TestMediaIdImageBinding`，新增按 media_id 精确匹配、未知 media_id 还原、跨消息乱序匹配等用例。

## 原因

此前按全局图片顺序配对时，历史消息中的占位符与未读消息中的占位符会相互干扰，导致图片错位（一次错位还会扩散到后续消息）。`media_id` 是媒体数据的 SHA256 哈希，天然唯一且稳定，用它作为关联键可保证占位符与图片一一对应。

## 影响范围

- 仅影响 `default_chatter` 插件（`native_multimodal=True` 路径）。
- 不涉及框架代码与其他插件。

## 测试

- 已运行 `uv run pytest test/plugins/default_chatter/test_multimodal.py -v`：**14 passed**。

## Summary by Sourcery

Bind multimodal image placeholders by media_id hashes instead of message/image indices to prevent cross-message misalignment in the default_chatter plugin.

Bug Fixes:
- Ensure image placeholders in native multimodal mode are resolved using media_id-based lookup so historical and unread messages no longer interfere and cause image mismatches.

Enhancements:
- Introduce media_id-based placeholder format and indexing for images, including restoring unknown media_id placeholders as text without borrowing other images.
- Expand multimodal tests to cover media_id-bound image matching across users, multiple images per message, missing media_ids, and out-of-order text versus message sequences.