### PR TITLE
fix(booku_memory): paginate memory admin entries

### DIFF
--- a/plugins/booku_memory/router/memory_admin.html
+++ b/plugins/booku_memory/router/memory_admin.html
@@ -246,6 +246,23 @@
       padding-right: 6px;
     }
 
+    .pagination {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 12px;
+      margin-top: 14px;
+    }
+
+    .pagination button {
+      padding: 9px 14px;
+    }
+
+    .pagination .helper {
+      text-align: center;
+      white-space: nowrap;
+    }
+
     .memory-card {
       border: 1px solid rgba(148, 110, 77, 0.14);
       border-radius: 18px;
@@ -322,6 +339,13 @@
     button:hover {
       transform: translateY(-1px);
       box-shadow: 0 14px 24px rgba(124, 45, 18, 0.12);
+    }
+
+    button:disabled {
+      cursor: not-allowed;
+      opacity: 0.45;
+      transform: none;
+      box-shadow: none;
     }
 
     button.primary {
@@ -504,6 +528,11 @@
             </div>
           </div>
           <div class="memory-list" id="memory-list"></div>
+          <div class="pagination">
+            <button class="secondary" id="previous-page-button" type="button">上一页</button>
+            <span class="helper" id="page-indicator">第 1 / 1 页</span>
+            <button class="secondary" id="next-page-button" type="button">下一页</button>
+          </div>
         </div>
 
         <div class="editor-panel panel">
@@ -668,6 +697,12 @@
     const state = {
       selectedId: null,
       items: [],
+      page: 1,
+      pageSize: 60,
+      total: 0,
+      loadedPage: 1,
+      listRequestId: 0,
+      listLoading: false,
       counts: {
         memory: 0,
         knowledge: 0
@@ -682,6 +717,9 @@
     const filterDeleted = document.getElementById('filter-deleted');
     const memoryList = document.getElementById('memory-list');
     const listSummary = document.getElementById('list-summary');
+    const previousPageButton = document.getElementById('previous-page-button');
+    const nextPageButton = document.getElementById('next-page-button');
+    const pageIndicator = document.getElementById('page-indicator');
     const statusBar = document.getElementById('status-bar');
     const form = document.getElementById('editor-form');
 
@@ -734,7 +772,8 @@
       if (filterStatus.value) params.set('status', filterStatus.value);
       params.set('include_deleted', String(filterDeleted.checked));
       params.set('include_archived', 'true');
-      params.set('limit', '60');
+      params.set('page', String(state.page));
+      params.set('page_size', String(state.pageSize));
       return params;
     }
 
@@ -771,14 +810,36 @@
       renderMetrics();
     }
 
+    function resetListQueryState() {
+      state.listRequestId += 1;
+      state.page = 1;
+      state.loadedPage = 1;
+      state.listLoading = false;
+      state.items = [];
+      state.total = 0;
+      state.selectedId = null;
+      renderList();
+      renderPagination();
+    }
+
+    function renderPagination() {
+      const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+      pageIndicator.textContent = `第 ${state.page} / ${totalPages} 页`;
+      previousPageButton.disabled = state.listLoading || state.page <= 1;
+      nextPageButton.disabled = state.listLoading || state.page >= totalPages;
+    }
+
     function renderList() {
       if (!state.items.length) {
         memoryList.innerHTML = '<div class="empty">当前过滤条件下没有记录</div>';
-        listSummary.textContent = '共 0 条';
+        listSummary.textContent = '第 0-0 条，共 0 条';
+        renderPagination();
         return;
       }
 
-      listSummary.textContent = `共 ${state.items.length} 条`;
+      const rangeStart = (state.page - 1) * state.pageSize + 1;
+      const rangeEnd = Math.min(rangeStart + state.items.length - 1, state.total);
+      listSummary.textContent = `第 ${rangeStart}-${rangeEnd} 条，共 ${state.total} 条`;
       memoryList.innerHTML = state.items.map((item) => {
         const metadata = item.metadata || {};
         const isActive = item.id === state.selectedId ? 'active' : '';
@@ -798,16 +859,51 @@
       memoryList.querySelectorAll('.memory-card').forEach((card) => {
         card.addEventListener('click', () => loadDetail(card.dataset.id));
       });
+      renderPagination();
     }
 
-    async function loadList(preserveSelection = true) {
-      const result = await request(`/memories?${currentFilters().toString()}`);
-      state.items = Array.isArray(result.items) ? result.items : [];
-      if (!preserveSelection || !state.items.some((item) => item.id === state.selectedId)) {
-        state.selectedId = null;
+    async function loadList(preserveSelection = true, allowPageFallback = true) {
+      const requestId = ++state.listRequestId;
+      state.listLoading = true;
+      renderPagination();
+      try {
+        const result = await request(`/memories?${currentFilters().toString()}`);
+        if (requestId !== state.listRequestId) return;
+
+        const items = Array.isArray(result.items) ? result.items : [];
+        const total = Math.max(0, Number(result.total) || 0);
+        const page = Math.max(1, Number(result.page) || state.page);
+        const pageSize = Math.max(1, Number(result.page_size) || state.pageSize);
+        const totalPages = Math.max(1, Math.ceil(total / pageSize));
+        if (allowPageFallback && page > totalPages) {
+          state.page = totalPages;
+          state.loadedPage = totalPages;
+          state.pageSize = pageSize;
+          state.total = total;
+          state.items = [];
+          state.selectedId = null;
+          renderList();
+          return loadList(preserveSelection, false);
+        }
+
+        state.items = items;
+        state.total = total;
+        state.page = page;
+        state.pageSize = pageSize;
+        if (!preserveSelection || !state.items.some((item) => item.id === state.selectedId)) {
+          state.selectedId = null;
+        }
+        state.loadedPage = state.page;
+        state.listLoading = false;
+        renderList();
+        renderMetrics();
+      } catch (error) {
+        if (requestId !== state.listRequestId) return;
+        state.page = state.loadedPage;
+        state.listLoading = false;
+        renderPagination();
+        throw error;
       }
-      renderList();
-      renderMetrics();
     }
 
     function fillField(id, value) {
@@ -970,8 +1066,30 @@
     document.getElementById('hard-delete-button').addEventListener('click', () => removeMemory(true));
     form.addEventListener('submit', saveMemory);
 
+    previousPageButton.addEventListener('click', async () => {
+      if (state.listLoading || state.page <= 1) return;
+      state.page -= 1;
+      try {
+        await loadList(false);
+      } catch (error) {
+        setStatus(`翻页失败：${error.message}`, true);
+      }
+    });
+
+    nextPageButton.addEventListener('click', async () => {
+      const totalPages = Math.max(1, Math.ceil(state.total / state.pageSize));
+      if (state.listLoading || state.page >= totalPages) return;
+      state.page += 1;
+      try {
+        await loadList(false);
+      } catch (error) {
+        setStatus(`翻页失败：${error.message}`, true);
+      }
+    });
+
     [filterFolder, filterType, filterStatus, filterDeleted].forEach((node) => {
       node.addEventListener('change', async () => {
+        resetListQueryState();
         try {
           await loadStatus();
           await loadList(false);
@@ -983,6 +1101,7 @@
 
     let keywordTimer = null;
     filterKeyword.addEventListener('input', () => {
+      resetListQueryState();
       window.clearTimeout(keywordTimer);
       keywordTimer = window.setTimeout(async () => {
         try {

--- a/plugins/booku_memory/router/memory_admin_router.py
+++ b/plugins/booku_memory/router/memory_admin_router.py
@@ -201,7 +201,8 @@ class BookuMemoryAdminRouter(BaseRouter):
             bucket: str | None = Query(default=None, description="bucket"),
             include_archived: bool = Query(default=True, description="是否包含 archived"),
             include_deleted: bool = Query(default=False, description="是否包含软删除"),
-            limit: int = Query(default=60, ge=1, le=200, description="返回上限"),
+            page: int = Query(default=1, ge=1, description="页码"),
+            page_size: int = Query(default=60, ge=1, le=200, description="每页条数"),
         ) -> dict[str, Any]:
             """按条件列出记忆。"""
 
@@ -214,7 +215,8 @@ class BookuMemoryAdminRouter(BaseRouter):
                 bucket=self._normalize_single(bucket),
                 include_archived=include_archived,
                 include_deleted=include_deleted,
-                limit=limit,
+                page=page,
+                page_size=page_size,
             )
 
         @self.app.get("/api/memories/{memory_id}")

--- a/plugins/booku_memory/service/booku_memory_service.py
+++ b/plugins/booku_memory/service/booku_memory_service.py
@@ -2208,9 +2208,10 @@ class BookuMemoryService(BaseService):
         bucket: str | None = None,
         include_archived: bool = True,
         include_deleted: bool = False,
-        limit: int = 50,
+        page: int = 1,
+        page_size: int = 60,
     ) -> dict[str, Any]:
-        """按后台管理所需的结构化条件列出记忆。
+        """按后台管理所需的结构化条件分页列出记忆。
 
         Args:
             keyword: 标题、正文、ID 的模糊关键词。
@@ -2219,12 +2220,13 @@ class BookuMemoryService(BaseService):
             person_id: 人物 ID 过滤。
             folder_id: folder 过滤。
             bucket: bucket 过滤。
-            include_archived: 是否包含 archived bucket，默认 True。
+            include_archived: 是否包含 archived 状态，默认 True。
             include_deleted: 是否包含软删除记录，默认 False。
-            limit: 最大返回条数。
+            page: 页码，从 1 开始。
+            page_size: 每页条数。
 
         Returns:
-            包含 action、total、items 字段的字典。
+            包含 action、total、page、page_size、items 字段的字典。
         """
         repo = await self._get_repo()
         config = self._get_config()
@@ -2236,29 +2238,27 @@ class BookuMemoryService(BaseService):
             )
 
         normalized_bucket = (bucket or "").strip().lower() or None
-        records = await repo.search_records(
+        normalized_page = max(1, int(page))
+        normalized_page_size = max(1, int(page_size))
+        records, total = await repo.paginate_records(
             keyword=(keyword or "").strip() or None,
             memory_type=(memory_type or "").strip().lower() or None,
             status=(status or "").strip().lower() or None,
             person_id=(person_id or "").strip() or None,
             folder_id=normalized_folder_id,
+            bucket=normalized_bucket,
+            include_archived=include_archived,
             include_deleted=include_deleted,
-            limit=max(1, int(limit)),
+            page=normalized_page,
+            page_size=normalized_page_size,
         )
-
-        filtered_records: list[Any] = []
-        for record in records:
-            record_bucket = str(getattr(record, "bucket", "") or "").strip().lower()
-            if normalized_bucket and record_bucket != normalized_bucket:
-                continue
-            if not include_archived and record_bucket == "archived":
-                continue
-            filtered_records.append(record)
 
         return {
             "action": "list_memory_entries",
-            "total": len(filtered_records),
-            "items": [self._build_record_item(record) for record in filtered_records],
+            "total": total,
+            "page": normalized_page,
+            "page_size": normalized_page_size,
+            "items": [self._build_record_item(record) for record in records],
         }
 
     async def update_activated(self, memory_id: str) -> None:

--- a/plugins/booku_memory/service/metadata_repository.py
+++ b/plugins/booku_memory/service/metadata_repository.py
@@ -915,6 +915,83 @@ class BookuMemoryMetadataRepository:
         rows = await qb.order_by("-updated_at").limit(max(1, int(limit))).all()
         return [self._to_record(r) for r in rows]  # type: ignore[arg-type]
 
+    async def paginate_records(
+        self,
+        *,
+        keyword: str | None = None,
+        memory_type: str | None = None,
+        status: str | None = None,
+        person_id: str | None = None,
+        folder_id: str | None = None,
+        bucket: str | None = None,
+        include_archived: bool = True,
+        include_deleted: bool = False,
+        page: int = 1,
+        page_size: int = 60,
+    ) -> tuple[list[BookuMemoryRecord], int]:
+        """按结构化约束分页查询记忆记录及过滤后的总数。"""
+
+        R = BookuMemoryRecordModel
+        normalized_page = max(1, int(page))
+        normalized_page_size = max(1, int(page_size))
+
+        stmt = select(R)
+        if folder_id is not None:
+            stmt = stmt.where(R.folder_id == folder_id)
+        if memory_type:
+            stmt = stmt.where(R.memory_type == memory_type)
+        if status:
+            stmt = stmt.where(R.status == status)
+        if person_id:
+            stmt = stmt.where(R.person_id == person_id)
+        if bucket:
+            stmt = stmt.where(R.bucket == bucket)
+        if not include_archived:
+            stmt = stmt.where(R.status != "archived")
+        if not include_deleted:
+            stmt = stmt.where(R.is_deleted == 0)
+
+        cleaned_keyword = (keyword or "").strip()
+        if cleaned_keyword:
+            like_value = f"%{cleaned_keyword}%"
+            stmt = stmt.where(
+                or_(
+                    R.title.like(like_value),
+                    R.content.like(like_value),
+                    R.memory_id.like(like_value),
+                )
+            )
+
+        count_stmt = select(func.count()).select_from(
+            stmt.order_by(None).subquery()
+        )
+        page_stmt = (
+            stmt.order_by(
+                R.last_activated_at.desc(),
+                R.updated_at.desc(),
+                R.memory_id.desc(),
+            )
+            .offset((normalized_page - 1) * normalized_page_size)
+            .limit(normalized_page_size)
+        )
+        async with self._db.session() as s:
+            total = int((await s.execute(count_stmt)).scalar_one())
+            rows = (await s.execute(page_stmt)).scalars().all()
+
+        if not rows:
+            return [], total
+
+        ids = [row.memory_id for row in rows]
+        records_by_id = await self.get_records_map(
+            ids,
+            include_deleted=include_deleted,
+        )
+        return [
+            records_by_id[row.memory_id]
+            for row in rows
+            if row.memory_id in records_by_id
+        ], total
+
     async def search_records(
         self,
         *,

--- a/test/plugins/booku_memory/test_memory_admin_router.py
+++ b/test/plugins/booku_memory/test_memory_admin_router.py
@@ -91,6 +91,7 @@ class StubMemoryService:
             ),
         }
         self.last_create: dict[str, Any] | None = None
+        self.last_list: dict[str, Any] | None = None
         self.last_update: dict[str, Any] | None = None
         self.last_move: dict[str, Any] | None = None
         self.last_delete: dict[str, Any] | None = None
@@ -128,6 +129,7 @@ class StubMemoryService:
     async def list_memory_entries(self, **kwargs: Any) -> dict[str, Any]:
         """返回记忆列表。"""
 
+        self.last_list = kwargs
         bucket = kwargs.get("bucket")
         include_deleted = bool(kwargs.get("include_deleted", False))
         items = []
@@ -144,7 +146,17 @@ class StubMemoryService:
                 "is_truncated": item["is_truncated"],
                 "metadata": deepcopy(metadata),
             })
-        return {"action": "list_memory_entries", "total": len(items), "items": items}
+        page = max(1, int(kwargs.get("page", 1)))
+        page_size = max(1, int(kwargs.get("page_size", 60)))
+        total = len(items)
+        offset = (page - 1) * page_size
+        return {
+            "action": "list_memory_entries",
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "items": items[offset : offset + page_size],
+        }
 
     async def get_memory_detail(self, *, memory_id: str, include_deleted: bool = True) -> dict[str, Any]:
         """返回单条记忆详情。"""
@@ -288,6 +300,60 @@ async def test_admin_pages_return_html(client: AsyncClient) -> None:
     assert memory_response.status_code == 200
     assert "常规记忆" in memory_response.text
     assert "memory" in memory_response.text
+    assert 'id="previous-page-button"' in memory_response.text
+    assert 'id="next-page-button"' in memory_response.text
+    assert 'id="page-indicator"' in memory_response.text
+    assert "loadedPage: 1" in memory_response.text
+    assert "listRequestId: 0" in memory_response.text
+    assert "listLoading: false" in memory_response.text
+    assert "const requestId = ++state.listRequestId;" in memory_response.text
+    assert "if (requestId !== state.listRequestId) return;" in memory_response.text
+    assert "state.listLoading || state.page <= 1" in memory_response.text
+    assert "state.listLoading || state.page >= totalPages" in memory_response.text
+
+    fallback_start = memory_response.text.index(
+        "if (allowPageFallback && page > totalPages)"
+    )
+    fallback_end = memory_response.text.index(
+        "\n        }\n\n        state.items = items;",
+        fallback_start,
+    )
+    fallback_block = memory_response.text[fallback_start:fallback_end]
+    fallback_call = "return loadList(preserveSelection, false);"
+    assert fallback_call in fallback_block
+    assert fallback_block.index("state.loadedPage = totalPages;") < fallback_block.index(
+        fallback_call
+    )
+    assert fallback_block.index("state.items = [];") < fallback_block.index(fallback_call)
+    assert fallback_block.index("state.selectedId = null;") < fallback_block.index(
+        fallback_call
+    )
+
+    reset_start = memory_response.text.index("function resetListQueryState()")
+    reset_end = memory_response.text.index("\n    }", reset_start)
+    reset_block = memory_response.text[reset_start:reset_end]
+    assert "state.listRequestId += 1;" in reset_block
+    assert "state.loadedPage = 1;" in reset_block
+    assert "state.items = [];" in reset_block
+    assert "state.total = 0;" in reset_block
+
+    change_start = memory_response.text.index(
+        "[filterFolder, filterType, filterStatus, filterDeleted].forEach"
+    )
+    change_end = memory_response.text.index("let keywordTimer", change_start)
+    change_handler = memory_response.text[change_start:change_end]
+    assert change_handler.index("resetListQueryState();") < change_handler.index(
+        "await loadStatus();"
+    )
+
+    keyword_start = memory_response.text.index(
+        "filterKeyword.addEventListener('input'"
+    )
+    keyword_end = memory_response.text.index("async function boot()", keyword_start)
+    keyword_handler = memory_response.text[keyword_start:keyword_end]
+    assert keyword_handler.index("resetListQueryState();") < keyword_handler.index(
+        "window.setTimeout"
+    )
 
     knowledge_response = await client.get("/knowledge")
     assert knowledge_response.status_code == 200
@@ -302,6 +368,8 @@ async def test_list_and_create_memory(client: AsyncClient, stub_service: StubMem
     list_response = await client.get("/api/memories")
     assert list_response.status_code == 200
     assert list_response.json()["total"] == 1
+    assert list_response.json()["page"] == 1
+    assert list_response.json()["page_size"] == 60
 
     folders_response = await client.get("/api/folders")
     assert folders_response.status_code == 200
@@ -329,6 +397,33 @@ async def test_list_and_create_memory(client: AsyncClient, stub_service: StubMem
     assert detail["item"]["metadata"]["bucket"] == "knowledge"
     assert stub_service.last_create is not None
     assert stub_service.last_create["folder_id"] == "project-a"
+
+
+@pytest.mark.asyncio
+async def test_list_memories_passes_pagination_to_service(
+    client: AsyncClient,
+    stub_service: StubMemoryService,
+) -> None:
+    """列表接口应透传分页参数并返回分页元数据。"""
+
+    for index in range(40):
+        memory_id = f"m-{index + 2}"
+        stub_service.items[memory_id] = _build_item(
+            memory_id,
+            title=f"记忆 {index + 2}",
+            content=f"正文 {index + 2}",
+        )
+
+    response = await client.get("/api/memories?page=2&page_size=20")
+
+    assert response.status_code == 200
+    assert stub_service.last_list is not None
+    assert stub_service.last_list["page"] == 2
+    assert stub_service.last_list["page_size"] == 20
+    assert response.json()["total"] == 41
+    assert response.json()["page"] == 2
+    assert response.json()["page_size"] == 20
+    assert len(response.json()["items"]) == 20
 
 
 @pytest.mark.asyncio

--- a/test/plugins/booku_memory/test_metadata_repository.py
+++ b/test/plugins/booku_memory/test_metadata_repository.py
@@ -10,11 +10,13 @@ from collections.abc import AsyncGenerator
 from pathlib import Path
 
 import pytest
+from sqlalchemy import update
 
 from plugins.booku_memory.service.metadata_repository import (
     BookuMemoryMetadataRepository,
     BookuMemoryRecord,
 )
+from plugins.booku_memory.service.models import BookuMemoryRecordModel
 
 
 # ---------------------------------------------------------------------------
@@ -273,6 +275,64 @@ async def test_list_records_by_bucket_filters_and_limits(
 
     limited = await repo.list_records_by_bucket(bucket="memory", folder_id=None, limit=1)
     assert len(limited) == 1
+
+
+@pytest.mark.asyncio
+async def test_paginate_records_returns_second_page_and_filtered_total(
+    repo: BookuMemoryMetadataRepository,
+) -> None:
+    """paginate_records 应在 SQL 过滤 bucket 后返回准确总数与第二页。"""
+
+    for index in range(65):
+        await repo.upsert_record(
+            **_sample_kwargs(f"memory-{index:02d}", bucket="memory")
+        )
+    for index in range(3):
+        await repo.upsert_record(
+            **_sample_kwargs(f"knowledge-{index:02d}", bucket="knowledge")
+        )
+
+    records, total = await repo.paginate_records(
+        bucket="memory",
+        page=2,
+        page_size=60,
+    )
+
+    assert total == 65
+    assert len(records) == 5
+    assert all(record.bucket == "memory" for record in records)
+
+
+@pytest.mark.asyncio
+async def test_paginate_records_uses_memory_id_as_stable_tiebreaker(
+    repo: BookuMemoryMetadataRepository,
+) -> None:
+    """相同激活和更新时间的记录跨页时应按 memory_id 稳定倒序。"""
+
+    memory_ids = [f"stable-{index}" for index in range(5)]
+    for memory_id in memory_ids:
+        await repo.upsert_record(**_sample_kwargs(memory_id))
+
+    async with repo._db.session() as session:  # pyright: ignore[reportPrivateUsage]
+        await session.execute(
+            update(BookuMemoryRecordModel)
+            .where(BookuMemoryRecordModel.memory_id.in_(memory_ids))
+            .values(last_activated_at=100.0, updated_at=100.0)
+        )
+
+    pages = [
+        await repo.paginate_records(page=page, page_size=2)
+        for page in range(1, 4)
+    ]
+    paged_ids = [
+        record.memory_id
+        for records, _ in pages
+        for record in records
+    ]
+
+    assert [total for _, total in pages] == [5, 5, 5]
+    assert paged_ids == sorted(memory_ids, reverse=True)
+    assert len(paged_ids) == len(set(paged_ids)) == len(memory_ids)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary by Sourcery

Add server-side pagination support for memory admin listing and wire it through the API, service layer, repository, UI, and tests.

New Features:
- Introduce paginated memory listing in the admin UI with next/previous controls and page indicators.

Enhancements:
- Refine list summary display to show item ranges and total count instead of only item count.
- Ensure list queries and pagination state are robust against concurrent requests, empty pages, and filter changes.
- Add repository-level pagination query that returns filtered totals and a stable ordering for cross-page navigation.

Tests:
- Extend memory admin router tests to cover pagination controls, request state handling, and API pagination metadata.
- Add tests for the stub service, API, and repository to verify pagination parameters are passed through and results are correctly paginated.