### PR TITLE
feat(neo_default_chatter): 原生多模态图片按 media_id 精确关联 + 预处理日志优化

### DIFF
--- a/plugins/neo_default_chatter/components/config.py
+++ b/plugins/neo_default_chatter/components/config.py
@@ -186,15 +186,6 @@ class NeoChatterConfig(BaseConfig):
             tag="ai",
             hint="启用前请确认 actor 模型支持图片输入",
         )
-        image_placeholder_template: str = Field(
-            default="[图片-{idx}]",
-            description=(
-                "文本侧图片占位符模板，{idx} 为从 1 开始的序号，"
-                "与请求体里的 base64 图片一一对应，让模型区分每张图。"
-            ),
-            label="图片占位符模板",
-            tag="ai",
-        )
         enable_stop_direct_message_wake: bool = Field(
             default=False,
             description="是否允许私聊或 @Bot 消息按概率提前解除 stop 冷却。",

--- a/plugins/neo_default_chatter/components/event_handlers/defaults/inject_unread_payload.py
+++ b/plugins/neo_default_chatter/components/event_handlers/defaults/inject_unread_payload.py
@@ -1,7 +1,8 @@
 """``:inject_unread_payload`` 默认实现——内联图片或纯文本写入 USER payload。
 
-镜像 ``ConversationSession._append_user_payload`` 的原逻辑：原生多模态开启时
-从未读消息提取图片按占位符内联，否则把提示文本作为纯 :class:`Text` 追加。
+镜像 DFC 的多模态定位思路：原生多模态开启时，先把 ``[图片(media_id)]`` /
+``[图片(media_id):description]`` 占位符转换为内部标记，再按 media_id 在所有
+未读消息中精确查找对应图片并内联，避免全局顺序匹配导致的多模态错位。
 """
 
 from __future__ import annotations
@@ -13,13 +14,14 @@ from src.app.plugin_system.base import BaseEventHandler
 from src.app.plugin_system.types import Content, LLMPayload, LLMUsable, ROLE, Text
 from src.kernel.event import EventDecision
 
-from ....components.config import NeoChatterConfig
 from ....utils.event_publisher import NdfcEvent
-from ....utils.multimodal import extract_images_from_messages, inline_images_into_text
+from ....utils.multimodal import (
+    get_image_media_list,
+    inline_message_images_into_text,
+    tokenize_message_scoped_image_placeholders,
+)
 
 logger = get_logger("neo_default_chatter.defaults.inject_unread_payload")
-
-_DEFAULT_PLACEHOLDER = "[图片-{idx}]"
 
 
 class InjectUnreadPayloadDefaultHandler(BaseEventHandler):
@@ -47,15 +49,17 @@ class InjectUnreadPayloadDefaultHandler(BaseEventHandler):
             native_multimodal = bool(params.get("native_multimodal"))
 
             if native_multimodal and unread_msgs:
-                placeholder = self._read_placeholder()
-                images = extract_images_from_messages(unread_msgs)
-                content_list: list[Content | LLMUsable] = inline_images_into_text(
-                    formatted_text, images, placeholder
+                scoped_text = tokenize_message_scoped_image_placeholders(
+                    formatted_text, unread_msgs
                 )
-                if images:
-                    logger.debug(
-                        f"已内联 {len(images)} 张图片到占位符位置"
-                    )
+                content_list: list[Content | LLMUsable] = (
+                    inline_message_images_into_text(scoped_text, unread_msgs)
+                )
+                image_count = sum(
+                    len(get_image_media_list(msg)) for msg in unread_msgs
+                )
+                if image_count:
+                    logger.debug(f"已按 media_id 内联 {image_count} 张图片")
             else:
                 content_list = [Text(formatted_text)]
 
@@ -65,13 +69,6 @@ class InjectUnreadPayloadDefaultHandler(BaseEventHandler):
             # response.add_payload 失败会让 USER payload 缺失，LLM 请求会缺少本轮输入。
             # 让 EventBus 降级为 PASS，session 不会重复注入。
             return EventDecision.PASS, params
-
-    def _read_placeholder(self) -> str:
-        """从插件配置读取图片占位符模板，缺失时回退默认值。"""
-        config = getattr(self.plugin, "config", None)
-        if isinstance(config, NeoChatterConfig):
-            return str(config.plugin.image_placeholder_template)
-        return _DEFAULT_PLACEHOLDER
 
 
 __all__ = ["InjectUnreadPayloadDefaultHandler"]

--- a/plugins/neo_default_chatter/components/event_handlers/defaults/preprocess/probability_bypass.py
+++ b/plugins/neo_default_chatter/components/event_handlers/defaults/preprocess/probability_bypass.py
@@ -87,14 +87,14 @@ class ProbabilityBypassHandler(BaseEventHandler):
             params["proceed"] = True
             params["reason"] = f"概率直通命中 (prob={probability:.2f}): {reason}"
             logger.info(
-                f"[概率直通] 概率直通命中 stream={chat_stream.stream_id[:8]} "
+                f"[green]概率直通[/]: 命中 stream={chat_stream.stream_id[:8]} "
                 f"prob={probability:.2f} ({reason})"
             )
             return EventDecision.STOP, params
 
         logger.debug(
-            f"[概率直通] 概率直通未命中 stream={chat_stream.stream_id[:8]} "
-            f"prob={probability:.2f} ({reason}) → 交由 sub_agent 判定"
+            f"[yellow]概率直通[/]: 未命中 stream={chat_stream.stream_id[:8]} "
+            f"prob={probability:.2f} ({reason}) → 交由后续判定"
         )
         return EventDecision.SUCCESS, params
 

--- a/plugins/neo_default_chatter/components/event_handlers/defaults/preprocess/sub_agent_decision.py
+++ b/plugins/neo_default_chatter/components/event_handlers/defaults/preprocess/sub_agent_decision.py
@@ -114,14 +114,14 @@ class SubAgentDecisionHandler(BaseEventHandler):
             params["proceed"] = True
             params["reason"] = f"sub_agent 判定值得回复: {reason}"
             logger.info(
-                f"[SubAgent] 判定值得回复 stream={chat_stream.stream_id[:8]} "
+                f"[bright_cyan]子代理判定[/]: 值得回复 stream={chat_stream.stream_id[:8]} "
                 f"reason={reason}"
             )
         else:
             params["proceed"] = False
             params["reason"] = f"sub_agent 判定不值得回复: {reason}"
             logger.info(
-                f"[SubAgent] 判定不值得回复 stream={chat_stream.stream_id[:8]} "
+                f"[dim]子代理判定[/]: 不值得回复 stream={chat_stream.stream_id[:8]} "
                 f"reason={reason}"
             )
         return EventDecision.SUCCESS, params

--- a/plugins/neo_default_chatter/docs/ndfc-neo-default-chatter-status.md
+++ b/plugins/neo_default_chatter/docs/ndfc-neo-default-chatter-status.md
@@ -141,7 +141,6 @@ WAIT_USER ──(收到未读/恢复事件)──▶ MODEL_TURN ──(LLM 响�
 | --- | --- | --- | --- |
 | `enabled` | `true` | **`false`** | 默认不启用，需用户显式开启 |
 | `native_multimodal` | `false` | `false` | 一致 |
-| `image_placeholder_template` | `[图片-{idx}]` | `[图片-{idx}]` | 一致 |
 | `enable_stop_direct_message_wake` | `false` | `false` | 一致 |
 | `stop_direct_message_wake_probability` | `0.5` | `0.5` | 一致 |
 | `reinforce_negative_behaviors` | `true` | `true` | 一致 |
@@ -295,5 +294,5 @@ async for result in session.execute():
 2. **同步更新设计文档**：把 §5.1 列出的偏差反向同步到 `nfc-neo-default-chatter-design.md`，或者把该文档标记为「历史设计稿」、本文档作为「事实现状」的唯一来源。
 3. **`enable_cooldown=false` 时的语义验证**：当前实现把 `Stop.time` 直接置 0，未在 chatter 层做特殊处理，需确认框架对 `Stop(time=0)` 的处理是否符合预期。
 4. **`actor_round` step_data 消费方落地**：`_consume_step_data` 已上报 `used_tools` 列表，但目前没有内置订阅者；可考虑提供一个默认的 `actor_round` EventHandler 供统计 / 审计使用。
-5. **设计 §7.4 占位符引用回写**：模型回复里写 `[图片-1]` 时由 `send_text` 自动改发原图片——本期未实现，作为后续扩展项跟踪。
+5. **设计 §7.4 占位符引用回写**：模型回复里写 `[图片(media_id)]` 时由 `send_text` 自动改发原图片——本期未实现，作为后续扩展项跟踪。
 6. **会话结束清理 ``_runtime_helper`` 缓存**：当前 :func:`drop_runtime` 已实现但未被 session 生命周期调用。可在 ``Stop / Failure`` 终态处调一次 ``drop_runtime(stream_id)``，避免长期运行时 ``_RUNTIME_CACHE`` 累积无用 ``NeoChatter`` 实例。

--- a/plugins/neo_default_chatter/docs/nfc-neo-default-chatter-design.md
+++ b/plugins/neo_default_chatter/docs/nfc-neo-default-chatter-design.md
@@ -210,7 +210,6 @@ config/plugins/neo_default_chatter/config.toml
 | --- | --- | --- | --- |
 | `enabled` | bool | `true` | 是否启用 NFC |
 | `native_multimodal` | bool | `false` | 原生多模态：图片 base64 直接入 LLM 请求体，跳过媒体 API 描述；启用前需确认 actor 模型支持图片输入 |
-| `image_placeholder_template` | str | `"[图片-{idx}]"` | 文本侧图片占位符模板，`{idx}` 为从 1 开始的序号；与请求体里的 base64 一一对应 |
 | `enable_stop_direct_message_wake` | bool | `false` | 是否允许私聊或 @Bot 消息按概率提前解除 stop 冷却 |
 | `stop_direct_message_wake_probability` | float | `0.5` | 私聊或 @Bot 消息提前解除 stop 冷却的概率，范围 `0.0–1.0` |
 | `reinforce_negative_behaviors` | bool | `true` | 是否在每轮 user 提示词的 extra 板块中再次强调负面行为约束 |
@@ -239,7 +238,6 @@ config/plugins/neo_default_chatter/config.toml
 [plugin]
 enabled = true
 native_multimodal = true
-image_placeholder_template = "[图片-{idx}]"
 enable_stop_direct_message_wake = true
 stop_direct_message_wake_probability = 0.5
 reinforce_negative_behaviors = true
@@ -281,7 +279,6 @@ class NeoChatterConfig(BaseConfig):
 
         enabled: bool = Field(default=True, description="是否启用 Neo-Default-Chatter", tag="plugin")
         native_multimodal: bool = Field(default=False, description="原生多模态：图片 base64 直接进 LLM 请求体", tag="ai")
-        image_placeholder_template: str = Field(default="[图片-{idx}]", description="文本侧图片占位符模板", tag="ai")
         enable_stop_direct_message_wake: bool = Field(default=False, description="是否允许私聊或 @Bot 消息按概率提前解除 stop 冷却", tag="performance")
         stop_direct_message_wake_probability: float = Field(default=0.5, description="私聊或 @Bot 消息提前解除 stop 冷却的概率", tag="performance")
         reinforce_negative_behaviors: bool = Field(default=True, description="是否在每轮 user 提示词的 extra 板块中再次强调负面行为约束", tag="ai")
@@ -303,26 +300,28 @@ class NeoChatterConfig(BaseConfig):
 启用 `native_multimodal` 后，NFC **不调用** `media_api` 把图片转成文字描述，而是：
 
 1. 从未读消息中提取所有图片段。
-2. 给每张图分配一个**唯一占位符**，按 `image_placeholder_template` 渲染（默认 `[图片-1]`、`[图片-2]`…）。
-3. 在 user prompt 的文本里，把原来 `[图片]` 的位置替换成对应占位符，让模型从上下文知道「这张图属于哪条消息」。
-4. 在 LLM 请求体里，按占位符顺序追加 `Image` 内容段（base64），与文本侧一一对应。
+2. 框架 converter 已为每条消息生成带 `media_id`（图片 SHA256 哈希）的占位符：
+   - `[图片(media_id):description]` — VLM 识别成功，带描述
+   - `[图片(media_id)]` — VLM 跳过/早退，无描述
+3. 在 user prompt 的文本里，通过 `media_id` 精确关联每条消息的图片，把占位符替换为内部标记
+   `[[NDFC_IMAGE:media_id]]`，再按 `media_id` 在消息 media 列表中精确查找 base64 并内联。
+4. 在 LLM 请求体里，生成 Text/Image 交替排列的 content 列表——每张图物理插入到其所属
+   消息文本之后，模型既能看到文本标记，也能通过邻接关系理解图片归属。
 
 ### 7.2 占位符与请求体对应关系
 
 ```
-文本侧（USER payload 的 Text 部分）：
-  【10:23】小明 [msg_123]：你看这张图 [图片-1]
-  【10:24】小红 [msg_124]：还有这张 [图片-2]
-
-请求体侧（同一条 USER payload 的多模态 content list）：
-  [
-    Text("【10:23】小明 [msg_123]：你看这张图 [图片-1]\n【10:24】小红 [msg_124]：还有这张 [图片-2]"),
-    Image(base64=img1_b64),   # 对应 [图片-1]
-    Image(base64=img2_b64),   # 对应 [图片-2]
-  ]
+文本侧（USER payload 的 Text/Image 交替部分）：
+  Text("【10:23】小明 [msg_123]：你看这张图 [图片(abc123)]")
+  Image(base64=img1_b64)   # media_id == abc123
+  Text("【10:24】小红 [msg_124]：还有这张 [图片(def456)]")
+  Image(base64=img2_b64)   # media_id == def456
 ```
 
-实现上沿用 `default_chatter` 已验证的 `extract_images_from_messages` + `inline_images_into_text` 思路（见 `plugins/default_chatter/utils/multimodal.py`），但占位符模板从配置读取，便于不同模型适配（有的模型偏好 `<image_1>`、有的偏好 `[图片-1]`）。
+实现上沿用 `default_chatter` 已验证的 media_id 精确关联思路
+（`tokenize_message_scoped_image_placeholders` + `inline_message_images_into_text`，
+见 `plugins/default_chatter/utils/multimodal.py`），以图片哈希而非全局顺序定位，
+避免历史消息与未读消息占位符混合时的错位问题。
 
 ### 7.3 关闭时的行为
 
@@ -330,9 +329,14 @@ class NeoChatterConfig(BaseConfig):
 
 ### 7.4 实现注意
 
-- 占位符**全局唯一**：单次请求内 `idx` 从 1 递增；跨请求不复用（每次 `execute` 重新计数）。
-- 占位符**可被模型引用**：模型在回复里写 `[图片-1]` 时，`send_text` 等动作可识别并做相应处理（如改为发送原图片，留作后续扩展，本期不强制）。
-- 表情包图片**不进原生多模态**：与 `default_chatter` 一致，表情包仍走 VLM 识别以利用哈希缓存，避免每次都重算。
+- 占位符以 `media_id`（图片 SHA256 哈希）为唯一标识：`[图片(media_id)]` / `[图片(media_id):description]`。
+  `media_id` 是图片内容的哈希，天然全局唯一且跨请求稳定，不会因消息顺序变化而错位。
+- 描述在 tokenize 阶段**丢弃**：native_multimodal 下图片以 `Image(base64)` 形式直接传给 LLM，
+  文本侧不再需要 VLM 描述，避免冗余 token。
+- 找不到对应图片时（如历史消息占位符在本轮未读中无对应媒体）：还原为 `[图片(media_id)]` 纯文本，
+  不暴露内部标记给 LLM。
+- 表情包图片**不进原生多模态**：与 `default_chatter` 一致，表情包仍走 VLM 识别以利用哈希缓存，
+  避免每次都重算。
 
 ## 8. stop 冷却与直接唤醒
 
@@ -481,7 +485,7 @@ from ..components.service import NeoChatterService
 
 # session.py 内（如需 prompt/多模态工具）
 from .utils.preprocess import run_preprocess
-from .utils.multimodal import inline_images_into_text
+from .utils.multimodal import inline_message_images_into_text
 from .utils.prompt_builder import build_system_prompt, build_user_prompt
 ```
 

--- a/plugins/neo_default_chatter/session.py
+++ b/plugins/neo_default_chatter/session.py
@@ -498,7 +498,8 @@ class ConversationSession:
                             stop_result, chat_stream.chat_type
                         )
                         return
-                    logger.info(
+                    # 拦截主日志已在 event_publisher.preprocess 打印；此处补充「继续等待」细节，供调试
+                    logger.debug(
                         f"[预处理] 拦截但继续等待：{decision.reason or '未提供理由'}"
                     )
                     resume_event = yield Wait()

--- a/plugins/neo_default_chatter/utils/event_publisher.py
+++ b/plugins/neo_default_chatter/utils/event_publisher.py
@@ -509,19 +509,19 @@ class NdfcPublisher:
         )
 
         if published and logger is not None:
+            # 各处理器（概率直通 / 兴趣值 / 子代理判定）已各自打印一行 INFO 决策日志，
+            # 这里仅作 debug 汇总，避免同一决策重复刷屏。
             if decision.proceed:
-                logger.info(
-                    f"[预处理] 放行：{decision.reason or '无理由'}"
-                    + (f" | extra+{len(decision.extra)}字符" if decision.extra else "")
+                logger.debug(f"[预处理] 放行：{decision.reason or '无理由'}")
+                if decision.extra:
+                    logger.debug(f"[预处理] extra+{len(decision.extra)}字符")
+            elif decision.force_stop_minutes is not None:
+                logger.debug(
+                    f"[预处理] 拦截：{decision.reason or '未提供理由'} "
+                    f"→ Stop({decision.force_stop_minutes}分钟)"
                 )
             else:
-                logger.info(
-                    f"[预处理] 拦截：{decision.reason or '未提供理由'}"
-                    + (
-                        f" → 进入 Stop({decision.force_stop_minutes}分钟)"
-                        if decision.force_stop_minutes is not None
-                        else " → 等待新消息"
-                    )
-                )
+                logger.debug(f"[预处理] 拦截：{decision.reason or '未提供理由'}")
+                logger.debug("[预处理] → 等待新消息")
 
         return decision

--- a/plugins/neo_default_chatter/utils/multimodal.py
+++ b/plugins/neo_default_chatter/utils/multimodal.py
@@ -16,11 +16,11 @@ from typing import Any
 from src.app.plugin_system.types import Content, Image, LLMUsable, Message, Text
 
 _IMAGE_TOKEN_TEMPLATE = "[[NDFC_IMAGE:{media_id}]]"
-_IMAGE_TOKEN_PATTERN = re.compile(r"\[\[NDFC_IMAGE:([0-9a-fA-F]+)\]\]")
+_IMAGE_TOKEN_PATTERN = re.compile(r"\[\[NDFC_IMAGE:([0-9a-fA-F]{64})\]\]")
 # 匹配 [图片(media_id)] 或 [图片(media_id):description] 格式占位符，
 # media_id 为 64 字符 SHA256 哈希，description 为 VLM 识别后的图片描述
 _MEDIA_ID_PLACEHOLDER_PATTERN = re.compile(
-    r"\[图片\(([0-9a-fA-F]+)\)(?::([^]]*))?\]"
+    r"\[图片\(([0-9a-fA-F]{64})\)(?::([^]]*))?\]"
 )
 
 

--- a/plugins/neo_default_chatter/utils/multimodal.py
+++ b/plugins/neo_default_chatter/utils/multimodal.py
@@ -1,16 +1,27 @@
-"""Neo-Default-Chatter 图片提取与原生多模态内容构建。
+"""Neo-Default-Chatter 图片提取与多模态内容构建函数。
 
-与 default_chatter 的固定 ``[图片]`` 占位符不同，NFC 使用可配置的唯一占位符模板
-（默认 ``[图片-{idx}]``），让模型能区分并引用每张图片。
+多模态模式下（``native_multimodal=True``），框架 converter 生成两种占位符格式：
+- ``[图片(media_id):description]`` — VLM 识别成功，带描述
+- ``[图片(media_id)]`` — VLM 跳过/早退，无描述
+
+其中 ``media_id`` 是媒体数据的 SHA256 哈希。NDFC 通过 ``media_id`` 在消息的
+media 列表中精确定位图片 base64，避免全局顺序匹配导致的多模态错位。
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from src.app.plugin_system.types import Content, Image, LLMUsable, Message, Text
 
-_DEFAULT_PLACEHOLDER = "[图片]"
+_IMAGE_TOKEN_TEMPLATE = "[[NDFC_IMAGE:{media_id}]]"
+_IMAGE_TOKEN_PATTERN = re.compile(r"\[\[NDFC_IMAGE:([0-9a-fA-F]+)\]\]")
+# 匹配 [图片(media_id)] 或 [图片(media_id):description] 格式占位符，
+# media_id 为 64 字符 SHA256 哈希，description 为 VLM 识别后的图片描述
+_MEDIA_ID_PLACEHOLDER_PATTERN = re.compile(
+    r"\[图片\(([0-9a-fA-F]+)\)(?::([^]]*))?\]"
+)
 
 
 def get_image_media_list(msg: Message) -> list[dict[str, Any]]:
@@ -32,7 +43,7 @@ def extract_images_from_messages(
     """按顺序从消息列表中提取全部图片。
 
     Args:
-        messages: 待扫描的消息（通常为未读消息）
+        messages: 待扫描的消息（可为未读消息或历史消息子集）
 
     Returns:
         提取到的媒体字典列表，保持原始消息顺序
@@ -44,69 +55,94 @@ def extract_images_from_messages(
     return items
 
 
-def inline_images_into_text(
+def tokenize_message_scoped_image_placeholders(
     text: str,
-    media_items: list[dict[str, Any]],
-    placeholder_template: str = "[图片-{idx}]",
-) -> list[Content | LLMUsable]:
-    """将图片内联到文本占位符位置，并给每张图分配唯一可引用的占位符。
+    messages: list[Message],
+) -> str:
+    """将 ``[图片(media_id)]`` 或 ``[图片(media_id):description]`` 占位符
+    替换为内部标记 ``[[NDFC_IMAGE:media_id]]``。
 
-    处理流程：
-
-    1. 按 ``media_items`` 中图片顺序，依次将 ``text`` 里的 ``[图片]`` 占位符
-       替换为 ``placeholder_template.format(idx=k+1)``（如 ``[图片-1]``），
-       使模型在文本中能看到每张图的唯一标签。
-    2. 在替换后的完整文本之后，按顺序追加 ``Image`` 内容段，与标签一一对应。
-
-    当占位符数量与图片数量不匹配时：
-
-    - 图片用完但仍有 ``[图片]`` 占位符：保留 ``[图片]`` 文本（无对应图片）
-    - 占位符用完但仍有图片：把多余图片追加到末尾，并继续递增 ``idx``
+    通过 media_id 精确关联占位符与消息中的图片，不依赖全局顺序匹配，
+    彻底消除历史消息占位符与未读消息占位符相互干扰导致的错位问题。
+    带描述的占位符（VLM 识别成功）和不带描述的占位符（VLM 跳过）统一处理，
+    描述信息在替换时丢弃——native_multimodal 模式下图片以 Image 形式
+    直接传给 LLM，无需文本描述。
 
     Args:
-        text: 包含 ``[图片]`` 占位符的完整文本
-        media_items: 按消息时序排列的图片媒体字典列表
-        placeholder_template: 占位符模板，``{idx}`` 会被替换为从 1 开始的序号
+        text: 包含 ``[图片(media_id)]`` 或 ``[图片(media_id):description]``
+            占位符的完整文本
+        messages: 未读消息列表（用于建立 media_id 到图片数据的索引）
 
     Returns:
-        ``[Text(替换后的完整文本), Image(...), Image(...), ...]`` 格式的内容列表
+        占位符已被 ``[[NDFC_IMAGE:media_id]]`` 标记替换的文本
     """
-    images = [item for item in media_items if item.get("type") == "image" and item.get("data")]
-    if not images or not text:
-        return [Text(text)]
+    del messages  # media_id 已编码在占位符中，无需按消息顺序匹配
 
-    rendered_parts: list[str] = []
-    remaining = text
-    img_idx = 0
-    next_label = 1
+    def replace_placeholder(match: re.Match[str]) -> str:
+        """提取 media_id 并生成内部标记，忽略可选的描述部分。"""
+        media_id = match.group(1)
+        return _IMAGE_TOKEN_TEMPLATE.format(media_id=media_id)
 
-    while remaining:
-        pos = remaining.find(_DEFAULT_PLACEHOLDER)
-        if pos < 0:
-            rendered_parts.append(remaining)
-            break
+    return _MEDIA_ID_PLACEHOLDER_PATTERN.sub(replace_placeholder, text)
 
-        rendered_parts.append(remaining[:pos])
-        if img_idx < len(images):
-            rendered_parts.append(placeholder_template.format(idx=next_label))
-            next_label += 1
-            img_idx += 1
+
+def inline_message_images_into_text(
+    text: str,
+    messages: list[Message],
+) -> list[Content | LLMUsable]:
+    """按 media_id 标记将图片内联到文本。
+
+    每个 ``[[NDFC_IMAGE:media_id]]`` 标记通过 media_id 在所有消息的
+    media 列表中精确查找 ``image_id == media_id`` 的图片：
+
+    - 找到：在标记位置插入 ``[图片(media_id)]`` 文本 + ``Image(base64)``，
+      AI 可据此文本标记与图片的邻接关系建立关联。
+    - 找不到（如历史消息中的占位符在未读消息中无对应图片）：还原为
+      ``[图片(media_id)]`` 文本，不暴露内部标记给 LLM。
+
+    Args:
+        text: 包含 ``[[NDFC_IMAGE:media_id]]`` 标记的文本
+        messages: 用于查找图片的消息列表
+
+    Returns:
+        Text/Image 交替排列的内容列表
+    """
+    media_index = _build_media_id_index(messages)
+
+    content_list: list[Content | LLMUsable] = []
+    cursor = 0
+    for match in _IMAGE_TOKEN_PATTERN.finditer(text):
+        if match.start() > cursor:
+            content_list.append(Text(text[cursor:match.start()]))
+
+        media_id = match.group(1)
+        image = media_index.get(media_id)
+
+        if image is None:
+            content_list.append(Text(f"[图片({media_id})]"))
         else:
-            rendered_parts.append(_DEFAULT_PLACEHOLDER)
+            content_list.append(Text(f"[图片({media_id})]"))
+            content_list.append(Image(str(image["data"])))
+        cursor = match.end()
 
-        remaining = remaining[pos + len(_DEFAULT_PLACEHOLDER):]
-
-    while img_idx < len(images):
-        rendered_parts.append("\n")
-        rendered_parts.append(placeholder_template.format(idx=next_label))
-        next_label += 1
-        img_idx += 1
-
-    content_list: list[Content | LLMUsable] = [Text("".join(rendered_parts))]
-    for image in images:
-        content_list.append(Image(str(image["data"])))
-
+    if cursor < len(text):
+        content_list.append(Text(text[cursor:]))
+    if not content_list:
+        content_list.append(Text(text))
     return content_list
+
+
+def _build_media_id_index(
+    messages: list[Message],
+) -> dict[str, dict[str, Any]]:
+    """构建 media_id → 图片媒体字典的索引。"""
+    index: dict[str, dict[str, Any]] = {}
+    for msg in messages:
+        for item in get_image_media_list(msg):
+            image_id = item.get("image_id")
+            if isinstance(image_id, str) and image_id:
+                index[image_id] = item
+    return index
 
 
 def _extract_dict_list(raw: Any) -> list[dict[str, Any]] | None:

--- a/test/plugins/neo_default_chatter/test_multimodal.py
+++ b/test/plugins/neo_default_chatter/test_multimodal.py
@@ -1,0 +1,292 @@
+"""Neo-Default-Chatter 原生多模态辅助模块单元测试。
+
+覆盖 media_id 精确关联的图片内联逻辑：
+``tokenize_message_scoped_image_placeholders`` / ``inline_message_images_into_text`` /
+``get_image_media_list`` / ``extract_images_from_messages``。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from src.core.models.message import Message, MessageType
+from src.kernel.llm import Text
+
+from plugins.neo_default_chatter.utils.multimodal import (
+    extract_images_from_messages,
+    get_image_media_list,
+    inline_message_images_into_text,
+    tokenize_message_scoped_image_placeholders,
+)
+
+# 一个最小可解码的合法 base64 字符串（Image 构造时会做 b64decode 校验）
+_VALID_B64 = "aGVsbG8="  # b"hello"
+# 三个不同的 64 字符十六进制哈希，模拟 converter 输出的 image_id
+_HASH_A = "a" * 64
+_HASH_B = "b" * 64
+_HASH_C = "c" * 64
+
+# NDFC 内部标记模板，与 utils/multimodal.py 保持一致
+_NDFC_TOKEN = "[[NDFC_IMAGE:{media_id}]]"
+
+
+def _make_msg(
+    *,
+    message_id: str = "msg_1",
+    media: list[dict[str, Any]] | None = None,
+    via: str = "content",
+) -> Message:
+    """构造带 media 的 Message。
+
+    via:
+        - "content": media 写入 content dict（converter 默认路径）
+        - "extra":   media 仅写入 extra（兼容路径）
+    """
+    if media is None:
+        media = []
+    if via == "content":
+        return Message(
+            message_id=message_id,
+            content={"text": "", "media": media},
+            message_type=MessageType.IMAGE,
+        )
+    return Message(
+        message_id=message_id,
+        content="",
+        message_type=MessageType.TEXT,
+        media=media,
+    )
+
+
+class TestGetImageMediaList:
+    def test_only_images_are_returned(self) -> None:
+        msg = _make_msg(
+            media=[
+                {"type": "image", "data": "base64|aaa"},
+                {"type": "emoji", "data": "base64|bbb"},
+                {"type": "voice", "data": "base64|ccc"},
+            ]
+        )
+        result = get_image_media_list(msg)
+        assert len(result) == 1
+        assert result[0]["type"] == "image"
+
+    def test_image_without_data_is_skipped(self) -> None:
+        msg = _make_msg(media=[{"type": "image"}, {"type": "image", "data": ""}])
+        assert get_image_media_list(msg) == []
+
+    def test_extra_path_is_used_when_content_lacks_media(self) -> None:
+        msg = _make_msg(
+            via="extra",
+            media=[{"type": "image", "data": "base64|x"}],
+        )
+        result = get_image_media_list(msg)
+        assert len(result) == 1
+
+
+class TestExtractImagesFromMessages:
+    def test_returns_all_images_in_order(self) -> None:
+        m1 = _make_msg(message_id="m1", media=[{"type": "image", "data": "1"}])
+        m2 = _make_msg(message_id="m2", media=[{"type": "image", "data": "2"}])
+        m3 = _make_msg(message_id="m3", media=[{"type": "image", "data": "3"}])
+
+        items = extract_images_from_messages([m1, m2, m3])
+        assert len(items) == 3
+        assert items[0]["data"] == "1"
+        assert items[1]["data"] == "2"
+        assert items[2]["data"] == "3"
+
+    def test_skips_emoji_and_voice(self) -> None:
+        m = _make_msg(
+            media=[
+                {"type": "emoji", "data": "e"},
+                {"type": "voice", "data": "v"},
+                {"type": "image", "data": "i"},
+            ]
+        )
+        items = extract_images_from_messages([m])
+        assert len(items) == 1
+        assert items[0]["type"] == "image"
+        assert items[0]["data"] == "i"
+
+
+class TestMediaIdImageBinding:
+    """基于 media_id 精确匹配的图片内联测试。"""
+
+    def test_two_users_images_bound_by_media_id(self) -> None:
+        """两个用户各发一张图，按 media_id 精确匹配，不会错位。"""
+        first = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        text = f"张三[m1]：[图片({_HASH_A})]\\n李四[m2]：[图片({_HASH_B})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        content = inline_message_images_into_text(scoped_text, [first, second])
+
+        assert scoped_text == (
+            f"张三[m1]：[[NDFC_IMAGE:{_HASH_A}]]"
+            f"\\n李四[m2]：[[NDFC_IMAGE:{_HASH_B}]]"
+        )
+        # 每个图片标记位置输出 Text("[图片(media_id)]") + Image(base64)
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image", "Text", "Text", "Image",
+        ]
+
+    def test_multiple_images_in_one_message_bound_independently(self) -> None:
+        """同一条消息多张图，每张按自己的 media_id 独立匹配。"""
+        first = _make_msg(
+            message_id="m1",
+            media=[
+                {"type": "image", "data": _VALID_B64, "image_id": _HASH_A},
+                {"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B},
+            ],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_C}],
+        )
+        text = f"[图片({_HASH_A})][图片({_HASH_B})]\\n[图片({_HASH_C})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        content = inline_message_images_into_text(scoped_text, [first, second])
+
+        assert scoped_text == (
+            f"[[NDFC_IMAGE:{_HASH_A}]][[NDFC_IMAGE:{_HASH_B}]]"
+            f"\\n[[NDFC_IMAGE:{_HASH_C}]]"
+        )
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Image", "Text", "Image", "Text", "Text", "Image",
+        ]
+
+    def test_unknown_media_id_restored_as_placeholder(self) -> None:
+        """media_id 在消息列表中找不到时，还原为 [图片(media_id)] 文本。"""
+        msg = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+
+        content = inline_message_images_into_text(
+            f"[[NDFC_IMAGE:{_HASH_B}]]",
+            [msg],
+        )
+
+        assert len(content) == 1
+        assert isinstance(content[0], Text)
+        assert content[0].text == f"[图片({_HASH_B})]"
+
+    def test_imageless_message_between_image_messages(self) -> None:
+        """无图消息夹在有图消息之间时，按 media_id 仍能精确匹配。"""
+        m1 = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        m2 = _make_msg(message_id="m2", media=[])  # 纯文本
+        m3 = _make_msg(
+            message_id="m3",
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_C}],
+        )
+        text = f"[图片({_HASH_A})]\\nhello\\n[图片({_HASH_C})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [m1, m2, m3])
+        assert scoped_text == (
+            f"[[NDFC_IMAGE:{_HASH_A}]]\\nhello\\n[[NDFC_IMAGE:{_HASH_C}]]"
+        )
+
+        content = inline_message_images_into_text(scoped_text, [m1, m2, m3])
+        types = [type(item).__name__ for item in content]
+        assert types == ["Text", "Image", "Text", "Text", "Image"]
+
+    def test_no_placeholders_returns_text_only(self) -> None:
+        """完全没有占位符时，返回纯文本。"""
+        msg = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        text = "没有图片占位符的纯文本"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
+        assert scoped_text == text
+
+        content = inline_message_images_into_text(scoped_text, [msg])
+        assert len(content) == 1
+        assert isinstance(content[0], Text)
+        assert content[0].text == text
+
+    def test_image_from_second_message_found_across_all_messages(self) -> None:
+        """media_id 在第二条消息中，即使文本顺序不与消息顺序一致也能匹配。"""
+        first = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        # 文本中第二条消息的图片占位符在前面，但按 media_id 仍能精确匹配
+        text = f"[图片({_HASH_B})]\\n[图片({_HASH_A})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        content = inline_message_images_into_text(scoped_text, [first, second])
+
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Image", "Text", "Text", "Image",
+        ]
+
+    def test_placeholder_with_description_is_tokenized(self) -> None:
+        """带描述的占位符 [图片(media_id):description] 也能被正确 tokenize。"""
+        msg = _make_msg(
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        text = f"张三[m1]：[图片({_HASH_A}):一只猫]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [msg])
+        assert scoped_text == f"张三[m1]：[[NDFC_IMAGE:{_HASH_A}]]"
+
+        content = inline_message_images_into_text(scoped_text, [msg])
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image",
+        ]
+
+    def test_mixed_described_and_undescribed_placeholders(self) -> None:
+        """混合带描述和不带描述的占位符，均按 media_id 精确匹配。"""
+        first = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        # 第一张带描述（VLM 识别成功），第二张不带描述（VLM 跳过）
+        text = f"张三[m1]：[图片({_HASH_A}):一只猫]\\n李四[m2]：[图片({_HASH_B})]"
+
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [first, second])
+        assert scoped_text == (
+            f"张三[m1]：[[NDFC_IMAGE:{_HASH_A}]]"
+            f"\\n李四[m2]：[[NDFC_IMAGE:{_HASH_B}]]"
+        )
+
+        content = inline_message_images_into_text(scoped_text, [first, second])
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image", "Text", "Text", "Image",
+        ]
+
+    def test_text_and_image_interleaved_not_bunched_at_end(self) -> None:
+        """关键：图片按 media_id 物理插入到所属文本之后，而非堆积在末尾。"""
+        first = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        text = f"甲：{_NDFC_TOKEN.format(media_id=_HASH_A)}\\n乙：{_NDFC_TOKEN.format(media_id=_HASH_B)}"
+
+        content = inline_message_images_into_text(text, [first, second])
+
+        # Text("甲：") → Text("[图片(a..)])") → Image → Text("乙：") → Text → Image
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image", "Text", "Text", "Image",
+        ]

--- a/test/plugins/neo_default_chatter/test_multimodal.py
+++ b/test/plugins/neo_default_chatter/test_multimodal.py
@@ -290,3 +290,46 @@ class TestMediaIdImageBinding:
         assert [type(item).__name__ for item in content] == [
             "Text", "Text", "Image", "Text", "Text", "Image",
         ]
+
+
+class TestStrictMediaIdPattern:
+    """media_id 必须为 64 字符 SHA256 十六进制哈希。
+
+    非 64 位或非十六进制的内容不再被当作合法占位符，避免在含占位符或
+    格式异常的文本中误将非预期内容识别为合法标记。
+    """
+
+    def test_short_hex_media_id_not_tokenized(self) -> None:
+        """过短的十六进制 media_id 不被识别为图片占位符。"""
+        text = "[图片(abc123)]"
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [])
+        assert scoped_text == text
+
+    def test_long_hex_media_id_not_tokenized(self) -> None:
+        """超过 64 位的十六进制 media_id 不被识别为图片占位符。"""
+        media_id = "a" * 65
+        text = f"[图片({media_id})]"
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [])
+        assert scoped_text == text
+
+    def test_non_hex_media_id_not_tokenized(self) -> None:
+        """含非十六进制字符的 media_id 不被识别为图片占位符。"""
+        media_id = "a" * 63 + "g"  # 'g' 不是十六进制字符
+        text = f"[图片({media_id})]"
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [])
+        assert scoped_text == text
+
+    def test_uppercase_hex_media_id_still_tokenized(self) -> None:
+        """大写 64 位十六进制 media_id 仍被识别（大小写不敏感）。"""
+        media_id = "A" * 64
+        text = f"[图片({media_id}):一只猫]"
+        scoped_text = tokenize_message_scoped_image_placeholders(text, [])
+        assert scoped_text == f"[[NDFC_IMAGE:{media_id}]]"
+
+    def test_short_media_id_token_not_inlined(self) -> None:
+        """非 64 位内部标记不被还原为 [图片(...)] 文本，保持原样。"""
+        text = "[[NDFC_IMAGE:abc123]]"
+        content = inline_message_images_into_text(text, [])
+        assert len(content) == 1
+        assert isinstance(content[0], Text)
+        assert content[0].text == text


### PR DESCRIPTION
# PR：NDFC 原生多模态图片按 media_id 精确关联 + 预处理日志优化

## 改动内容

### 1. 原生多模态图片定位改为 media_id 精确关联（对齐 DFC）

**问题背景**：NDFC 原生多模态（`native_multimodal`）此前用「顺序索引」定位图片——第 N 个 `[图片]` 占位符对应第 N 张图，替换为 `[图片-{idx}]` 序号标签，图片全部追加在文本末尾。但框架 converter 实际生成的是带哈希的占位符 `[图片(media_id)]` / `[图片(media_id):description]`，旧逻辑用 `find("[图片]")` 替换会残留 `(media_id)]` 尾巴导致文本错乱；且图片堆积在末尾，模型无法通过邻接关系理解图片归属，历史/未读占位符混合时存在错位风险。

**改动**：
- `plugins/neo_default_chatter/utils/multimodal.py`：重写为 DFC 同款 media_id 方案
  - `tokenize_message_scoped_image_placeholders`：`[图片(media_id)]` / `[图片(media_id):description]` → `[[NDFC_IMAGE:media_id]]` 内部标记，丢弃 VLM 描述
  - `inline_message_images_into_text`：按 media_id 在所有消息 media 列表中精确查找 base64，生成 Text/Image 交替排列（图片物理插入所属文本后）；找不到时还原 `[图片(media_id)]` 纯文本，不暴露内部标记
  - `_build_media_id_index`：media_id → 图片索引
  - 移除旧的顺序计数 `inline_images_into_text`
- `plugins/neo_default_chatter/components/event_handlers/defaults/inject_unread_payload.py`：handler 改用 tokenize + media_id 内联，移除 `_read_placeholder()`
- `plugins/neo_default_chatter/components/config.py`：移除已无意义的 `image_placeholder_template` 配置项（新方案用 media_id 而非序号模板）
- 文档同步：`docs/nfc-neo-default-chatter-design.md` §6/§7/§11、`docs/ndfc-neo-default-chatter-status.md`
- 新增 `test/plugins/neo_default_chatter/test_multimodal.py`（14 个用例）：覆盖 media_id 精确匹配、跨消息匹配、无图消息夹层、未知 media_id 还原、带/不带描述混合、Text/Image 交替排列（不堆积末尾）

### 2. 预处理日志优化

- `probability_bypass.py`：命中/未命中日志加颜色（`[green]概率直通[/]` / `[yellow]概率直通[/]`）
- `sub_agent_decision.py`：值得/不值得日志加颜色（`[bright_cyan]子代理判定[/]` / `[dim]子代理判定[/]`）
- `session.py` + `utils/event_publisher.py`：预处理汇总日志由 info 降为 debug，避免同一决策重复刷屏（各处理器已各自打印一行决策日志）

## 影响范围

- 仅 `plugins/neo_default_chatter/`（NDFC）与对应测试
- 无框架（`src/`）改动
- 无其他插件改动

## 验证

- `uv run pytest test/plugins/neo_default_chatter/ -q`：147 项全部通过（含新增 14 项）
- `uv run ruff check`：全部通过

## Summary by Sourcery

Align neo_default_chatter native multimodal image handling with media_id-based binding and tighten preprocess logging behavior.

New Features:
- Introduce media_id-scoped tokenization and inline image insertion for native multimodal content in neo_default_chatter, matching images to text by SHA256-based media_id and interleaving Text/Image segments instead of appending images at the end.

Bug Fixes:
- Eliminate mismatches and text corruption caused by naive placeholder-based image alignment when historical and unread messages share image placeholders.

Enhancements:
- Simplify configuration by removing the now-unused image_placeholder_template option from neo_default_chatter.
- Update design and status documentation to describe media_id-based multimodal behavior and revised placeholder semantics.
- Improve preprocess logging by coloring probability-bypass and sub-agent decision logs and downgrading aggregate preprocess logs to debug to reduce noise.
- Adjust session-level preprocess logging to only emit debug-level wait details instead of duplicating intercept info.

Tests:
- Add comprehensive unit tests for neo_default_chatter multimodal utilities to cover media_id matching, cross-message binding, placeholder tokenization, and Text/Image interleaving behavior.