### PR TITLE
feat(media): 新增媒体描述缓存写入与文件读取公开 API

### DIFF
--- a/src/app/plugin_system/api/media_api.py
+++ b/src/app/plugin_system/api/media_api.py
@@ -227,10 +227,61 @@ async def get_media_info(media_hash: str) -> dict[str, Any] | None:
     return None
 
 
+async def save_description_cache(
+    media_hash: str,
+    media_type: str,
+    description: str,
+) -> None:
+    """保存媒体识别描述到对应的描述缓存表。
+
+    按 ``media_type`` 路由到 MediaManager：
+    - ``image`` / ``emoji`` → ``ImageDescriptions`` 表（type 为动态值）
+    - ``voice`` → ``VoiceDescriptions`` 表
+    - ``video`` → ``VideoDescriptions`` 表
+
+    描述写入缓存后，converter 收媒体时会以 ``use_cache=True`` 查该缓存，
+    命中后描述直接替换占位符进入上下文（如 ``[视频(media_id):描述]``）。
+
+    Args:
+        media_hash: 媒体哈希值（作为描述缓存的主键）
+        media_type: 媒体类型，``image`` / ``emoji`` / ``voice`` / ``video``
+        description: 媒体识别描述文本
+
+    Returns:
+        None
+    """
+    _validate_non_empty(media_hash, "media_hash")
+    _validate_media_type(media_type)
+    _validate_non_empty(description, "description")
+    await _get_media_manager().save_description_cache(
+        media_hash=media_hash,
+        media_type=media_type,
+        description=description,
+    )
+
+
+async def get_media_file(media_hash: str) -> str | None:
+    """根据媒体哈希读取落盘文件的 base64 内容。
+
+    先经 MediaManager 查询媒体记录的 path，再按该路径读文件并编码为
+    base64。文件不存在或读取失败（例如已被清理）时返回 None。
+
+    Args:
+        media_hash: 媒体哈希值（image_id / voice_id / video_id）
+
+    Returns:
+        base64 编码的文件内容；文件不存在或读取失败时返回 None
+    """
+    _validate_non_empty(media_hash, "media_hash")
+    return await _get_media_manager().get_media_file(media_hash)
+
+
 __all__ = [
     "API_VERSION",
     "recognize_media",
     "recognize_batch",
     "save_media_info",
     "get_media_info",
+    "save_description_cache",
+    "get_media_file",
 ]

--- a/src/app/plugin_system/api/media_api.py
+++ b/src/app/plugin_system/api/media_api.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-API_VERSION = "1.1.0"
+API_VERSION = "1.2.0"
 
 if TYPE_CHECKING:
     from src.core.managers.media_manager import MediaManager

--- a/src/core/managers/media_manager/cache.py
+++ b/src/core/managers/media_manager/cache.py
@@ -60,31 +60,49 @@ class MediaCache:
         media_type: str,
         description: str,
     ) -> None:
-        """保存描述到缓存。
+        """保存媒体识别描述到对应的描述缓存表。
+
+        按 ``media_type`` 路由写入三张镜像结构表：
+        - ``image`` / ``emoji`` → ``ImageDescriptions``（type 为动态值）
+        - ``voice`` → ``VoiceDescriptions``（type 固定为 voice）
+        - ``video`` → ``VideoDescriptions``（type 固定为 video）
+
+        三张表结构镜像一致，差异仅在 ``*_description_hash`` 字段名与
+        ``type`` 取值，此处统一路由写入。
 
         Args:
