### PR TITLE
fix(neo_default_chatter): 修复 send_text 打字延迟不生效

### DIFF
--- a/plugins/neo_default_chatter/components/actions/send_text.py
+++ b/plugins/neo_default_chatter/components/actions/send_text.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from typing import Annotated
+from typing import Annotated, AsyncGenerator
 from uuid import uuid4
 
 from src.app.plugin_system.api.adapter_api import get_bot_info_by_platform
@@ -53,11 +53,16 @@ class SendTextAction(BaseAction):
     def _read_typing_delay_config(self) -> tuple[float, float]:
         """从插件配置读取打字延迟参数，配置缺失时回退默认值。"""
         config = self.plugin.config
-        return (
-                float(config.plugin.typing_delay_per_char),
-                float(config.plugin.typing_delay_max_seconds),
+        if not isinstance(config, NeoChatterConfig):
+            return (
+                _TYPING_DELAY_PER_CHAR_DEFAULT,
+                _TYPING_DELAY_MAX_SECONDS_DEFAULT,
             )
-        
+        return (
+            float(config.plugin.typing_delay_per_char),
+            float(config.plugin.typing_delay_max_seconds),
+        )
+
     async def _sleep_for_typing_delay(self, content: str) -> None:
         """在连续发送文本时等待剩余的模拟打字时间。"""
         last_send_time = float(
@@ -88,8 +93,13 @@ class SendTextAction(BaseAction):
         content: Annotated[str, "要发送的文本内容，不用添加标记，只写你想说的话即可"],
         reply_to: Annotated[str | None, "可选，要引用回复的目标消息 ID"] = None,
         at: Annotated[str | None, "可选，不使用 reply_to 时指定要 @ 的对象（用户 ID）"] = None,
-    ) -> tuple[bool, str]:
-        """执行发送文本消息的逻辑。
+    ) -> AsyncGenerator[tuple[bool, str] | None, None]:
+        """执行发送文本消息的逻辑（异步生成器）。
+
+        写成异步生成器并在真正发送前 ``yield None`` 暂停到 ``"_READY"`` 状态：
+        统一调度器（``run_llm_usable_executions``）会按 tool call 顺序门控推进
+        异步生成器，从而把多个 ``send_text`` 的发送串行化，使打字延迟
+        （基于上次发送时间的差值）能真正逐条生效，而不是并发同时发出。
 
         Args:
             content: 要发送的文本内容，不用添加标记，只写你想说的话即可
@@ -111,16 +121,23 @@ class SendTextAction(BaseAction):
                 content = content[at_match.end():].lstrip()
 
         if not (content or at_prefix_hint):
-            return True, "内容为空，跳过发送"
+            yield True, "内容为空，跳过发送"
+            return
         if not content:
-            return True, "内容为空，跳过发送"
+            yield True, "内容为空，跳过发送"
+            return
 
         if reply_to:
-            return await self._send_with_reply(content, reply_to)
-        return await self._send_with_at(content, at or at_prefix_hint)
+            async for item in self._send_with_reply(content, reply_to):
+                yield item
+            return
+        async for item in self._send_with_at(content, at or at_prefix_hint):
+            yield item
 
-    async def _send_with_reply(self, content: str, reply_to: str) -> tuple[bool, str]:
-        """以引用回复方式发送。"""
+    async def _send_with_reply(
+        self, content: str, reply_to: str
+    ) -> AsyncGenerator[tuple[bool, str] | None, None]:
+        """以引用回复方式发送（异步生成器，发送前 yield None 进入顺序门控）。"""
         target_stream_id = self.chat_stream.stream_id
         platform = self.chat_stream.platform
         chat_type = self.chat_stream.chat_type
@@ -168,26 +185,33 @@ class SendTextAction(BaseAction):
         )
         message.extra.update(extra)
 
+        yield None
         await self._sleep_for_typing_delay(content)
         success = await send_message(message)
         if success:
             self._record_send_time()
