### PR TITLE
fix(media): 发送端统一结构化媒体 content，根除 base64 被当文本计数

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ reports/
 
 # Ignore temporary files
 *.tmp
+tmp/
 ~*
 
 # Ignore build artifacts from poetry/uv if any

--- a/src/app/plugin_system/api/send_api.py
+++ b/src/app/plugin_system/api/send_api.py
@@ -10,6 +10,49 @@ from src.core.models.message import Message, MessageType
 
 API_VERSION = "1.0.0"
 
+
+def _build_media_content(
+    media_type: str,
+    media_data: str,
+    text: str,
+    media_id_key: str,
+) -> dict[str, Any]:
+    """将发送端媒体数据组装为与接收端一致的结构化 content。
+
+    发送路径（``send_image`` / ``send_emoji`` / ``send_voice`` / ``send_video``）
+    与接收路径（``MessageConverter.envelope_to_message`` 的 ``_build_content``）
+    采用相同的数据结构 ``{"text": ..., "media": [{"type", "data", "id"}]}``，
+    避免裸 base64 作为 ``Message.content`` 落库后被当作文本参与 token 计数。
+
+    媒体 ``data`` 经 ``normalize_base64`` 规范化、``id`` 用与 MediaManager 识别
+    流程相同的哈希算法计算，保证发送端媒体的 ``image_id`` / ``voice_id`` /
+    ``video_id`` 可在媒体表中回查，与接收端媒体项完全对称。
+
+    Args:
+        media_type: 媒体段类型（``image`` / ``emoji`` / ``voice`` / ``video``）。
+        media_data: 媒体数据（base64 或 URL）。
+        text: 消息的人类可读文本（占位符，如 ``[图片]``）。
+        media_id_key: 媒体 ID 字段名（``image_id`` / ``voice_id`` / ``video_id``）。
+
+    Returns:
+        结构化 content 字典。
+    """
+    from src.core.managers.media_manager import MediaManager
+    from src.core.transport.message_receive.utils import normalize_base64
+
+    normalized_data = normalize_base64(media_data)
+    return {
+        "text": text,
+        "media": [
+            {
+                "type": media_type,
+                "data": normalized_data,
+                media_id_key: MediaManager.compute_media_hash(normalized_data),
+            }
+        ],
+    }
+
+
 # =============================================================================
 # 基础消息发送
 # =============================================================================