-            media_hash: 媒体哈希值
-            media_type: 媒体类型
+            media_hash: 媒体哈希值（作为描述缓存的主键）
+            media_type: 媒体类型（image/emoji/voice/video）
             description: 描述文本
         """
+        if media_type == "voice":
+            model_cls = VoiceDescriptions
+            hash_field = "voice_description_hash"
+        elif media_type == "video":
+            model_cls = VideoDescriptions
+            hash_field = "video_description_hash"
+        else:
+            # image 与 emoji 共用 ImageDescriptions 表，仅 type 取值不同
+            model_cls = ImageDescriptions
+            hash_field = "image_description_hash"
         try:
             created = False
             async with get_db_session() as session:
                 stmt = (
-                    select(ImageDescriptions)
+                    select(model_cls)
                     .where(
-                        ImageDescriptions.image_description_hash == media_hash,
-                        ImageDescriptions.type == media_type,
+                        getattr(model_cls, hash_field) == media_hash,
+                        model_cls.type == media_type,
                     )
-                    .order_by(ImageDescriptions.timestamp.desc())
+                    .order_by(model_cls.timestamp.desc())
                     .limit(1)
                 )
                 result = await session.execute(stmt)
                 existing = result.scalars().first()
 
                 if not existing:
-                    new_desc = ImageDescriptions(
-                        image_description_hash=media_hash,
+                    new_desc = model_cls(
+                        **{hash_field: media_hash},
                         type=media_type,
                         description=description,
                         timestamp=time.time(),
@@ -94,7 +112,7 @@ class MediaCache:
                     await session.commit()
                     logger.debug(f"保存描述缓存: {media_hash[:8]}...")
             if created:
-                invalidate_model_cache(ImageDescriptions)
+                invalidate_model_cache(model_cls)
 
         except Exception as e:
             logger.error(f"保存描述缓存失败: {e}", exc_info=True)
@@ -124,52 +142,6 @@ class MediaCache:
             logger.debug(f"查询语音缓存失败: {e}")
             return None
 
-    async def save_voice_description_cache(
-        self,
-        voice_hash: str,
-        description: str,
-    ) -> None:
-        """保存语音识别结果到缓存。
-
-        镜像 :meth:`save_description_cache` 的语义，但写入 ``VoiceDescriptions`` 表。
-        type 固定为 ``voice``。
-
-        Args:
-            voice_hash: 语音哈希值
-            description: ASR 识别文本
-        """
-        try:
-            created = False
-            async with get_db_session() as session:
-                stmt = (
-                    select(VoiceDescriptions)
-                    .where(
-                        VoiceDescriptions.voice_description_hash == voice_hash,
-                        VoiceDescriptions.type == "voice",
-                    )
-                    .order_by(VoiceDescriptions.timestamp.desc())
-                    .limit(1)
-                )
-                result = await session.execute(stmt)
-                existing = result.scalars().first()
-
-                if not existing:
-                    new_desc = VoiceDescriptions(
-                        voice_description_hash=voice_hash,
-                        type="voice",
-                        description=description,
-                        timestamp=time.time(),
-                    )
-                    session.add(new_desc)
-                    created = True
-                    await session.commit()
-                    logger.debug(f"保存语音描述缓存: {voice_hash[:8]}...")
-            if created:
-                invalidate_model_cache(VoiceDescriptions)
-
-        except Exception as e:
-            logger.error(f"保存语音描述缓存失败: {e}", exc_info=True)
-
     async def get_cached_video_description(self, video_hash: str) -> str | None:
         """从数据库缓存获取视频识别结果。
 
@@ -195,48 +167,3 @@ class MediaCache:
             logger.debug(f"查询视频缓存失败: {e}")
             return None
 
-    async def save_video_description_cache(
-        self,
-        video_hash: str,
-        description: str,
-    ) -> None:
-        """保存视频识别结果到缓存。
-
-        镜像 :meth:`save_voice_description_cache` 的语义，但写入 ``VideoDescriptions`` 表。
-        type 固定为 ``video``。
-
-        Args:
-            video_hash: 视频哈希值
-            description: 视频识别文本
-        """
-        try:
-            created = False
-            async with get_db_session() as session:
-                stmt = (
-                    select(VideoDescriptions)
-                    .where(
-                        VideoDescriptions.video_description_hash == video_hash,
-                        VideoDescriptions.type == "video",
-                    )
-                    .order_by(VideoDescriptions.timestamp.desc())
-                    .limit(1)
-                )
-                result = await session.execute(stmt)
-                existing = result.scalars().first()
-
-                if not existing:
-                    new_desc = VideoDescriptions(
-                        video_description_hash=video_hash,
-                        type="video",
-                        description=description,
-                        timestamp=time.time(),
-                    )
-                    session.add(new_desc)
-                    created = True
-                    await session.commit()
-                    logger.debug(f"保存视频描述缓存: {video_hash[:8]}...")
-            if created:
-                invalidate_model_cache(VideoDescriptions)
-
-        except Exception as e:
-            logger.error(f"保存视频描述缓存失败: {e}", exc_info=True)

