### PR TITLE
fix(onebot_adapter): preserve flash transfer messages

### DIFF
--- a/plugins/onebot_adapter/src/event_models.py
+++ b/plugins/onebot_adapter/src/event_models.py
@@ -61,6 +61,7 @@ class RealMessageType:  # 实际消息分类
     node = "node"  # 转发消息节点
     json = "json"  # json消息
     file = "file"  # 文件
+    flashtransfer = "flashtransfer"  # QQ 闪传
 
 
 class MessageSentType:

--- a/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
@@ -218,6 +218,11 @@ class MessageHandler:
                 return await self._handle_json_message(segment)
             case RealMessageType.file:
                 return await self._handle_file_message(segment)
+            case RealMessageType.flashtransfer:
+                return {
+                    "type": RealMessageType.flashtransfer,
+                    "data": segment.get("data", {}),
+                }
 
             case _:
                 logger.warning(f"Unsupported segment type: {seg_type}")
@@ -930,4 +935,3 @@ class MessageHandler:
         except Exception as e:
             logger.error(f"处理联系人名片分享消息时发生未知错误: {e}")
             return None
-

--- a/test/plugins/test_onebot_adapter_message_handler.py
+++ b/test/plugins/test_onebot_adapter_message_handler.py
@@ -1,0 +1,42 @@
+"""测试 OneBot 适配器消息转换。"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from plugins.onebot_adapter.src.handlers.to_core import message_handler
+
+
+@pytest.mark.asyncio
+async def test_handle_raw_message_preserves_flash_transfer_segment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QQ 闪传消息段应原样透传给核心层。"""
+    monkeypatch.setattr(
+        message_handler,
+        "get_group_info",
+        AsyncMock(return_value={"group_name": "测试群"}),
+    )
+    handler = message_handler.MessageHandler(SimpleNamespace(plugin=None))
+    flash_transfer_segment = {
+        "type": "flashtransfer",
+        "data": {"fileSetId": "flash-transfer-file-set-id"},
+    }
+    raw_message = {
+        "message_type": "group",
+        "message_id": 63001,
+        "group_id": 63002,
+        "sender": {
+            "user_id": 63003,
+            "nickname": "测试用户",
+            "card": "群名片",
+            "role": "member",
+        },
+        "message": [flash_transfer_segment],
+    }
+
+    envelope = await handler.handle_raw_message(raw_message)
+
+    assert envelope["message_segment"] == flash_transfer_segment
+    assert "flashtransfer" in envelope["message_info"]["format_info"]["content_format"]


### PR DESCRIPTION
## Summary by Sourcery

Preserve QQ flash transfer message segments when converting OneBot messages to core envelopes.

Bug Fixes:
- Treat QQ flash transfer segments as a first-class message type so they are no longer dropped during message handling.

Tests:
- Add an async test ensuring flash transfer segments are passed through unchanged and correctly reflected in message format info.