### PR TITLE
copilot在aotupilot模式下修改的部分内容（NDFC）

### DIFF
--- a/plugins/neo_default_chatter/docs/ndfc-neo-default-chatter-status.md
+++ b/plugins/neo_default_chatter/docs/ndfc-neo-default-chatter-status.md
@@ -53,10 +53,12 @@ plugins/neo_default_chatter/
 │   ├── actions/
 │   │   ├── send_text.py           # SendTextAction（打字延迟 + reply_to + at）
 │   │   └── control.py             # PassAndWaitAction + StopConversationAction
-│   └── event_handlers/            # 【新增】设计文档未列出的子目录
-│       ├── probability_bypass.py  # ProbabilityBypassHandler (weight=100)
-│       ├── sub_agent_decision.py  # SubAgentDecisionHandler (weight=50)
-│       └── defaults/              # 【新增】16 个 Tier II 默认 handler (weight=0)
+│   └── event_handlers/
+│       └── defaults/              # 16 个 Tier II 默认 handler (weight=0) + 预处理门
+│           ├── preprocess/        # NDFC 自带预处理策略（weight>0，按权重顺序执行）
+│           │   ├── private_chat_bypass.py # PrivateChatBypassHandler (weight=2)
+│           │   ├── probability_bypass.py  # ProbabilityBypassHandler (weight=1)
+│           │   └── sub_agent_decision.py  # SubAgentDecisionHandler (weight=0)
 │           ├── _runtime_helper.py # 共享 NeoChatter 缓存（被 6 个委托 _runtime 的 handler 引用）
 │           ├── fetch_unreads.py
 │           ├── format_unread_line.py