--- a/src/core/managers/media_manager/manager.py
+++ b/src/core/managers/media_manager/manager.py
@@ -11,7 +11,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Iterable
+from pathlib import Path
 from typing import Any
 
 from src.core.managers.media_manager.cache import MediaCache
@@ -278,6 +280,70 @@ class MediaManager:
             视频信息字典，不存在返回 None
         """
         return await self._repository.get_video_info(video_hash)
+
+    async def save_description_cache(
+        self,
+        media_hash: str,
+        media_type: str,
+        description: str,
+    ) -> None:
+        """保存媒体识别描述到对应的描述缓存表。
+
+        按 ``media_type`` 路由到缓存组件：
+        - ``image`` / ``emoji`` → ``ImageDescriptions`` 表（type 为动态值）
+        - ``voice`` → ``VoiceDescriptions`` 表
+        - ``video`` → ``VideoDescriptions`` 表
+
+        converter 收媒体时会以 ``use_cache=True`` 查该缓存，命中后描述会
+        直接替换占位符进入上下文（如 ``[视频(media_id):描述]``）。
+
+        Args:
+            media_hash: 媒体哈希值（作为描述缓存的主键）
+            media_type: 媒体类型（image/emoji/voice/video）
+            description: 媒体识别描述文本
+        """
+        if media_type == "voice":
+            await self._cache.save_voice_description_cache(media_hash, description)
+        elif media_type == "video":
+            await self._cache.save_video_description_cache(media_hash, description)
+        else:
+            await self._cache.save_description_cache(
+                media_hash, media_type, description
+            )
+
+    async def get_media_file(self, media_hash: str) -> str | None:
+        """根据媒体哈希读取落盘文件的 base64 内容。
+
+        先经 ``get_media_info`` 获取媒体记录的 path，再按该路径读文件并
+        编码为 base64。文件不存在或读取失败时返回 None（例如已被清理）。
+
+        Args:
+            media_hash: 媒体哈希值（image_id/voice_id/video_id）
+
+        Returns:
+            base64 编码的文件内容；文件不存在或读取失败时返回 None
+        """
+        info = await self._repository.get_media_info(media_hash)
+        if not info:
+            return None
+        file_path = info.get("path")
+        if not file_path:
+            return None
+
+        try:
+            from src.core.utils.base64_helper import base64_encode_bytes
+
+            path = Path(file_path)
+            if not path.is_absolute():
+                path = Path(".") / path
+            if not path.exists():
+                logger.debug(f"媒体文件不存在: {path}")
+                return None
+            data = await asyncio.to_thread(path.read_bytes)
+            return base64_encode_bytes(data)
+        except Exception as e:
+            logger.warning(f"读取媒体文件失败: {file_path}: {e}")
+            return None
 
     # ──────────────────────────────────────────
     # 静态 API：哈希计算（供外部模块直接调用）

--- a/src/core/managers/media_manager/manager.py
+++ b/src/core/managers/media_manager/manager.py
@@ -289,11 +289,8 @@ class MediaManager:
     ) -> None:
         """保存媒体识别描述到对应的描述缓存表。
 
-        按 ``media_type`` 路由到缓存组件：
-        - ``image`` / ``emoji`` → ``ImageDescriptions`` 表（type 为动态值）
-        - ``voice`` → ``VoiceDescriptions`` 表
-        - ``video`` → ``VideoDescriptions`` 表
-
+        委托 :meth:`MediaCache.save_description_cache` 按 ``media_type`` 路由写入
+        ImageDescriptions / VoiceDescriptions / VideoDescriptions 三张表之一。
         converter 收媒体时会以 ``use_cache=True`` 查该缓存，命中后描述会
         直接替换占位符进入上下文（如 ``[视频(media_id):描述]``）。
 