-        return success, f"已发送消息:{content}"
+        yield success, f"已发送消息:{content}"
 
-    async def _send_with_at(self, content: str, at_hint: str | None) -> tuple[bool, str]:
-        """以 @ 用户或普通文本方式发送。"""
+    async def _send_with_at(
+        self, content: str, at_hint: str | None
+    ) -> AsyncGenerator[tuple[bool, str] | None, None]:
+        """以 @ 用户或普通文本方式发送（异步生成器，发送前 yield None 进入顺序门控）。"""
         at_hint = (at_hint or "").strip().lstrip("@").strip()
         if not at_hint:
+            yield None
             success = await self._send_plain_text(content)
-            return success, f"已发送消息:{content}"
+            yield success, f"已发送消息:{content}"
+            return
 
         target_stream_id = self.chat_stream.stream_id
         platform = self.chat_stream.platform
         chat_type = self.chat_stream.chat_type
 
         if chat_type != "group":
+            yield None
             success = await self._send_plain_text(content)
-            return success, f"已发送消息:{content}"
+            yield success, f"已发送消息:{content}"
+            return
 
         from src.core.utils.user_query_helper import get_user_query_helper
 
@@ -199,8 +223,10 @@ class SendTextAction(BaseAction):
 
         if not at_user_id:
             logger.info(f"无法定位 at 目标: {at_hint}，按普通文本发送")
+            yield None
             success = await self._send_plain_text(content)
-            return success, f"已发送消息:{content}"
+            yield success, f"已发送消息:{content}"
+            return
 
         target_group_id = None
         target_group_name = None
@@ -228,8 +254,9 @@ class SendTextAction(BaseAction):
         )
         message.extra.update(extra)
 
+        yield None
         await self._sleep_for_typing_delay(content)
         success = await send_message(message)
         if success:
             self._record_send_time()
-        return success, f"已发送消息:{content}"
+        yield success, f"已发送消息:{content}"

--- a/plugins/neo_default_chatter/components/actions/send_text.py
+++ b/plugins/neo_default_chatter/components/actions/send_text.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import asyncio
 import re
 import time
-from typing import Annotated, AsyncGenerator
+from typing import Annotated, AsyncGenerator, cast
 from uuid import uuid4
 
 from src.app.plugin_system.api.adapter_api import get_bot_info_by_platform
@@ -22,8 +22,6 @@ from ...components.config import NeoChatterConfig
 
 logger = get_logger("neo_default_chatter")
 
-_TYPING_DELAY_PER_CHAR_DEFAULT = 0.5
-_TYPING_DELAY_MAX_SECONDS_DEFAULT = 10.0
 _LAST_SEND_TIME_ATTR = "_neo_default_chatter_last_send_text_time"
 
 
@@ -51,13 +49,8 @@ class SendTextAction(BaseAction):
         return min(len(content) * per_char, max_seconds)
 
     def _read_typing_delay_config(self) -> tuple[float, float]:
-        """从插件配置读取打字延迟参数，配置缺失时回退默认值。"""
-        config = self.plugin.config
-        if not isinstance(config, NeoChatterConfig):
-            return (
-                _TYPING_DELAY_PER_CHAR_DEFAULT,
-                _TYPING_DELAY_MAX_SECONDS_DEFAULT,
-            )
+        """从插件配置读取打字延迟参数。"""
+        config = cast(NeoChatterConfig, self.plugin.config)
         return (
             float(config.plugin.typing_delay_per_char),
             float(config.plugin.typing_delay_max_seconds),

--- a/test/plugins/neo_default_chatter/test_send_text_action.py
+++ b/test/plugins/neo_default_chatter/test_send_text_action.py
@@ -1,0 +1,163 @@
+"""``neo_default_chatter`` 的 ``SendTextAction`` 行为测试。
+
+重点覆盖本次修复：``execute`` 改为**异步生成器**，在真正发送前 ``yield None``
+暂停到 ``"_READY"`` 状态，配合统一调度器（``run_llm_usable_executions``）的
+顺序门控把同一轮多个 ``send_text`` 串行化，使打字延迟（基于上次发送时间差值）
+能逐条生效，而不是并发同时发出。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from plugins.neo_default_chatter.components.actions.send_text import (
+    SendTextAction,
+    _LAST_SEND_TIME_ATTR,
+)
+from plugins.neo_default_chatter.components.config import NeoChatterConfig
+from src.core.models.stream import ChatStream
+
+
+def _make_action(
+    *, stream: ChatStream | None = None, config: NeoChatterConfig | None = None
+) -> SendTextAction:
+    """构造一个 config 已注入 mock 插件实例的 SendTextAction。"""
+    plugin = MagicMock()
+    plugin.config = config if config is not None else NeoChatterConfig()
+    return SendTextAction(
+        chat_stream=stream or ChatStream(stream_id="s_group", platform="qq", chat_type="group"),
+        plugin=plugin,
+    )
+
+
+@pytest.mark.asyncio
+async def test_execute_yields_none_before_sending(monkeypatch: pytest.MonkeyPatch) -> None:
+    """execute 应先 yield None 进入 READY，再执行打字延迟与发送。"""
+    action = _make_action()
+    sleep_mock = AsyncMock()
+    send_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(action, "_sleep_for_typing_delay", sleep_mock)
+    monkeypatch.setattr(action, "_send_to_stream", send_mock)
+
+    execution = action.execute(content="你好")
+
+    # 第一次推进：进入 READY 门控，尚未 sleep / 发送
+    first = await anext(execution)
+    assert first is None
+    sleep_mock.assert_not_awaited()
+    send_mock.assert_not_awaited()
+
+    # 第二次推进：执行延迟并发送，产出最终结果
+    second = await anext(execution)
+    assert second == (True, "已发送消息:你好")
+    sleep_mock.assert_awaited_once_with("你好")
+    send_mock.assert_awaited_once_with("你好")
+
+
+@pytest.mark.asyncio
+async def test_execute_via_wrap_execute_returns_final_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """通过 ``_wrap_execute().wait_done()`` 走框架协议应拿到最终 (success, text)。"""
+    action = _make_action()
+    monkeypatch.setattr(action, "_sleep_for_typing_delay", AsyncMock())
+    monkeypatch.setattr(action, "_send_to_stream", AsyncMock(return_value=True))
+
+    execution = action._wrap_execute(content="你好")
+    success, detail = await execution.wait_done()
+
+    assert success is True
+    assert detail == "已发送消息:你好"
+
+
+@pytest.mark.asyncio
+async def test_execute_empty_content_skips_without_sending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """空内容直接产出结果，不发送。"""
+    action = _make_action()
+    send_mock = AsyncMock(return_value=True)
+    monkeypatch.setattr(action, "_send_to_stream", send_mock)
+
+    execution = action.execute(content="")
+    first = await anext(execution)
+    assert first == (True, "内容为空，跳过发送")
+    send_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_typing_delay_uses_length_and_max_cap() -> None:
+    """打字延迟应随字符长度增长，并受最大等待时间限制。"""
+    config = NeoChatterConfig()
+    config.plugin.typing_delay_per_char = 0.5
+    config.plugin.typing_delay_max_seconds = 10.0
+    action = _make_action(config=config)
+
+    assert action._typing_delay_seconds("你好呀") == pytest.approx(1.5)
+    assert action._typing_delay_seconds("x" * 10_000) == 10.0
+
+
+@pytest.mark.asyncio
+async def test_sleep_for_typing_delay_first_message_does_not_wait(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """首条消息（无上次发送时间）不等待。"""
+    action = _make_action()
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(
+        "plugins.neo_default_chatter.components.actions.send_text.asyncio.sleep",
+        sleep_mock,
+    )
+
+    await action._sleep_for_typing_delay("你好")
+
+    sleep_mock.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sleep_for_typing_delay_waits_only_remaining(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """连续发送只等待尚未经过的模拟打字时间。"""
+    stream = ChatStream(stream_id="s_group", platform="qq", chat_type="group")
+    action = _make_action(stream=stream)
+    setattr(stream.context, _LAST_SEND_TIME_ATTR, 100.0)
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(
+        "plugins.neo_default_chatter.components.actions.send_text.time.monotonic",
+        lambda: 100.5,
+    )
+    monkeypatch.setattr(
+        "plugins.neo_default_chatter.components.actions.send_text.asyncio.sleep",
+        sleep_mock,
+    )
+
+    await action._sleep_for_typing_delay("你好呀")
+
+    # 3 字符 * 0.5 = 1.5s 目标，已过 0.5s，剩余 1.0s
+    sleep_mock.assert_awaited_once_with(pytest.approx(1.0))
+
+
+@pytest.mark.asyncio
+async def test_sleep_for_typing_delay_skips_when_interval_elapsed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """距上次发送间隔足够时不等待。"""
+    stream = ChatStream(stream_id="s_group", platform="qq", chat_type="group")
+    action = _make_action(stream=stream)
+    setattr(stream.context, _LAST_SEND_TIME_ATTR, 100.0)
+    sleep_mock = AsyncMock()
+    monkeypatch.setattr(
+        "plugins.neo_default_chatter.components.actions.send_text.time.monotonic",
+        lambda: 102.0,
+    )
+    monkeypatch.setattr(
+        "plugins.neo_default_chatter.components.actions.send_text.asyncio.sleep",
+        sleep_mock,
+    )
+
+    await action._sleep_for_typing_delay("你好呀")
+
+    sleep_mock.assert_not_awaited()


### PR DESCRIPTION
# PR: 修复 neo_default_chatter 打字延迟不生效

## 改动内容

`plugins/neo_default_chatter` 的 `SendTextAction` 打字延迟在「同一轮 LLM 输出多个 `send_text`」时失效，多条消息会同时发出。本次修复将其 `execute` 改为异步生成器，在发送前 `yield None` 进入统一调度器的 `_READY` 顺序门控，使同一轮多个 `send_text` 串行发送，打字延迟逐条生效。

## 原因

框架统一调度器 `run_llm_usable_executions`（`src/core/utils/llm_tool_call.py`）会把普通 coroutine 工具**并发**执行（不经过 `_READY` 顺序门控）。原 `SendTextAction.execute` 是普通协程，多个 `send_text` 并行运行时各自读到的 `last_send_time` 相同、`asyncio.sleep` 并发等待，最终同时发出，打字延迟被绕过。

## 影响范围

- 仅改动插件 `plugins/neo_default_chatter/components/actions/send_text.py`
- 未触碰框架代码与其他插件
- 新增单元测试 `test/plugins/neo_default_chatter/test_send_text_action.py`

## 测试

- 新增 7 个单测覆盖：先 `yield None` 进入 READY 再发送、走 `_wrap_execute().wait_done()` 协议、空内容跳过、延迟按字符数/上限、首条不等待、只等剩余时间、间隔足够不等待
- NFC 全量 + tool_flow：`164 passed`
- `ruff check`：通过

## 运行时验证

同一轮连续两个 `send_text`（"好呀，那我就多说几句…" 与 "怎么样，这个速度你还满意吗♪"）实际发送间隔约 8 秒，符合 `min(字符数 × 0.5, 10)` 秒的打字延迟预期。

## Summary by Sourcery

Serialize neo_default_chatter text sending so typing delay applies correctly across multiple send_text calls in the same LLM turn.

Bug Fixes:
- Ensure SendTextAction respects configured typing delay when multiple messages are emitted in one LLM output by making execution sequenced through the READY gate.

Enhancements:
- Fallback to default typing delay configuration values when plugin config is not an instance of NeoChatterConfig.

Tests:
- Add unit tests covering SendTextAction async generator behavior, typing delay timing rules, and edge cases like empty content and already elapsed intervals.