### PR TITLE
fix(converter): 视频/语音占位符注入 media_id

### DIFF
--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -776,7 +776,8 @@ class MessageConverter:
                         video_texts.append((i, None))
 
             # 将识别结果应用回 text_parts，替换占位符
-            # 占位符格式：[图片(media_id):description] / [表情包(media_id):description] / [语音(media_id):text]
+            # 占位符格式：[图片(media_id):description] / [表情包(media_id):description]
+            #           / [语音(media_id):text] / [视频(media_id):text]
             # media_id 为该媒体的 sha256 哈希，AI 可据此精确引用历史媒体
             new_text_parts = []
             media_idx = 0
@@ -803,7 +804,7 @@ class MessageConverter:
                     if voice_idx < len(voice_texts):
                         voice_i, text = voice_texts[voice_idx]
                         voice_idx += 1
-                        media_id = result.media[voice_i].get("image_id", "")
+                        media_id = result.media[voice_i].get("voice_id", "")
                         if media_id and text:
                             new_text_parts.append(f"[语音({media_id}):{text}]")
                         elif media_id:
@@ -816,9 +817,14 @@ class MessageConverter:
                         new_text_parts.append(part)
                 elif part == "[视频]":
                     if video_idx < len(video_texts):
-                        _, text = video_texts[video_idx]
+                        video_i, text = video_texts[video_idx]
                         video_idx += 1
-                        if text:
+                        media_id = result.media[video_i].get("video_id", "")
+                        if media_id and text:
+                            new_text_parts.append(f"[视频({media_id}):{text}]")
+                        elif media_id:
+                            new_text_parts.append(f"[视频({media_id})]")
+                        elif text:
                             new_text_parts.append(f"[视频:{text}]")
                         else:
                             new_text_parts.append(part)

