### PR TITLE
fix(media): NDFC 多模态对同一 media_id 图片去重，避免重复内联 base64

### DIFF
--- a/plugins/neo_default_chatter/utils/multimodal.py
+++ b/plugins/neo_default_chatter/utils/multimodal.py
@@ -100,6 +100,11 @@ def inline_message_images_into_text(
     - 找不到（如历史消息中的占位符在未读消息中无对应图片）：还原为
       ``[图片(media_id)]`` 文本，不暴露内部标记给 LLM。
 
+    同一 ``media_id`` 在文本中出现多次时，仅首次出现会附加 ``Image(base64)``，
+    后续重复出现只保留 ``[图片(media_id)]`` 文本标记。未读消息与引用回复
+    常携带同一张图片（如回复内嵌被回复消息的图片），去重避免相同 base64
+    被重复传给 LLM 造成 token 浪费与上下文冗余。
+
     Args:
         text: 包含 ``[[NDFC_IMAGE:media_id]]`` 标记的文本
         messages: 用于查找图片的消息列表
@@ -108,6 +113,7 @@ def inline_message_images_into_text(
         Text/Image 交替排列的内容列表
     """
     media_index = _build_media_id_index(messages)
+    inlined_media_ids: set[str] = set()
 
     content_list: list[Content | LLMUsable] = []
     cursor = 0
@@ -122,7 +128,9 @@ def inline_message_images_into_text(
             content_list.append(Text(f"[图片({media_id})]"))
         else:
             content_list.append(Text(f"[图片({media_id})]"))
-            content_list.append(Image(str(image["data"])))
+            if media_id not in inlined_media_ids:
+                content_list.append(Image(str(image["data"])))
+                inlined_media_ids.add(media_id)
         cursor = match.end()
 
     if cursor < len(text):

--- a/test/plugins/neo_default_chatter/test_multimodal.py
+++ b/test/plugins/neo_default_chatter/test_multimodal.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from typing import Any
 
 from src.core.models.message import Message, MessageType
-from src.kernel.llm import Text
+from src.kernel.llm import Image, Text
 
 from plugins.neo_default_chatter.utils.multimodal import (
     extract_images_from_messages,
@@ -290,6 +290,55 @@ class TestMediaIdImageBinding:
         assert [type(item).__name__ for item in content] == [
             "Text", "Text", "Image", "Text", "Text", "Image",
         ]
+
+    def test_same_media_id_inlined_only_once(self) -> None:
+        """同一 media_id 重复出现时，仅首次附加 Image(base64)。
+
+        未读消息与引用回复常携带同一张图片（回复内嵌被回复消息的图片），
+        重复占位符只保留文本标记，不重复内联相同 base64。
+        """
+        msg = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        text = (
+            f"原始消息：{_NDFC_TOKEN.format(media_id=_HASH_A)}\\n"
+            f"引用回复又提到同一张图：{_NDFC_TOKEN.format(media_id=_HASH_A)}\\n"
+            f"再次引用：{_NDFC_TOKEN.format(media_id=_HASH_A)}"
+        )
+
+        content = inline_message_images_into_text(text, [msg])
+
+        # 首次出现：Text → Text → Image；后续重复：仅 Text 标记
+        assert [type(item).__name__ for item in content] == [
+            "Text", "Text", "Image", "Text", "Text", "Text", "Text",
+        ]
+        images = [item for item in content if isinstance(item, Image)]
+        assert len(images) == 1
+        # 每次出现都保留 [图片(media_id)] 文本标记，仅去重 base64
+        text_parts = [item.text for item in content if isinstance(item, Text)]
+        assert text_parts.count(f"[图片({_HASH_A})]") == 3
+
+    def test_distinct_media_ids_both_inlined(self) -> None:
+        """不同 media_id 互不影响，每张图都完整内联。"""
+        first = _make_msg(
+            message_id="m1",
+            media=[{"type": "image", "data": _VALID_B64, "image_id": _HASH_A}],
+        )
+        second = _make_msg(
+            message_id="m2",
+            media=[{"type": "image", "data": "aGVsbG8=", "image_id": _HASH_B}],
+        )
+        text = (
+            f"{_NDFC_TOKEN.format(media_id=_HASH_A)}\\n"
+            f"{_NDFC_TOKEN.format(media_id=_HASH_B)}\\n"
+            f"{_NDFC_TOKEN.format(media_id=_HASH_A)}"
+        )
+
+        content = inline_message_images_into_text(text, [first, second])
+
+        images = [item for item in content if isinstance(item, Image)]
+        assert len(images) == 2
 
 
 class TestStrictMediaIdPattern:


### PR DESCRIPTION
## 修复：NDFC 多模态对同一 media_id 的图片重复内联

### 问题描述

原生多模态模式下，`inline_message_images_into_text` 会为文本中**每一次**出现的 `[[NDFC_IMAGE:media_id]]` 标记都内联一份完整的 `Image(base64)`。

当同一张图片在单轮文本中多次出现时（例如用户发图后，另一人**引用回复**该消息，引用文本内嵌被回复消息的图片占位符；或跨轮累积时同一图多次进入未读列表），NDFC 会把这**同一张图的多份完全相同 base64** 都传给 LLM，造成：

- token 浪费（同一图片按次数重复计费）
- 上下文冗余，干扰模型对图片引用关系的理解
- 依赖该上下文镜像的组件（如上下文快照）会把重复媒体如实落盘

### 改动内容

`plugins/neo_default_chatter/utils/multimodal.py` 的 `inline_message_images_into_text`：

- 新增 `inlined_media_ids: set[str]`，记录已内联的 media_id
- 同一 media_id 首次出现时附加 `Image(base64)`，后续重复出现只保留 `[图片(media_id)]` 文本标记，不再重复内联 base64
- 不同 media_id 互不影响，每张图都完整内联

语义保持不变：每次出现仍保留 `[图片(media_id)]` 文本标记供模型建立关联，仅去重实际传入的媒体数据。

### 测试

`test/plugins/neo_default_chatter/test_multimodal.py` 新增 2 个用例：

- `test_same_media_id_inlined_only_once`：同一 media_id 重复出现时仅内联一次，且每次保留文本标记
- `test_distinct_media_ids_both_inlined`：不同 media_id 互不影响，每张图都完整内联

验证：`test/plugins/neo_default_chatter/` 全量 162 passed，无回归。

### 影响范围

- 仅修改 `neo_default_chatter` 的多模态内联函数及其测试
- 不涉及框架源码与其他插件

## Summary by Sourcery

Deduplicate inline multimodal images for repeated media IDs to avoid sending duplicate base64 payloads to the LLM while preserving textual image markers.

Bug Fixes:
- Ensure the multimodal inlining logic attaches Image(base64) only on the first occurrence of a given media_id, leaving subsequent occurrences as text markers only to prevent redundant media duplication.

Tests:
- Add regression tests covering repeated occurrences of the same media_id being inlined only once and distinct media_ids each being fully inlined.