@@ -127,8 +129,8 @@ WAIT_USER ──(收到未读/恢复事件)──▶ MODEL_TURN ──(LLM 响�
 | `SendTextAction` | Action | `send_text` | `components/actions/send_text.py` | §9.1 |
 | `PassAndWaitAction` | Action | `pass_and_wait` | `components/actions/control.py` | §9.2 |
 | `StopConversationAction` | Action | `stop_conversation` | `components/actions/control.py` | §8.1 / §9.3 |
-| `ProbabilityBypassHandler` | EventHandler | `probability_bypass` | `components/event_handlers/probability_bypass.py` | **设计未列出** |
-| `SubAgentDecisionHandler` | EventHandler | `sub_agent_decision` | `components/event_handlers/sub_agent_decision.py` | **设计未列出** |
+| `ProbabilityBypassHandler` | EventHandler | `probability_bypass` | `components/event_handlers/defaults/preprocess/probability_bypass.py` | 预处理概率直通 |
+| `SubAgentDecisionHandler` | EventHandler | `sub_agent_decision` | `components/event_handlers/defaults/preprocess/sub_agent_decision.py` | 预处理 LLM 判定 |
 | 16 个 Tier II 默认 handler | EventHandler | `<seam>_default` | `components/event_handlers/defaults/*.py` | ndfc-event-hooks.md §5 |
 
 > Config（`NeoChatterConfig`）通过 `plugin.configs = [NeoChatterConfig]` 注册，未在 `include` 里登记，符合规范。

--- a/test/plugins/neo_default_chatter/test_ndfc_event_publisher.py
+++ b/test/plugins/neo_default_chatter/test_ndfc_event_publisher.py
@@ -17,7 +17,11 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from plugins.neo_default_chatter.components.config import NeoChatterConfig
-from plugins.neo_default_chatter.utils.event_publisher import NdfcEvent, NdfcPublisher
+from plugins.neo_default_chatter.utils.event_publisher import (
+    NdfcEvent,
+    NdfcPublisher,
+    PreprocessDecision,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -596,3 +600,60 @@ async def test_session_transition_passes_all_fields(
     assert set(params.keys()) == {
         "stream_id", "from_phase", "to_phase", "turn_result",
     }
+
+
+async def test_preprocess_publishes_event_and_builds_decision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``NdfcPublisher.preprocess`` 应发布事件并构造最终决策。"""
+
+    captured: dict[str, Any] = {}
+
+    async def _fake_publish(
+        event: Any,
+        params: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        assert event == NdfcEvent.PREPROCESS
+        assert params is not None
+        captured.update(dict(params))
+        params["proceed"] = True
+        params["reason"] = "第三方策略放行"
+        params["mutations"] = "追加上下文"
+        params["force_stop_minutes"] = 2.5
+        return {"decision": None, "params": params}
+
+    monkeypatch.setattr(
+        "plugins.neo_default_chatter.utils.event_publisher.publish_event",
+        _fake_publish,
+    )
+
+    chat_stream = MagicMock()
+    cfg = _make_config()
+    logger = MagicMock()
+    result = await NdfcPublisher.preprocess(
+        chat_stream=chat_stream,
+        unreads=[],
+        history_text="hist",
+        config=cfg,
+        logger=logger,
+    )
+
+    assert isinstance(result, PreprocessDecision)
+    assert result.proceed is True
+    assert result.reason == "第三方策略放行"
+    assert result.extra == "追加上下文"
+    assert result.force_stop_minutes == 2.5
+    assert result.published is True
+    assert result.raw_params["chat_stream"] is chat_stream
+    assert captured["chat_stream"] is chat_stream
+    assert captured["history_text"] == "hist"
+    assert captured["config"] is cfg
+    assert captured["unreads"] == []
+    assert captured["proceed"] is False
+    assert captured["reason"] == ""
+    assert captured["mutations"] == ""
+    assert captured["force_stop_minutes"] is None
+    # published=True 且 proceed=True 时，仅以 debug 汇总，避免重复刷屏。
+    logger.debug.assert_any_call("[预处理] 放行：第三方策略放行")
+    logger.debug.assert_any_call("[预处理] extra+5字符")
+    logger.info.assert_not_called()

--- a/test/plugins/test_default_chatter_tool_flow.py
+++ b/test/plugins/test_default_chatter_tool_flow.py
@@ -7,7 +7,7 @@ from typing import Any, cast
 
 import pytest
 
-from plugins.default_chatter import tool_flow as tool_flow_mod
+from plugins.default_chatter.utils import tool_flow as tool_flow_mod
 from src.kernel.llm import ROLE
 
 append_suspend_payload_if_action_only = cast(Any, tool_flow_mod.append_suspend_payload_if_action_only)


### PR DESCRIPTION
## 背景

`NdfcPublisher.preprocess` 是 NDFC 预处理事件的核心入口，此前缺少直接覆盖其"发布事件 -> 预填决策字段 -> 构造 PreprocessDecision"完整链路的单测；状态文档对 `ProbabilityBypassHandler` / `SubAgentDecisionHandler` 的归属目录描述已过时。

## 改动内容

- 新增 `test_preprocess_publishes_event_and_builds_decision`，覆盖：
  - 发布 `NdfcEvent.PREPROCESS` 事件；
  - 预填决策字段默认值（proceed=False / reason="" / mutations="" / force_stop_minutes=None）；
  - 处理器就地改写字段后构造 `PreprocessDecision`；
  - `published=True` 且 `proceed=True` 时走 `logger.debug` 汇总（而非 `info`），避免重复刷屏。
- 同步 `ndfc-neo-default-chatter-status.md`：将 `ProbabilityBypassHandler` / `SubAgentDecisionHandler` 归入 `defaults/preprocess/` 子目录，补齐 `private_chat_bypass` 与 `preprocess` 目录说明。
- 修正 `test_default_chatter_tool_flow.py` 导入路径为 `plugins.default_chatter.utils.tool_flow`。

## 测试

- `pytest test/plugins/neo_default_chatter/test_ndfc_event_publisher.py test/plugins/test_default_chatter_tool_flow.py` -> 40 passed

## Summary by Sourcery

Add coverage for NDFC preprocess event publishing and decision construction, align handler documentation with current directory structure, and fix a default chatter tool-flow import path.

New Features:
- Add an async test to verify that NdfcPublisher.preprocess publishes the PREPROCESS event, populates default params, and returns a correct PreprocessDecision object.

Enhancements:
- Clarify neo_default_chatter status documentation to reflect preprocess handlers living under the defaults/preprocess directory and describe their roles.
- Update the default chatter tool-flow import to use the utils.tool_flow module for better alignment with the current package layout.

Tests:
- Extend neo_default_chatter event publisher tests to cover the full preprocess pipeline including logging behavior when an event is published and proceeds.