--- a/test/core/transport/test_message_converter_media_id.py
+++ b/test/core/transport/test_message_converter_media_id.py
@@ -1,0 +1,155 @@
+"""MessageConverter 媒体占位符 media_id 注入的单元测试。
+
+覆盖场景：
+- 图片 / 表情包：占位符带 media_id（image_id），``[图片(hash):desc]`` 或 ``[图片(hash)]``。
+- 语音：占位符带 media_id（voice_id），``[语音(hash):text]`` 或 ``[语音(hash)]``。
+- 视频：占位符带 media_id（video_id），``[视频(hash):text]`` 或 ``[视频(hash)]``。
+- 视频段 dict 形态（OneBot 适配器产出的 ``{"base64": ...}``）同样注入 video_id。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, _patch, patch
+
+import pytest
+
+from src.core.managers.media_manager.utils import compute_media_hash
+from src.core.transport.message_receive.converter import _ParseResult, MessageConverter
+
+#: 固定的 base64 输入，识别调用一律返回 None（模拟"跳过/未识别"）
+_RAW_BASE64 = "aGVsbG8gd29ybGQ="
+
+
+def _make_envelope(segments: list[dict]) -> dict:
+    """构造一个最小可用的 MessageEnvelope。"""
+    return {
+        "direction": "incoming",
+        "message_info": {
+            "message_id": "m1",
+            "platform": "qq",
+            "time": 1700000000.0,
+            "user_info": {
+                "platform": "qq",
+                "user_id": "u1",
+                "user_nickname": "Alice",
+            },
+        },
+        "message_segment": segments,
+    }
+
+
+def _patch_manager(recognize_return: str | None = None) -> tuple[MagicMock, _patch]:
+    """构造打桩的 media manager，并 patch converter 内的 get_media_manager。"""
+    mock_manager = MagicMock()
+    mock_manager.should_skip_recognition.return_value = False
+    mock_manager.recognize_media = AsyncMock(return_value=recognize_return)
+    patch_get = patch(
+        "src.core.managers.media_manager.get_media_manager",
+        return_value=mock_manager,
+    )
+    return mock_manager, patch_get
+
+
+@pytest.mark.asyncio
+async def test_video_placeholder_injects_video_id() -> None:
+    """视频（dict 形态）占位符应注入 video_id，无识别结果时保留 ``[视频(hash)]``。"""
+    mock_manager, patch_get = _patch_manager(recognize_return=None)
+    with patch_get:
+        converter = MessageConverter()
+        envelope = _make_envelope([
+            {
+                "type": "video",
+                "data": {"base64": _RAW_BASE64, "filename": "v.mp4", "size_mb": 1.0},
+            },
+        ])
+        message = await converter.envelope_to_message(envelope)
+
+    expected_hash = compute_media_hash(_RAW_BASE64)
+    assert message.extra["media"][0]["video_id"] == expected_hash
+    assert message.processed_plain_text == f"[视频({expected_hash})]"
+    mock_manager.recognize_media.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_video_placeholder_with_description() -> None:
+    """视频识别成功后占位符应为 ``[视频(hash):text]``。"""
+    _, patch_get = _patch_manager(recognize_return="两个人边走边聊")
+    with patch_get:
+        converter = MessageConverter()
+        envelope = _make_envelope([
+            {"type": "video", "data": {"base64": _RAW_BASE64}},
+        ])
+        message = await converter.envelope_to_message(envelope)
+
+    expected_hash = compute_media_hash(_RAW_BASE64)
+    assert message.processed_plain_text == f"[视频({expected_hash}):两个人边走边聊]"
+
+
+@pytest.mark.asyncio
+async def test_video_placeholder_without_video_id_keeps_legacy() -> None:
+    """media 项缺失 video_id 时，回退为旧的 ``[视频:desc]`` / ``[视频]`` 形态。"""
+    _, patch_get = _patch_manager(recognize_return=None)
+    with patch_get:
+        converter = MessageConverter()
+        # 直接构造 media 项无 video_id 的解析结果，绕开 _parse_segments 的哈希注入
+        result = _ParseResult()
+        result.media.append({"type": "video", "data": _RAW_BASE64})
+        result.text_parts.append("[视频]")
+        updated = await converter._recognize_media_with_manager(result, "stream_1")
+    assert updated.plain_text == "[视频]"
+
+
+@pytest.mark.asyncio
+async def test_voice_placeholder_injects_voice_id() -> None:
+    """语音占位符应注入 voice_id（而不是误读 image_id）。"""
+    mock_manager, patch_get = _patch_manager(recognize_return=None)
+    with patch_get:
+        converter = MessageConverter()
+        envelope = _make_envelope([{"type": "voice", "data": _RAW_BASE64}])
+        message = await converter.envelope_to_message(envelope)
+
+    expected_hash = compute_media_hash(_RAW_BASE64)
+    assert message.extra["media"][0]["voice_id"] == expected_hash
+    assert message.processed_plain_text == f"[语音({expected_hash})]"
+    mock_manager.recognize_media.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_voice_placeholder_with_description() -> None:
+    """语音识别成功后占位符应为 ``[语音(hash):text]``。"""
+    _, patch_get = _patch_manager(recognize_return="明天见")
+    with patch_get:
+        converter = MessageConverter()
+        envelope = _make_envelope([{"type": "voice", "data": _RAW_BASE64}])
+        message = await converter.envelope_to_message(envelope)
+
+    expected_hash = compute_media_hash(_RAW_BASE64)
+    assert message.processed_plain_text == f"[语音({expected_hash}):明天见]"
+
+
+@pytest.mark.asyncio
+async def test_image_placeholder_still_injects_image_id() -> None:
+    """图片占位符保持既有行为：注入 image_id。"""
+    _, patch_get = _patch_manager(recognize_return=None)
+    with patch_get:
+        converter = MessageConverter()
+        envelope = _make_envelope([{"type": "image", "data": _RAW_BASE64}])
+        message = await converter.envelope_to_message(envelope)
+
+    expected_hash = compute_media_hash(_RAW_BASE64)
+    assert message.extra["media"][0]["image_id"] == expected_hash
+    assert message.processed_plain_text == f"[图片({expected_hash})]"
+
+
+@pytest.mark.asyncio
+async def test_emoji_placeholder_still_injects_image_id() -> None:
+    """表情包占位符保持既有行为：注入 image_id。"""
+    _, patch_get = _patch_manager(recognize_return=None)
+    with patch_get:
+        converter = MessageConverter()
+        envelope = _make_envelope([{"type": "emoji", "data": _RAW_BASE64}])
+        message = await converter.envelope_to_message(envelope)
+
+    expected_hash = compute_media_hash(_RAW_BASE64)
+    assert message.extra["media"][0]["image_id"] == expected_hash
+    assert message.processed_plain_text == f"[表情包({expected_hash})]"

--- a/test/core/transport/test_message_converter_media_id.py
+++ b/test/core/transport/test_message_converter_media_id.py
@@ -9,7 +9,8 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, _patch, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -38,7 +39,7 @@ def _make_envelope(segments: list[dict]) -> dict:
     }
 
 
-def _patch_manager(recognize_return: str | None = None) -> tuple[MagicMock, _patch]:
+def _patch_manager(recognize_return: str | None = None) -> tuple[MagicMock, Any]:
     """构造打桩的 media manager，并 patch converter 内的 get_media_manager。"""
     mock_manager = MagicMock()
     mock_manager.should_skip_recognition.return_value = False
@@ -87,7 +88,7 @@ async def test_video_placeholder_with_description() -> None:
 
 @pytest.mark.asyncio
 async def test_video_placeholder_without_video_id_keeps_legacy() -> None:
-    """media 项缺失 video_id 时，回退为旧的 ``[视频:desc]`` / ``[视频]`` 形态。"""
+    """media 项缺失 video_id 时，回退为旧的 ``[视频]`` 形态。"""
     _, patch_get = _patch_manager(recognize_return=None)
     with patch_get:
         converter = MessageConverter()
@@ -97,6 +98,19 @@ async def test_video_placeholder_without_video_id_keeps_legacy() -> None:
         result.text_parts.append("[视频]")
         updated = await converter._recognize_media_with_manager(result, "stream_1")
     assert updated.plain_text == "[视频]"
+
+
+@pytest.mark.asyncio
+async def test_video_placeholder_without_video_id_keeps_legacy_description() -> None:
+    """media 项缺失 video_id 但有识别文本时，回退为旧的 ``[视频:desc]`` 形态。"""
+    _, patch_get = _patch_manager(recognize_return="一段风景视频")
+    with patch_get:
+        converter = MessageConverter()
+        result = _ParseResult()
+        result.media.append({"type": "video", "data": _RAW_BASE64})
+        result.text_parts.append("[视频]")
+        updated = await converter._recognize_media_with_manager(result, "stream_1")
+    assert updated.plain_text == "[视频:一段风景视频]"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR: fix(converter): 视频/语音占位符注入 media_id

## 改动内容

在消息转换器 `src/core/transport/message_receive/converter.py` 的
`_recognize_media_with_manager` 中，修复媒体占位符缺失 media_id 的问题：

1. **视频分支**：占位符不再只输出 `[视频]` / `[视频:desc]`，而是读取媒体项的
   `video_id`，输出 `[视频(video_id):desc]` 或 `[视频(video_id)]`，与图片/表情包/语音
   的占位符格式对齐。
2. **语音分支**：修正读取键错误。此前误读 `image_id`（实际 `_handle_voice` 写入的是
   `voice_id`），导致语音的 media_id 实际为空；改为读取 `voice_id`。

两种分支都保留了媒体项缺失对应 ID 时的旧格式兜底，不破坏现有第三方插件。

## 原因

图片/表情包/语音在既有提交中已支持 `[图片(hash):...]` / `[语音(hash):...]` 占位符，
但视频分支一直遗漏；语音分支则因读取键错误导致哈希未生效。修复后四类媒体的
占位符均携带内容哈希（SHA256），LLM 可据此在长上下文中精确引用历史媒体，避免
多模态长上下文错位。

## 影响范围

- 仅改动框架 `converter.py` 的占位符应用逻辑与新增对应单元测试
- 不涉及插件代码，不影响第三方插件既有行为
- 新增 `test/core/transport/test_message_converter_media_id.py`，覆盖视频（dict/string
  形态、带/不带描述、缺失 video_id 兜底）、语音（voice_id 注入、带描述）、图片/
  表情包回归，共 7 个用例

## 验证

- `ruff check` 通过
- 新增 7 个测试全部通过
- 相关 `test_media_manager.py` 40 个用例通过

## Summary by Sourcery

Align media placeholder handling for video and voice messages to include media_id hashes and ensure consistent behavior with existing image and emoji placeholders.

Bug Fixes:
- Fix voice placeholder to read voice_id instead of image_id so media_id is correctly injected.
- Ensure video placeholders inject video_id into the plain-text representation and fall back to legacy formats when IDs are missing.

Tests:
- Add unit tests covering media_id injection for video (including dict-form segments), voice, image, and emoji placeholders, and legacy fallback behavior for missing video_id.