@@ -88,7 +131,9 @@ async def send_image(
         )
     """
     return await _send_message(
-        content=image_data,
+        content=_build_media_content(
+            "image", image_data, processed_plain_text, "image_id"
+        ),
         message_type=MessageType.IMAGE,
         stream_id=stream_id,
         platform=platform,
@@ -128,7 +173,9 @@ async def send_emoji(
         )
     """
     return await _send_message(
-        content=emoji_data,
+        content=_build_media_content(
+            "emoji", emoji_data, processed_plain_text, "image_id"
+        ),
         message_type=MessageType.EMOJI,
         stream_id=stream_id,
         platform=platform,
@@ -166,7 +213,9 @@ async def send_voice(
         )
     """
     return await _send_message(
-        content=voice_data,
+        content=_build_media_content(
+            "voice", voice_data, processed_plain_text, "voice_id"
+        ),
         message_type=MessageType.VOICE,
         stream_id=stream_id,
         platform=platform,
@@ -204,7 +253,9 @@ async def send_video(
         )
     """
     return await _send_message(
-        content=video_data,
+        content=_build_media_content(
+            "video", video_data, processed_plain_text, "video_id"
+        ),
         message_type=MessageType.VIDEO,
         stream_id=stream_id,
         platform=platform,

--- a/src/core/managers/stream_manager.py
+++ b/src/core/managers/stream_manager.py
@@ -30,65 +30,175 @@ if TYPE_CHECKING:
 
 logger = get_logger("stream_manager", display="StreamMgr")
 
-# 含原始二进制的媒体类型，序列化入库时仅在 payload 过大时剔除 data 字段
-_BINARY_MEDIA_TYPES: frozenset[str] = frozenset({"image", "emoji", "voice"})
-_MAX_MEDIA_DATA_BYTES = 1024
+# 含原始二进制的媒体类型，序列化入库时统一剔除 data 字段。
+# 二进制 base64 不应持久化：一是造成数据库存储暴涨，二是反序列化时
+# 会被当作普通文本参与 token 计数（触发上下文压缩误判）。媒体项经剔除
+# data 后仍保留 image_id/voice_id/video_id，可按哈希回查媒体表。
+# file 的 data 是元信息（name/size/id）而非二进制，不在此列。
+_BINARY_MEDIA_TYPES: frozenset[str] = frozenset(
+    {"image", "emoji", "voice", "video"}
+)
 
 
-def _get_content_size_bytes(content: Any) -> int:
-    """估算内容的 UTF-8 序列化字节数。"""
-    if isinstance(content, bytes):
-        return len(content)
-    if isinstance(content, str):
-        return len(content.encode("utf-8"))
-    return len(str(content).encode("utf-8"))
-
-
-def _strip_oversized_media_data(item: dict[str, Any]) -> dict[str, Any]:
-    """移除超出阈值的媒体 data 字段，保留其余元信息。
+def _strip_media_data(item: dict[str, Any]) -> dict[str, Any]:
+    """移除二进制媒体项的 data 字段，保留其余元信息。
 
     媒体项的媒体 ID（``image_id`` / ``voice_id`` / ``video_id``）由
     ``MessageConverter`` 在创建媒体项时注入，此处剔除 ``data`` 后媒体 ID
     自然保留，便于后续按哈希回查 Images/Voices/Videos 表。
     """
-    media_data = item.get("data")
-    if media_data is None:
-        return item
-
-    if _get_content_size_bytes(media_data) <= _MAX_MEDIA_DATA_BYTES:
+    if item.get("data") is None:
         return item
 
     return {key: value for key, value in item.items() if key != "data"}
 
 
-def _serialize_content_for_db(content: Any) -> str:
+def _serialize_content_for_db(content: Any, message_type: str = "text") -> str:
     """将消息 content 序列化为数据库存储字符串。
 
-    内存中的 content 字典可能包含图片/表情包/语音的原始 base64 数据（供 Chatter 多模态
-    使用），但这些数据不需要持久化，持久化会造成数据库存储暴涨。本函数在序列化前检查
-    image/emoji/voice 媒体项中的 ``data`` 实际大小，超过阈值时剔除该字段，其余元信息保留。
-    媒体项的媒体 ID（``image_id`` / ``voice_id`` / ``video_id``）由 ``MessageConverter``
-    在创建时注入，剔除 ``data`` 后保留，后续可按对应 ID 从 Images/Voices/Videos 表回查信息。
+    内存中的 content 可能是：
+    - dict（收到消息/多模态）：``{"text": ..., "media": [{"type": "image", "data": ...}]}``
+    - 裸 base64 字符串（Bot 通过 ``send_image``/``send_emoji`` 等发送）：content 即媒体数据
+
+    二进制 base64 不应持久化（存储暴涨 + 反序列化时被当作文本参与 token 计数）。
+    本函数统一剔除二进制媒体项（dict 的 ``media[].data`` 或裸字符串媒体 content）
+    的 data，其余元信息保留；媒体 ID 由 ``MessageConverter`` 注入，剔除后仍可按哈希
+    回查媒体表。
+
+    Args:
+        content: 消息 content（dict 或字符串）。
+        message_type: 消息类型（``MessageType`` 的 value），用于识别裸字符串媒体 content。
+
+    Returns:
+        序列化后的数据库存储字符串。
     """
-    if not isinstance(content, dict):
+    if isinstance(content, dict):
+        media = content.get("media")
+        if isinstance(media, list):
+            stripped_media = []
+            for item in media:
+                if not isinstance(item, dict):
+                    continue
+                if item.get("type") in _BINARY_MEDIA_TYPES:
+                    stripped_media.append(_strip_media_data(item))
+                    continue
+                stripped_media.append(item)
+            return str({**content, "media": stripped_media})
         return str(content)
 
-    media = content.get("media")
+    # 裸字符串：媒体类型的 content 即 base64，落库时用空占位替换，避免 b64 持久化
+    if message_type in _BINARY_MEDIA_TYPES:
+        return str({"text": "", "media": []})
+
+    return str(content)
+
+
+def _parse_db_content(content: Any) -> dict[str, Any] | None:
+    """解析数据库消息的 content 字符串为 dict；非 dict 结构返回 None。
+
+    DB 中 content 由 ``_serialize_content_for_db`` 写入，含媒体的消息是
+    ``str({"text": ..., "media": [...]})``（Python dict 字面量，单引号）。
+    历史加载时需解析回 dict 以提取 ``image_id`` 等媒体元信息，因此使用
+    ``ast.literal_eval`` 而非 ``json.loads``（后者无法解析单引号字符串）。
+
+    Args:
+        content: 数据库消息的 content 字段。
+
+    Returns:
+        解析后的 dict；无法解析或非 dict 结构返回 None。
+    """
+    import ast
+
+    if isinstance(content, dict):
+        return content
+    if not isinstance(content, str):
+        return None
+
+    try:
+        parsed = ast.literal_eval(content)
+    except (ValueError, SyntaxError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+async def _restore_media_data_from_db(content: Any) -> Any:
+    """按媒体 ID 从媒体表回查 base64，补齐历史消息的图片数据。
+
+    ``_serialize_content_for_db`` 入库时剔除了二进制 media 的 ``data`` 字段，
+    历史消息反序列化后 content 里的 media 项只有 ``image_id`` 等元信息、无
+    base64。此函数按 ``image_id`` 回查 Images 表读取文件并编码 base64，
+    使历史图片在 native 多模态下仍可内联。
+
+    返回与传入 ``content`` 同构的结构：dict 返回回填后的 dict，纯字符串
+    原样返回，保证调用方对 content 的访问路径一致。
+
+    Args:
+        content: 数据库消息的 content 字段（字符串或 dict）。
+
+    Returns:
+        回填 data 后的 content；无媒体或回查失败时保持原结构。
+    """
+    parsed = _parse_db_content(content)
+    if parsed is None:
+        return content
+
+    media = parsed.get("media")
     if not isinstance(media, list):
-        return str(content)
+        return content
 
-    stripped_media = []
+    restored: list[dict[str, Any]] = []
     for item in media:
         if not isinstance(item, dict):
             continue
-
-        if item.get("type") in _BINARY_MEDIA_TYPES:
-            stripped_media.append(_strip_oversized_media_data(item))
+        image_id = item.get("image_id")
+        # 仅对缺失 data 的二进制媒体回查；已带 data（旧数据）直接保留
+        if item.get("data") is not None or not isinstance(image_id, str) or not image_id:
+            restored.append(item)
             continue
+        try:
+            from src.core.managers.media_manager import get_media_manager
 
-        stripped_media.append(item)
+            data = await get_media_manager().get_media_file(image_id)
+            if data:
+                restored.append({**item, "data": data})
+                continue
+        except Exception as exc:
+            logger.warning(
+                f"回查媒体 base64 失败: image_id={image_id[:8]}, error={exc}"
+            )
+        restored.append(item)
 
-    return str({**content, "media": stripped_media})
+    return {**parsed, "media": restored}
+
+
+def _content_to_plain_text(content: Any, message_type: str = "text") -> str:
+    """从消息 content 提取纯文本，避免把媒体 base64 当作文本。
+
+    含媒体的 content 可能是：
+    - dict：``{"text": ..., "media": [...]}``，其中 ``media`` 项可能携带 base64
+    - 裸 base64 字符串（媒体消息 content 即数据）
+
+    直接 ``str(content)`` 会把 base64 拼进文本，导致 token 计数严重高估。
+    此函数仅提取 ``text`` 字段；媒体类型的裸字符串 content 返回占位符。
+
+    Args:
+        content: 数据库消息的 content 字段（字符串或 dict）。
+        message_type: 消息类型（``MessageType`` 的 value）。
+
+    Returns:
+        纯文本表示。
+    """
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str) and text:
+            return text
+        return "（非文本内容）"
+
+    # 媒体类型的裸字符串 content 即 base64，不得当作文本返回
+    if message_type in _BINARY_MEDIA_TYPES:
+        return "（非文本内容）"
+
+    return str(content)
 
 
 class StreamManager:
@@ -402,7 +512,9 @@ class StreamManager:
                 "person_id": person_id,
                 "time": message.time,
                 "message_type": message.message_type.value,
-                "content": _serialize_content_for_db(message.content),
+                "content": _serialize_content_for_db(
+                    message.content, message.message_type.value
+                ),
                 "processed_plain_text": message.processed_plain_text,
                 "reply_to": message.reply_to,
                 "platform": message.platform,
@@ -455,7 +567,9 @@ class StreamManager:
                 "person_id": "bot",
                 "time": message.time,
                 "message_type": message.message_type.value,
-                "content": str(message.content),
+                "content": _serialize_content_for_db(
+                    message.content, message.message_type.value
+                ),
                 "processed_plain_text": message.processed_plain_text,
                 "reply_to": message.reply_to,
                 "platform": message.platform,
@@ -943,13 +1057,20 @@ class StreamManager:
 
         normalized_plain_text = db_message.processed_plain_text
         if normalized_plain_text is None:
-            normalized_plain_text = str(db_message.content)
-        
+            normalized_plain_text = _content_to_plain_text(
+                db_message.content, db_message.message_type
+            )
+
+        # 历史消息入库时已剔除 media 的 base64（见 _serialize_content_for_db），
+        # 此处按 image_id 回查媒体表补回 data 到 content["media"]，
+        # 与运行时消息的属性结构保持一致（多模态内联仍可读 data）。
+        runtime_content = await _restore_media_data_from_db(db_message.content)
+
         return Message(
             message_id=db_message.message_id,
             time=db_message.time,
             reply_to=db_message.reply_to,
-            content=db_message.content,
+            content=runtime_content,
             processed_plain_text=normalized_plain_text,
             message_type=MessageType(db_message.message_type),
             sender_id=sender_id,

--- a/src/core/managers/stream_manager.py
+++ b/src/core/managers/stream_manager.py
@@ -53,21 +53,18 @@ def _strip_media_data(item: dict[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in item.items() if key != "data"}
 
 
-def _serialize_content_for_db(content: Any, message_type: str = "text") -> str:
+def _serialize_content_for_db(content: Any) -> str:
     """将消息 content 序列化为数据库存储字符串。
 
-    内存中的 content 可能是：
-    - dict（收到消息/多模态）：``{"text": ..., "media": [{"type": "image", "data": ...}]}``
-    - 裸 base64 字符串（Bot 通过 ``send_image``/``send_emoji`` 等发送）：content 即媒体数据
-
-    二进制 base64 不应持久化（存储暴涨 + 反序列化时被当作文本参与 token 计数）。
-    本函数统一剔除二进制媒体项（dict 的 ``media[].data`` 或裸字符串媒体 content）
-    的 data，其余元信息保留；媒体 ID 由 ``MessageConverter`` 注入，剔除后仍可按哈希
-    回查媒体表。
+    内存中的 content 是接收/发送路径统一构建的结构化 dict：
+    ``{"text": ..., "media": [{"type": "image", "data": ..., "image_id": ...}]}``。
+    二进制 base64 不应持久化（存储暴涨 + 反序列化时被当作文本参与 token 计数），
+    本函数剔除二进制媒体项（``image``/``emoji``/``voice``/``video``）的 ``data``，
+    其余元信息保留；媒体 ID 由 ``MessageConverter``/``send_*`` 注入，剔除后仍可
+    按哈希回查媒体表。
 
     Args:
-        content: 消息 content（dict 或字符串）。
-        message_type: 消息类型（``MessageType`` 的 value），用于识别裸字符串媒体 content。
+        content: 消息 content（结构化 dict 或纯文本字符串）。
 
     Returns:
         序列化后的数据库存储字符串。
@@ -85,10 +82,6 @@ def _serialize_content_for_db(content: Any, message_type: str = "text") -> str:
                 stripped_media.append(item)
             return str({**content, "media": stripped_media})
         return str(content)
-
-    # 裸字符串：媒体类型的 content 即 base64，落库时用空占位替换，避免 b64 持久化
-    if message_type in _BINARY_MEDIA_TYPES:
-        return str({"text": "", "media": []})
 
     return str(content)
 
@@ -171,19 +164,15 @@ async def _restore_media_data_from_db(content: Any) -> Any:
     return {**parsed, "media": restored}
 
 
-def _content_to_plain_text(content: Any, message_type: str = "text") -> str:
+def _content_to_plain_text(content: Any) -> str:
     """从消息 content 提取纯文本，避免把媒体 base64 当作文本。
 
-    含媒体的 content 可能是：
-    - dict：``{"text": ..., "media": [...]}``，其中 ``media`` 项可能携带 base64
-    - 裸 base64 字符串（媒体消息 content 即数据）
-
-    直接 ``str(content)`` 会把 base64 拼进文本，导致 token 计数严重高估。
-    此函数仅提取 ``text`` 字段；媒体类型的裸字符串 content 返回占位符。
+    含媒体的 content 是结构化 dict：``{"text": ..., "media": [...]}``，其中
+    ``media`` 项可能携带 base64。直接 ``str(content)`` 会把 base64 拼进文本，
+    导致 token 计数严重高估；此函数仅提取 ``text`` 字段，缺失时返回占位符。
 
     Args:
         content: 数据库消息的 content 字段（字符串或 dict）。
-        message_type: 消息类型（``MessageType`` 的 value）。
 
     Returns:
         纯文本表示。
@@ -192,10 +181,6 @@ def _content_to_plain_text(content: Any, message_type: str = "text") -> str:
         text = content.get("text")
         if isinstance(text, str) and text:
             return text
-        return "（非文本内容）"
-
-    # 媒体类型的裸字符串 content 即 base64，不得当作文本返回
-    if message_type in _BINARY_MEDIA_TYPES:
         return "（非文本内容）"
 
     return str(content)
@@ -512,9 +497,7 @@ class StreamManager:
                 "person_id": person_id,
                 "time": message.time,
                 "message_type": message.message_type.value,
-                "content": _serialize_content_for_db(
-                    message.content, message.message_type.value
-                ),
+                "content": _serialize_content_for_db(message.content),
                 "processed_plain_text": message.processed_plain_text,
                 "reply_to": message.reply_to,
                 "platform": message.platform,
@@ -567,9 +550,7 @@ class StreamManager:
                 "person_id": "bot",
                 "time": message.time,
                 "message_type": message.message_type.value,
-                "content": _serialize_content_for_db(
-                    message.content, message.message_type.value
-                ),
+                "content": _serialize_content_for_db(message.content),
                 "processed_plain_text": message.processed_plain_text,
                 "reply_to": message.reply_to,
                 "platform": message.platform,
@@ -1057,9 +1038,7 @@ class StreamManager:
 
         normalized_plain_text = db_message.processed_plain_text
         if normalized_plain_text is None:
-            normalized_plain_text = _content_to_plain_text(
-                db_message.content, db_message.message_type
-            )
+            normalized_plain_text = _content_to_plain_text(db_message.content)
 
         # 历史消息入库时已剔除 media 的 base64（见 _serialize_content_for_db），
         # 此处按 image_id 回查媒体表补回 data 到 content["media"]，

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -254,27 +254,48 @@ class MessageConverter:
         }
         if message.message_type in _MEDIA_TYPES:
             content = message.content
-            content_data: str
-            if isinstance(content, str):
-                content_data = content
-            elif isinstance(content, dict):
-                # send_file 等 API 传入 dict（如 {"path": "...", "name": "..."}）
-                # FILE 类型取 path 字段作为数据；其他类型取 data/path/url
-                if message.message_type == MessageType.FILE:
-                    content_data = content.get("path", "")
-                else:
-                    content_data = (
-                        content.get("data", "")
-                        or content.get("path", "")
-                        or content.get("url", "")
-                    )
+            # 结构化 content（send_image 等新路径）：{"text", "media": [...]}
+            # 媒体项与接收端 _build_content 产出同构：{type, data, image_id/...}
+            media_items: list[Any] | None = None
+            if isinstance(content, dict):
+                media_items = content.get("media")
+            if isinstance(media_items, list) and media_items:
+                for item in media_items:
+                    if isinstance(item, dict):
+                        seg_data = str(
+                            item.get("data", "")
+                            or item.get("path", "")
+                            or item.get("url", "")
+                        )
+                        seg_type = str(item.get("type") or message.message_type.value)
+                    else:
+                        seg_data = str(item)
+                        seg_type = message.message_type.value
+                    if seg_data:
+                        seg_list.append({"type": seg_type, "data": seg_data})
             else:
-                content_data = ""
-            if content_data:
-                seg_list.append({
-                    "type": message.message_type.value,
-                    "data": content_data,
-                })
+                # 兼容旧形态：裸字符串，或 {path}/{data}/{url} 等 dict
+                content_data: str
+                if isinstance(content, str):
+                    content_data = content
+                elif isinstance(content, dict):
+                    # send_file 等 API 传入 dict（如 {"path": "...", "name": "..."}）
+                    # FILE 类型取 path 字段作为数据；其他类型取 data/path/url
+                    if message.message_type == MessageType.FILE:
+                        content_data = content.get("path", "")
+                    else:
+                        content_data = (
+                            content.get("data", "")
+                            or content.get("path", "")
+                            or content.get("url", "")
+                        )
+                else:
+                    content_data = ""
+                if content_data:
+                    seg_list.append({
+                        "type": message.message_type.value,
+                        "data": content_data,
+                    })
         else:
             # 文本 / 混合消息
             text = message.processed_plain_text or (

--- a/test/app/plugin_system/api/test_send_api_media_content.py
+++ b/test/app/plugin_system/api/test_send_api_media_content.py
@@ -1,0 +1,59 @@
+"""send_api 媒体 content 结构化组装的单元测试。
+
+覆盖发送端 ``send_image``/``send_emoji``/``send_voice``/``send_video``
+组装 ``{"text", "media"}`` 结构化 content（与接收端 ``_build_content``
+产出同构），确保裸 base64 不再作为 ``Message.content`` 出现。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from src.app.plugin_system.api.send_api import _build_media_content
+
+
+def test_build_media_content_image_normalizes_and_hashes() -> None:
+    """图片媒体应规范化 base64 并计算 image_id（与接收端哈希算法一致）。"""
+    with patch(
+        "src.core.managers.media_manager.MediaManager.compute_media_hash",
+        return_value="hash123",
+    ) as mock_hash:
+        content = _build_media_content(
+            "image", "iVBORw0KGgo=", "[图片]", "image_id"
+        )
+
+    assert content["text"] == "[图片]"
+    assert len(content["media"]) == 1
+    item = content["media"][0]
+    assert item["type"] == "image"
+    assert item["data"] == "base64|iVBORw0KGgo="
+    assert item["image_id"] == "hash123"
+    mock_hash.assert_called_once_with("base64|iVBORw0KGgo=")
+
+
+def test_build_media_content_voice_uses_voice_id() -> None:
+    """语音媒体应注入 voice_id 字段名。"""
+    with patch(
+        "src.core.managers.media_manager.MediaManager.compute_media_hash",
+        return_value="voice_hash",
+    ):
+        content = _build_media_content(
+            "voice", "UklGRg==", "[语音]", "voice_id"
+        )
+
+    assert content["media"][0]["type"] == "voice"
+    assert content["media"][0]["voice_id"] == "voice_hash"
+    assert "image_id" not in content["media"][0]
+
+
+def test_build_media_content_keeps_existing_prefix() -> None:
+    """已带 base64| 前缀的数据不应重复添加前缀。"""
+    with patch(
+        "src.core.managers.media_manager.MediaManager.compute_media_hash",
+        return_value="hash",
+    ):
+        content = _build_media_content(
+            "image", "base64|iVBORw0KGgo=", "[图片]", "image_id"
+        )
+
+    assert content["media"][0]["data"] == "base64|iVBORw0KGgo="

--- a/test/core/managers/test_stream_manager_get_or_create.py
+++ b/test/core/managers/test_stream_manager_get_or_create.py
@@ -450,8 +450,8 @@ async def test_add_message_normalizes_direct_raw_person_id(monkeypatch) -> None:
     assert created_data["person_id"] == "hash_qq_user_123"
 
 
-def test_serialize_content_for_db_keeps_small_binary_media_data() -> None:
-    """小体积二进制媒体数据应保留，避免误删有效内容。"""
+def test_serialize_content_for_db_strips_small_binary_media_data() -> None:
+    """二进制媒体数据一律剔除（含小体积），避免 base64 落库后被当文本计数。"""
     content = {
         "text": "hello",
         "media": [{"type": "image", "data": "a" * 128, "name": "small.png"}],
@@ -459,8 +459,9 @@ def test_serialize_content_for_db_keeps_small_binary_media_data() -> None:
 
     serialized = _serialize_content_for_db(content)
 
-    assert "'data': '" in serialized
+    assert "'data': '" not in serialized
     assert "small.png" in serialized
+    assert "'type': 'image'" in serialized
 
 
 def test_serialize_content_for_db_strips_large_binary_media_data() -> None:

--- a/test/core/managers/test_stream_manager_media_serialization.py
+++ b/test/core/managers/test_stream_manager_media_serialization.py
@@ -143,17 +143,3 @@ async def test_restore_media_data_from_db_keeps_plain_text() -> None:
     mock_manager.get_media_file.assert_not_awaited()
 
 
-def test_content_to_plain_text_media_type_raw_string_placeholder() -> None:
-    """媒体类型的裸字符串 content（base64）应返回占位符，不产生 b64 文本。"""
-    assert _content_to_plain_text("iVBORw0KGgo=", "image") == "（非文本内容）"
-    assert "iVBORw0KGgo=" not in _content_to_plain_text("iVBORw0KGgo=", "emoji")
-    # 普通文本类型的裸字符串原样返回
-    assert _content_to_plain_text("hello", "text") == "hello"
-
-
-def test_serialize_content_for_db_strips_raw_string_media_content() -> None:
-    """媒体类型的裸字符串 content（base64）落库时不应包含 base64。"""
-    serialized = _serialize_content_for_db("iVBORw0KGgo=", "image")
-    assert "iVBORw0KGgo=" not in serialized
-    # 普通文本类型裸字符串原样落库
-    assert _serialize_content_for_db("hello", "text") == "hello"

--- a/test/core/managers/test_stream_manager_media_serialization.py
+++ b/test/core/managers/test_stream_manager_media_serialization.py
@@ -1,0 +1,159 @@
+"""StreamManager 媒体序列化与反序列化的单元测试。
+
+覆盖 base64 不落库、反序列化不产生 b64 文本、历史图片按 image_id 回查补全等行为，
+确保修复"b64 被当作文本参与 token 计数"根因后不回归。
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.core.managers.stream_manager import (
+    _content_to_plain_text,
+    _parse_db_content,
+    _restore_media_data_from_db,
+    _serialize_content_for_db,
+)
+
+
+def test_serialize_content_for_db_strips_binary_media_data() -> None:
+    """入库序列化应一律剔除 image/emoji/voice/video 的 data，保留 file 元数据。"""
+    content: dict[str, Any] = {
+        "text": "hello",
+        "media": [
+            {"type": "image", "data": "iVBORw0KGgoAAAANSUhEUg==", "image_id": "img1"},
+            {"type": "emoji", "data": "aGVsbG8=", "image_id": "emoji1"},
+            {"type": "voice", "data": "UklGRg==", "voice_id": "voice1"},
+            {"type": "video", "data": "AAAAIGZ0eXBpc29t", "video_id": "vid1"},
+            {"type": "file", "data": {"name": "a.txt", "size": 10, "id": "f1"}},
+        ],
+    }
+
+    serialized = _serialize_content_for_db(content)
+
+    assert '"data": "iVBORw0KGgoAAAANSUhEUg=="' not in serialized
+    assert '"data": "aGVsbG8="' not in serialized
+    assert '"data": "UklGRg=="' not in serialized
+    assert '"data": "AAAAIGZ0eXBpc29t"' not in serialized
+    # file 类型的 data 是元信息，应保留
+    assert "'data': {'name': 'a.txt'" in serialized or '"data": {"name": "a.txt"' in serialized
+    # 媒体 ID 保留，便于回查
+    assert "img1" in serialized
+    assert "voice1" in serialized
+    assert "vid1" in serialized
+
+
+def test_serialize_content_for_db_keeps_text_message() -> None:
+    """纯文本 content 直接字符串化，不破坏原样。"""
+    assert _serialize_content_for_db("你好") == "你好"
+
+
+def test_content_to_plain_text_extracts_text_field() -> None:
+    """含媒体 content 应提取 text 字段，不把 base64 当文本。"""
+    content: dict[str, Any] = {
+        "text": "[图片(abc)]",
+        "media": [{"type": "image", "data": "iVBORw0KGgo=", "image_id": "abc"}],
+    }
+    result = _content_to_plain_text(content)
+    assert result == "[图片(abc)]"
+    assert "iVBORw0KGgo=" not in result
+
+
+def test_content_to_plain_text_fallback_for_missing_text() -> None:
+    """无 text 字段的含媒体 content 返回占位符，不产生 b64 文本。"""
+    content: dict[str, Any] = {
+        "media": [{"type": "image", "data": "iVBORw0KGgo=", "image_id": "abc"}],
+    }
+    result = _content_to_plain_text(content)
+    assert "iVBORw0KGgo=" not in result
+    assert result == "（非文本内容）"
+
+
+def test_content_to_plain_text_keeps_plain_str() -> None:
+    """纯字符串 content 原样返回。"""
+    assert _content_to_plain_text("hello") == "hello"
+
+
+def test_parse_db_content_parses_dict_literal() -> None:
+    """DB 中 content 是 str(dict)（单引号），应能被 ast.literal_eval 解析。"""
+    raw = "{'text': 'hi', 'media': [{'type': 'image', 'image_id': 'img1'}]}"
+    parsed = _parse_db_content(raw)
+    assert parsed is not None
+    assert parsed["text"] == "hi"
+    assert parsed["media"][0]["image_id"] == "img1"
+
+
+def test_parse_db_content_returns_none_for_plain_text() -> None:
+    """纯文本 content 无法解析为 dict 时应返回 None。"""
+    assert _parse_db_content("plain text") is None
+
+
+@pytest.mark.asyncio
+async def test_restore_media_data_from_db_fills_missing_base64() -> None:
+    """历史消息 content 缺 data 时，应按 image_id 回查媒体表补全 base64 到 content。"""
+    raw = "{'text': 'hi', 'media': [{'type': 'image', 'image_id': 'img1'}]}"
+    mock_manager = AsyncMock()
+    mock_manager.get_media_file = AsyncMock(return_value="iVBORw0KGgo=")
+    with patch(
+        "src.core.managers.media_manager.get_media_manager",
+        return_value=mock_manager,
+    ):
+        restored = await _restore_media_data_from_db(raw)
+
+    assert isinstance(restored, dict)
+    assert restored["text"] == "hi"
+    assert len(restored["media"]) == 1
+    assert restored["media"][0]["data"] == "iVBORw0KGgo="
+    assert restored["media"][0]["image_id"] == "img1"
+    mock_manager.get_media_file.assert_awaited_once_with("img1")
+
+
+@pytest.mark.asyncio
+async def test_restore_media_data_from_db_keeps_item_when_lookup_fails() -> None:
+    """回查失败时应保留原 media 项（含元信息），不抛异常。"""
+    raw = "{'text': 'hi', 'media': [{'type': 'image', 'image_id': 'img1'}]}"
+    mock_manager = AsyncMock()
+    mock_manager.get_media_file = AsyncMock(return_value=None)
+    with patch(
+        "src.core.managers.media_manager.get_media_manager",
+        return_value=mock_manager,
+    ):
+        restored = await _restore_media_data_from_db(raw)
+
+    assert isinstance(restored, dict)
+    assert restored["media"][0]["image_id"] == "img1"
+    assert "data" not in restored["media"][0]
+
+
+@pytest.mark.asyncio
+async def test_restore_media_data_from_db_keeps_plain_text() -> None:
+    """纯文本 content 应原样返回，不触发 DB 查询。"""
+    mock_manager = AsyncMock()
+    with patch(
+        "src.core.managers.media_manager.get_media_manager",
+        return_value=mock_manager,
+    ):
+        assert await _restore_media_data_from_db("plain text") == "plain text"
+        assert await _restore_media_data_from_db(
+            "{'text': 'hi', 'media': []}"
+        ) == {"text": "hi", "media": []}
+    mock_manager.get_media_file.assert_not_awaited()
+
+
+def test_content_to_plain_text_media_type_raw_string_placeholder() -> None:
+    """媒体类型的裸字符串 content（base64）应返回占位符，不产生 b64 文本。"""
+    assert _content_to_plain_text("iVBORw0KGgo=", "image") == "（非文本内容）"
+    assert "iVBORw0KGgo=" not in _content_to_plain_text("iVBORw0KGgo=", "emoji")
+    # 普通文本类型的裸字符串原样返回
+    assert _content_to_plain_text("hello", "text") == "hello"
+
+
+def test_serialize_content_for_db_strips_raw_string_media_content() -> None:
+    """媒体类型的裸字符串 content（base64）落库时不应包含 base64。"""
+    serialized = _serialize_content_for_db("iVBORw0KGgo=", "image")
+    assert "iVBORw0KGgo=" not in serialized
+    # 普通文本类型裸字符串原样落库
+    assert _serialize_content_for_db("hello", "text") == "hello"

--- a/test/core/transport/test_message_converter_media_to_envelope.py
+++ b/test/core/transport/test_message_converter_media_to_envelope.py
@@ -1,0 +1,130 @@
+"""MessageConverter.message_to_envelope 结构化媒体 content 的单元测试。
+
+发送端 ``send_*`` 组装 ``{"text", "media": [...]}`` 结构化 content 后，
+``message_to_envelope`` 应从 ``media`` 列表逐项构建媒体段（与接收端
+``_build_content`` 产出同构）。
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.core.models.message import Message, MessageType
+from src.core.transport.message_receive.converter import MessageConverter
+
+
+def _patch_stream_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    """让 message_to_envelope 的流信息查询走 fake，避免依赖数据库。"""
+    fake_stream_manager = SimpleNamespace(
+        get_stream_info=AsyncMock(return_value=None)
+    )
+    monkeypatch.setattr(
+        "src.core.managers.stream_manager.get_stream_manager",
+        lambda: fake_stream_manager,
+    )
+
+
+def _make_media_message(
+    content: Any, message_type: MessageType
+) -> Message:
+    """构造一个带结构化媒体 content 的 Message。"""
+    return Message(
+        message_id="m-media-1",
+        content=content,
+        message_type=message_type,
+        sender_id="bot-001",
+        sender_name="NeoBot",
+        platform="qq",
+        chat_type="group",
+        stream_id="stream-group-1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_message_to_envelope_builds_segments_from_media_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """结构化 content 的 media 列表应逐项构建媒体段，不产生 base64 文本段。"""
+    _patch_stream_manager(monkeypatch)
+    converter = MessageConverter()
+    content: dict[str, Any] = {
+        "text": "[图片]",
+        "media": [
+            {
+                "type": "image",
+                "data": "base64|iVBORw0KGgo=",
+                "image_id": "img-hash-1",
+            }
+        ],
+    }
+    message = _make_media_message(content, MessageType.IMAGE)
+
+    envelope = await converter.message_to_envelope(message)
+
+    segments = envelope.get("message_segment")
+    assert isinstance(segments, list)
+    assert segments == [{"type": "image", "data": "base64|iVBORw0KGgo="}]
+
+
+@pytest.mark.asyncio
+async def test_message_to_envelope_supports_multiple_media_items(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """media 列表含多个不同媒体项时应逐项构建对应段。"""
+    _patch_stream_manager(monkeypatch)
+    converter = MessageConverter()
+    content: dict[str, Any] = {
+        "text": "",
+        "media": [
+            {"type": "image", "data": "base64|AAA", "image_id": "img-1"},
+            {"type": "voice", "data": "base64|BBB", "voice_id": "voice-1"},
+        ],
+    }
+    message = _make_media_message(content, MessageType.IMAGE)
+
+    envelope = await converter.message_to_envelope(message)
+
+    segments = envelope.get("message_segment")
+    assert isinstance(segments, list)
+    assert segments == [
+        {"type": "image", "data": "base64|AAA"},
+        {"type": "voice", "data": "base64|BBB"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_message_to_envelope_falls_back_to_legacy_raw_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """旧形态（裸字符串 content）应回退为按 message_type 构建单个段。"""
+    _patch_stream_manager(monkeypatch)
+    converter = MessageConverter()
+    message = _make_media_message("iVBORw0KGgo=", MessageType.IMAGE)
+
+    envelope = await converter.message_to_envelope(message)
+
+    segments = envelope.get("message_segment")
+    assert isinstance(segments, list)
+    assert segments == [{"type": "image", "data": "iVBORw0KGgo="}]
+
+
+@pytest.mark.asyncio
+async def test_message_to_envelope_falls_back_to_legacy_file_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """旧形态（send_file 的 {path} dict）应回退为按 message_type 构建单个段。"""
+    _patch_stream_manager(monkeypatch)
+    converter = MessageConverter()
+    message = _make_media_message(
+        {"path": "/tmp/a.pdf", "name": "a.pdf"}, MessageType.FILE
+    )
+
+    envelope = await converter.message_to_envelope(message)
+
+    segments = envelope.get("message_segment")
+    assert isinstance(segments, list)
+    assert segments == [{"type": "file", "data": "/tmp/a.pdf"}]


### PR DESCRIPTION
# PR: 发送端统一结构化媒体 content，根除 base64 被当作文本参与 token 计数

## 背景

运行日志中发现对话上下文被**莫名其妙触发压缩**。排查后确认根因是**消息媒体（图片/表情/语音/视频）的 base64 二进制数据被当作普通文本参与了 token 计数**，导致单张图折算数万 token，历史消息稍多即顶爆压缩阈值（`max_context × 0.95`）。

此前 `token_counter.py` 已有针对 `Image`/`File` 类型 payload 的 base64 屏蔽，但**未覆盖「base64 落库后经字符串兜底变文本」这条路径**，因此问题仍存在。

## 根因链路

1. **Bot 发送含媒体消息**（`send_image`/`send_emoji`/`send_voice`/`send_video`）时，content 为**裸 base64 字符串**，`StreamManager.add_sent_message_to_history` 以 `str(message.content)` 原样入库。
2. 历史消息从 DB 加载时，`StreamManager._db_message_to_runtime` 的兜底逻辑 `str(db_message.content)` 把含 base64 的 content 变成 `processed_plain_text`。
3. 历史文本构建把含 base64 的文本拼进 `Text` payload，tiktoken 将其当普通字符统计 → 触发上下文压缩。

## 方案（发送端与接收端数据结构统一，根治）

采用**发送端与接收端对称**的结构化 content：`send_image`/`send_emoji`/`send_voice`/`send_video` 不再传裸 base64，而是组装为与接收端 `_build_content` 产出同构的 dict `{"text", "media": [{"type", "data", "image_id"/"voice_id"/"video_id"}]}`，从源头消灭裸 base64 形态。

### `src/app/plugin_system/api/send_api.py`
- 新增 `_build_media_content`：规范化 media data（`normalize_base64`）、计算媒体 ID（与 `MediaManager` 识别流程相同哈希算法）、组装结构化 content。
- `send_image`/`send_emoji`/`send_voice`/`send_video` 内部改传结构化 content。**对外签名不变**，插件调用方无需修改。

### `src/core/transport/message_receive/converter.py`
- `message_to_envelope` 对媒体类型消息优先从 `content["media"]` 列表逐项构建媒体段；无 `media` 列表时保留旧形态兼容（裸字符串 / `{path}` dict）。

### `src/core/managers/stream_manager.py`
- `_serialize_content_for_db` 移除 `message_type` 参数与裸字符串媒体兜底分支（发送端不再产生裸 base64）。
- `_content_to_plain_text` 移除 `message_type` 参数与裸字符串媒体分支。
- `_db_message_to_runtime` 仍按 `image_id` 回查媒体表补回 data 到 `content["media"]`，历史图片多模态可用。

## 测试

- 新增 `test/app/plugin_system/api/test_send_api_media_content.py`（`_build_media_content` 规范化/哈希/字段名）。
- 新增 `test/core/transport/test_message_converter_media_to_envelope.py`（结构化 media 构建段、多媒体、旧形态兼容）。
- 更新 `test/core/managers/test_stream_manager_media_serialization.py`（移除已删参数的裸串测试）。

## 验证

- 相关测试：**52 passed**，无回归。
- `ruff check`：**All checks passed**。
- 其余 6 个失败测试（`test_stream_loop_message_buffer` / `test_message_converter_reply_seglist`）在干净基线上同样失败，为 dev 既有问题，与本次改动无关。

## 影响范围

- 框架层 `src/` 三个文件 + `.gitignore`（忽略临时目录），不涉及插件。
- 行为变化：数据库不再存储媒体 base64（存储更省）；历史图片多模态通过按 `image_id` 回查媒体表保持可用。
- 兼容性：`message_to_envelope` 保留旧形态兜底，存量数据不受影响。