@@ -302,14 +299,9 @@ class MediaManager:
             media_type: 媒体类型（image/emoji/voice/video）
             description: 媒体识别描述文本
         """
-        if media_type == "voice":
-            await self._cache.save_voice_description_cache(media_hash, description)
-        elif media_type == "video":
-            await self._cache.save_video_description_cache(media_hash, description)
-        else:
-            await self._cache.save_description_cache(
-                media_hash, media_type, description
-            )
+        await self._cache.save_description_cache(
+            media_hash, media_type, description
+        )
 
     async def get_media_file(self, media_hash: str) -> str | None:
         """根据媒体哈希读取落盘文件的 base64 内容。

--- a/src/core/managers/media_manager/recognition.py
+++ b/src/core/managers/media_manager/recognition.py
@@ -267,14 +267,9 @@ class MediaRecognition:
             description: 识别结果文本
             file_path: 文件路径
         """
-        if media_type == "voice":
-            await self._cache.save_voice_description_cache(media_hash, description)
-        elif media_type == "video":
-            await self._cache.save_video_description_cache(media_hash, description)
-        else:
-            await self._cache.save_description_cache(
-                media_hash, media_type, description
-            )
+        await self._cache.save_description_cache(
+            media_hash, media_type, description
+        )
 
         await self._repository.save_recognized_media(
             media_hash,

--- a/test/app/plugin_system/api/test_media_api.py
+++ b/test/app/plugin_system/api/test_media_api.py
@@ -154,3 +154,94 @@ class TestMediaAPI:
 
             assert result is not None
             assert result["voice_id"] == "voicehash123"
+
+    @pytest.mark.asyncio
+    async def test_save_description_cache_image(self) -> None:
+        """测试保存图片描述缓存（路由到 manager.save_description_cache）。"""
+        with patch('src.app.plugin_system.api.media_api._get_media_manager') as mock_get_mgr:
+            mock_manager = MagicMock()
+            mock_manager.save_description_cache = AsyncMock()
+            mock_get_mgr.return_value = mock_manager
+
+            await media_api.save_description_cache("img123", "image", "一只猫")
+
+            mock_manager.save_description_cache.assert_called_once_with(
+                media_hash="img123",
+                media_type="image",
+                description="一只猫",
+            )
+
+    @pytest.mark.asyncio
+    async def test_save_description_cache_video(self) -> None:
+        """测试保存视频描述缓存（路由到 manager.save_description_cache）。"""
+        with patch('src.app.plugin_system.api.media_api._get_media_manager') as mock_get_mgr:
+            mock_manager = MagicMock()
+            mock_manager.save_description_cache = AsyncMock()
+            mock_get_mgr.return_value = mock_manager
+
+            await media_api.save_description_cache("vid123", "video", "一段风景")
+
+            mock_manager.save_description_cache.assert_called_once_with(
+                media_hash="vid123",
+                media_type="video",
+                description="一段风景",
+            )
+
+    @pytest.mark.asyncio
+    async def test_save_description_cache_voice(self) -> None:
+        """测试保存语音描述缓存（路由到 manager.save_description_cache）。"""
+        with patch('src.app.plugin_system.api.media_api._get_media_manager') as mock_get_mgr:
+            mock_manager = MagicMock()
+            mock_manager.save_description_cache = AsyncMock()
+            mock_get_mgr.return_value = mock_manager
+
+            await media_api.save_description_cache("voi123", "voice", "你好")
+
+            mock_manager.save_description_cache.assert_called_once_with(
+                media_hash="voi123",
+                media_type="voice",
+                description="你好",
+            )
+
+    @pytest.mark.asyncio
+    async def test_save_description_cache_empty_hash_raises(self) -> None:
+        """测试空 media_hash 抛出 ValueError。"""
+        with pytest.raises(ValueError):
+            await media_api.save_description_cache("", "video", "描述")
+
+    @pytest.mark.asyncio
+    async def test_save_description_cache_empty_description_raises(self) -> None:
+        """测试空 description 抛出 ValueError。"""
+        with pytest.raises(ValueError):
+            await media_api.save_description_cache("hash123", "video", "")
+
+    @pytest.mark.asyncio
+    async def test_get_media_file(self) -> None:
+        """测试按哈希读取媒体文件（转发到 manager.get_media_file）。"""
+        with patch('src.app.plugin_system.api.media_api._get_media_manager') as mock_get_mgr:
+            mock_manager = MagicMock()
+            mock_manager.get_media_file = AsyncMock(return_value="base64data")
+            mock_get_mgr.return_value = mock_manager
+
+            result = await media_api.get_media_file("vid123")
+
+            assert result == "base64data"
+            mock_manager.get_media_file.assert_called_once_with("vid123")
+
+    @pytest.mark.asyncio
+    async def test_get_media_file_missing(self) -> None:
+        """测试文件不存在时返回 None。"""
+        with patch('src.app.plugin_system.api.media_api._get_media_manager') as mock_get_mgr:
+            mock_manager = MagicMock()
+            mock_manager.get_media_file = AsyncMock(return_value=None)
+            mock_get_mgr.return_value = mock_manager
+
+            result = await media_api.get_media_file("vid123")
+
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_get_media_file_empty_hash_raises(self) -> None:
+        """测试空 media_hash 抛出 ValueError。"""
+        with pytest.raises(ValueError):
+            await media_api.get_media_file("")


### PR DESCRIPTION
# PR: 新增媒体描述缓存写入与文件读取公开 API

## 背景

`MediaManager` 内部已具备四类媒体的描述缓存读写能力（`ImageDescriptions` /
`VoiceDescriptions` / `VideoDescriptions` 三张表），但 **插件没有公开 API 可以
写入这些描述缓存表**，也无法按媒体哈希读取落盘文件内容。

这带来两个限制：

1. 第三方媒体识别插件（如视频分析）识别完成后，无法把描述写入缓存表，
   导致 converter 收同一条媒体时命中不到缓存，描述不会自动进入上下文。
2. 插件无法按 media_id 读取框架落盘的媒体文件，只能自行重复存储二进制。

## 改动

### 1. `MediaManager` 门面新增两个方法

- `save_description_cache(media_hash, media_type, description)`：按 `media_type`
  路由写入对应描述缓存表（image/emoji → `ImageDescriptions`，voice →
  `VoiceDescriptions`，video → `VideoDescriptions`）。复用内部 `MediaCache` 三方法，
  不新增存储逻辑。
- `get_media_file(media_hash)`：经 `get_media_info` 获取媒体记录的 path，
  按该路径读取文件并编码为 base64 返回。文件不存在或已被清理时返回 `None`。

### 2. `media_api` 新增同名公开函数

- `save_description_cache(media_hash, media_type, description)`
- `get_media_file(media_hash)`

均带参数校验（非空 / 合法 media_type），并加入 `__all__`。API 版本由 `1.1.0`
提升至 `1.2.0`。

### 3. 统一 `MediaCache` 的保存缓存方法

`MediaCache` 原有的三个保存方法 `save_description_cache` /
`save_voice_description_cache` / `save_video_description_cache` 合并为单一的
`save_description_cache(media_hash, media_type, description)`，按 `media_type`
路由到三张镜像结构表，消除重复代码。`MediaRecognition` 与 `MediaManager` 内部
调用点同步改用统一方法。

### 4. 单元测试

`test/app/plugin_system/api/test_media_api.py` 新增 8 个用例，覆盖：

- `save_description_cache` 的 image / video / voice 三类型路由
- 空 media_hash、空 description 的校验
- `get_media_file` 正常读取、文件不存在返回 `None`、空 media_hash 校验

## 影响范围

- 纯新增 API，不改动既有行为。
- `MediaManager` / `media_api` 的现有方法签名与语义不变。
- 现有 `test_media_api.py` 全部通过，新增用例通过。

## 验证

- `uv run pytest test/app/plugin_system/api/test_media_api.py`（18 passed）
- `uv run ruff check src/core/managers/media_manager/manager.py src/app/plugin_system/api/media_api.py`
