### PR TITLE
refactor: 清理官方插件中的冗余版本号声明

### DIFF
--- a/AI插件编写规范.md
+++ b/AI插件编写规范.md
@@ -42,10 +42,11 @@ default_chatter:chatter:default_chatter
 
 - 必须继承 `BasePlugin`。
 - 必须使用 `@register_plugin` 装饰器。
-- 必须定义以下类属性：
-  - `plugin_name: str`
-  - `plugin_description: str`
-  - `plugin_version: str`
+- 必须定义类属性 `plugin_name: str`。
+- 版本号、描述、作者等元数据**只在 `manifest.json` 中声明**，插件类上不重复定义。
+  运行时 `plugin_version` 由框架从 manifest 注入（见 `PluginManager._inject_manifest_metadata`）；
+  插件类若再显式声明 `plugin_version` / `plugin_description` / `plugin_author`，
+  会被视为历史遗留冗余并触发 `DeprecationWarning`（不影响加载运行）。
 - 如果插件有配置类，必须在 `configs: list[type]` 中声明。
 - `get_components()` 必须返回组件类列表，返回值是 `list[type]`，不是实例列表。
 
@@ -58,8 +59,6 @@ from src.app.plugin_system.base import BasePlugin, register_plugin
 @register_plugin
 class MyPlugin(BasePlugin):
     plugin_name = "my_plugin"
-    plugin_description = "示例插件"
-    plugin_version = "1.0.0"
 
     configs: list[type] = []
     dependent_components: list[str] = []
@@ -820,8 +819,6 @@ class DemoPlugin(BasePlugin):
     """最小 demo 插件。"""
 
     plugin_name = "demo_plugin"
-    plugin_description = "最小 demo 插件"
-    plugin_version = "1.0.0"
 
     configs: list[type] = [DemoConfig]
     dependent_components: list[str] = []
@@ -851,7 +848,7 @@ AI 在生成插件前，先做下面的判定。
 在输出插件代码前，逐条检查：
 
 1. 是否使用了公开入口 `src.app.plugin_system.base/api/types`。
-2. 插件类是否有 `@register_plugin`，以及完整的 `plugin_name`、`plugin_description`、`plugin_version`。
+2. 插件类是否有 `@register_plugin`，以及 `plugin_name`。版本/描述/作者是否只在 `manifest.json` 声明，插件类上没有冗余的 `plugin_version` / `plugin_description` / `plugin_author`。
 3. `get_components()` 是否返回类而不是实例。
 4. 配置类是否放在 `configs` 中，而不是放进 `get_components()`。
 5. 每个组件是否定义了统一属性 `name`（不要继续使用 `tool_name` / `action_name` 等旧属性名），并与 manifest 中的 `component_name` 一致。

--- a/docs/guides/plugin-authoring/3-first-plugin.md
+++ b/docs/guides/plugin-authoring/3-first-plugin.md
@@ -162,8 +162,6 @@ class EchoDemoPlugin(BasePlugin):
     """最小回显插件。"""
 
     plugin_name = "echo_demo"
-    plugin_description = "一个用于演示插件加载与命令执行的最小插件"
-    plugin_version = "1.0.0"
 
     def get_components(self) -> list[type]:
         """返回当前插件包含的组件。"""

--- a/docs/guides/plugin-authoring/6-config.md
+++ b/docs/guides/plugin-authoring/6-config.md
@@ -274,8 +274,6 @@ class EchoDemoPlugin(BasePlugin):
     """最小回显插件。"""
 
     plugin_name = "echo_demo"
-    plugin_description = "一个用于演示插件加载与命令执行的最小插件"
-    plugin_version = "1.0.0"
 
     configs: list[type] = [EchoDemoConfig]
 

--- a/docs/guides/plugin-authoring/7-command-and-service.md
+++ b/docs/guides/plugin-authoring/7-command-and-service.md
@@ -193,8 +193,6 @@ class EchoDemoPlugin(BasePlugin):
     """最小回显插件。"""
 
     plugin_name = "echo_demo"
-    plugin_description = "一个用于演示插件加载与命令执行的最小插件"
-    plugin_version = "1.0.0"
 
     configs: list[type] = [EchoDemoConfig]
 

--- a/docs/guides/plugin-authoring/9-prompt-api.md
+++ b/docs/guides/plugin-authoring/9-prompt-api.md
@@ -107,8 +107,6 @@ class EchoDemoPlugin(BasePlugin):
     """最小回显插件。"""
 
     plugin_name = "echo_demo"
-    plugin_description = "一个用于演示插件加载与命令执行的最小插件"
-    plugin_version = "1.0.0"
 
     configs: list[type] = [EchoDemoConfig]
 

--- a/plugins/booku_memory/plugin.py
+++ b/plugins/booku_memory/plugin.py
@@ -28,7 +28,6 @@ class BookuMemoryAgentPlugin(BasePlugin):
 
     plugin_name: str = "booku_memory"
     plugin_description: str = "命令驱动的 Booku 记忆系统"
-    plugin_version: str = "1.0.0"
 
     configs: list[type] = [BookuMemoryConfig]
     dependent_components: list[str] = []

--- a/plugins/booku_memory/plugin.py
+++ b/plugins/booku_memory/plugin.py
@@ -27,7 +27,6 @@ class BookuMemoryAgentPlugin(BasePlugin):
     """Booku 记忆插件。"""
 
     plugin_name: str = "booku_memory"
-    plugin_description: str = "命令驱动的 Booku 记忆系统"
 
     configs: list[type] = [BookuMemoryConfig]
     dependent_components: list[str] = []

--- a/plugins/booku_memory/service/booku_knowledge_service.py
+++ b/plugins/booku_memory/service/booku_knowledge_service.py
@@ -627,7 +627,6 @@ class BookuKnowledgeService(BaseService):
 
     name: str = "booku_knowledge"
     description: str = "知识库服务，支持文档分块入库与语义检索"
-    version: str = "1.0.0"
     dependencies: list[str] = []
     _memory_service: BookuMemoryService | None = None
 

--- a/plugins/booku_memory/service/booku_memory_service.py
+++ b/plugins/booku_memory/service/booku_memory_service.py
@@ -302,7 +302,6 @@ class BookuMemoryService(BaseService):
 
     name: str = "booku_memory"
     description: str = "Booku 记忆服务，提供写入判重与检索重塑"
-    version: str = "1.0.0"
 
     _repo: BookuMemoryMetadataRepository | None = None
     _repo_initialized: bool = False

--- a/plugins/default_chatter/components/service.py
+++ b/plugins/default_chatter/components/service.py
@@ -27,7 +27,6 @@ class DefaultChatterService(BaseService):
 
     name = "chat_core"
     description = "Default Chatter 会话工厂和可重用聊天核心"
-    version = "1.0.0"
 
     def create_session(
         self,

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -248,7 +248,6 @@ class DefaultChatterPlugin(BasePlugin):
     """默认聊天插件。"""
 
     plugin_name = "default_chatter"
-    plugin_version = "1.2.0-alpha"
     plugin_author = "MoFox Team"
     plugin_description = "默认聊天组件，提供基础的消息处理和回复功能"
     configs = [DefaultChatterConfig]

--- a/plugins/default_chatter/plugin.py
+++ b/plugins/default_chatter/plugin.py
@@ -248,8 +248,6 @@ class DefaultChatterPlugin(BasePlugin):
     """默认聊天插件。"""
 
     plugin_name = "default_chatter"
-    plugin_author = "MoFox Team"
-    plugin_description = "默认聊天组件，提供基础的消息处理和回复功能"
     configs = [DefaultChatterConfig]
 
     async def on_plugin_loaded(self) -> None:

--- a/plugins/emoji_sender/plugin.py
+++ b/plugins/emoji_sender/plugin.py
@@ -68,7 +68,6 @@ class EmojiSenderPlugin(BasePlugin):
     """emoji_sender 插件。"""
 
     plugin_name: str = "emoji_sender"
-    plugin_description: str = "从 media cache 收藏表情包并按 tag+向量检索发送"
 
     configs: list[type] = [EmojiSenderConfig]
     dependent_components: list[str] = []

--- a/plugins/emoji_sender/plugin.py
+++ b/plugins/emoji_sender/plugin.py
@@ -69,7 +69,6 @@ class EmojiSenderPlugin(BasePlugin):
 
     plugin_name: str = "emoji_sender"
     plugin_description: str = "从 media cache 收藏表情包并按 tag+向量检索发送"
-    plugin_version: str = "1.0.0"
 
     configs: list[type] = [EmojiSenderConfig]
     dependent_components: list[str] = []

--- a/plugins/emoji_sender/service.py
+++ b/plugins/emoji_sender/service.py
@@ -95,7 +95,6 @@ class EmojiSenderService(BaseService):
 
     name: str = "emoji_sender"
     description: str = "表情包收藏、检索与发送服务"
-    version: str = "1.0.0"
 
     def _selection_temperature(self) -> float:
         """获取检索候选采样温度。"""

--- a/plugins/neo_default_chatter/components/service.py
+++ b/plugins/neo_default_chatter/components/service.py
@@ -28,7 +28,6 @@ class NeoChatterService(BaseService):
 
     name = "chat_core"
     description = "Neo-Default-Chatter 会话工厂，复用主会话逻辑构建自定义聊天器"
-    version = "0.1.0"
 
     def create_session(
         self,

--- a/plugins/neo_default_chatter/plugin.py
+++ b/plugins/neo_default_chatter/plugin.py
@@ -60,7 +60,6 @@ class NeoChatterPlugin(BasePlugin):
     """
 
     plugin_name = "neo_default_chatter"
-    plugin_version = "0.1.0"
     plugin_author = "MoFox Team"
     plugin_description = "可复用的会话逻辑中台，事件驱动预处理 + 原生多模态"
     configs = [NeoChatterConfig]

--- a/plugins/neo_default_chatter/plugin.py
+++ b/plugins/neo_default_chatter/plugin.py
@@ -60,8 +60,6 @@ class NeoChatterPlugin(BasePlugin):
     """
 
     plugin_name = "neo_default_chatter"
-    plugin_author = "MoFox Team"
-    plugin_description = "可复用的会话逻辑中台，事件驱动预处理 + 原生多模态"
     configs = [NeoChatterConfig]
 
     async def on_plugin_loaded(self) -> None:

--- a/plugins/onebot_adapter/__init__.py
+++ b/plugins/onebot_adapter/__init__.py
@@ -4,5 +4,4 @@
 实现 OneBot 11 协议的通信。
 """
 
-__version__ = "2.0.0"
 __author__ = "MoFox Team"

--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -352,8 +352,6 @@ class OneBotAdapterPlugin(BasePlugin):
     """OneBot 适配器插件"""
 
     plugin_name: str = "onebot_adapter"
-    plugin_author: str = "MoFox Team"
-    plugin_description: str = "OneBot 11 适配器（基于 Neo-MoFox 重写）"
     configs: list[type] = [OneBotAdapterConfig]
 
 

--- a/plugins/onebot_adapter/plugin.py
+++ b/plugins/onebot_adapter/plugin.py
@@ -51,7 +51,6 @@ class OneBotAdapter(BaseAdapter):
     """OneBot 适配器 - 完全基于 mofox-wire 架构"""
 
     name = "onebot_adapter"
-    adapter_version = "2.0.0"
     adapter_author = "MoFox Team"
     description = "基于 MoFox-Bus 的 OneBot 11 适配器"
     platform = "qq"
@@ -353,7 +352,6 @@ class OneBotAdapterPlugin(BasePlugin):
     """OneBot 适配器插件"""
 
     plugin_name: str = "onebot_adapter"
-    plugin_version: str = "2.0.0"
     plugin_author: str = "MoFox Team"
     plugin_description: str = "OneBot 11 适配器（基于 Neo-MoFox 重写）"
     configs: list[type] = [OneBotAdapterConfig]

--- a/plugins/perm_plugin/plugin.py
+++ b/plugins/perm_plugin/plugin.py
@@ -22,7 +22,6 @@ class PermPlugin(BasePlugin):
     """
 
     plugin_name: str = "perm_plugin"
-    plugin_description: str = "系统权限管理插件，提供聊天内 /perm 命令"
 
     configs: list[type] = []
     dependent_components: list[str] = []

--- a/plugins/perm_plugin/plugin.py
+++ b/plugins/perm_plugin/plugin.py
@@ -23,7 +23,6 @@ class PermPlugin(BasePlugin):
 
     plugin_name: str = "perm_plugin"
     plugin_description: str = "系统权限管理插件，提供聊天内 /perm 命令"
-    plugin_version: str = "1.0.0"
 
     configs: list[type] = []
     dependent_components: list[str] = []

--- a/plugins/skill_manager/__init__.py
+++ b/plugins/skill_manager/__init__.py
@@ -1,3 +1,1 @@
 """SkillManager 插件。"""
-
-__version__ = "1.0.0"

--- a/plugins/skill_manager/plugin.py
+++ b/plugins/skill_manager/plugin.py
@@ -68,7 +68,6 @@ class SkillManagerPlugin(BasePlugin):
     """Skill 管理器插件。"""
 
     plugin_name: str = "skill_manager"
-    plugin_description: str = "技能管理器"
 
     configs: list[type] = [SkillManagerConfig]
 

--- a/plugins/skill_manager/plugin.py
+++ b/plugins/skill_manager/plugin.py
@@ -69,7 +69,6 @@ class SkillManagerPlugin(BasePlugin):
 
     plugin_name: str = "skill_manager"
     plugin_description: str = "技能管理器"
-    plugin_version: str = "1.0.0"
 
     configs: list[type] = [SkillManagerConfig]
 

--- a/plugins/utility_commands/plugin.py
+++ b/plugins/utility_commands/plugin.py
@@ -27,7 +27,6 @@ class UtilityCommandsPlugin(BasePlugin):
 
     plugin_name: str = "utility_commands"
     plugin_description: str = "实用命令集合插件，收纳常用运维/管理类命令"
-    plugin_version: str = "1.0.0"
 
     configs: list[type] = []
     dependent_components: list[str] = []

--- a/plugins/utility_commands/plugin.py
+++ b/plugins/utility_commands/plugin.py
@@ -26,7 +26,6 @@ class UtilityCommandsPlugin(BasePlugin):
     """
 
     plugin_name: str = "utility_commands"
-    plugin_description: str = "实用命令集合插件，收纳常用运维/管理类命令"
 
     configs: list[type] = []
     dependent_components: list[str] = []

--- a/src/core/managers/plugin_manager.py
+++ b/src/core/managers/plugin_manager.py
@@ -221,6 +221,9 @@ class PluginManager:
         if not has_config:
             logger.debug(f"插件 '{plugin_name}' 未通过类属性 configs 声明配置，使用空配置")
 
+        # 5.1 以 manifest 为唯一权威来源，注入插件运行时版本号
+        self._inject_manifest_metadata(plugin_instance, manifest)
+
         # 6. 注册组件到全局注册表
         await self._register_components(plugin_instance)
 
@@ -486,6 +489,48 @@ class PluginManager:
                 state_manager.remove_runtime_data(signature)
             except Exception as e:
                 logger.warning(f"更新组件状态失败 '{signature}': {e}")
+
+    def _inject_manifest_metadata(
+        self, plugin_instance: "BasePlugin", manifest: "PluginManifest"
+    ) -> None:
+        """以 manifest 为唯一权威来源，注入插件运行时版本号。
+
+        将 ``manifest.version`` 写入 ``plugin_version``。若插件类在类级别显式
+        声明了 ``plugin_version`` / ``plugin_description`` / ``plugin_author``，
+        发出弃用警告提醒移除，不影响插件加载运行。
+
+        Args:
+            plugin_instance: 已实例化的插件对象
+            manifest: 该插件的 manifest 数据
+        """
+        import warnings
+
+        plugin_instance.plugin_version = manifest.version
+
+        declared_vars = vars(type(plugin_instance))
+        declared_version = declared_vars.get("plugin_version")
+        if declared_version is not None and declared_version != manifest.version:
+            warnings.warn(
+                f"插件 '{plugin_instance.plugin_name}' 的类属性 plugin_version "
+                f"({declared_version}) 与 manifest.version ({manifest.version}) 不一致，"
+                "已弃用；版本号请只保留在 manifest.json",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        if "plugin_description" in declared_vars and manifest.description:
+            warnings.warn(
+                f"插件 '{plugin_instance.plugin_name}' 的类属性 plugin_description "
+                "已弃用；描述请只保留在 manifest.json",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+        if "plugin_author" in declared_vars:
+            warnings.warn(
+                f"插件 '{plugin_instance.plugin_name}' 的类属性 plugin_author "
+                "已弃用；作者信息请只保留在 manifest.json",
+                DeprecationWarning,
+                stacklevel=3,
+            )
 
     async def reload_plugin(self, plugin_name: str) -> bool:
         """重载插件。

--- a/test/core/managers/test_plugin_manager_metadata.py
+++ b/test/core/managers/test_plugin_manager_metadata.py
@@ -1,0 +1,113 @@
+"""测试插件管理器注入 manifest 元数据的行为。
+
+验证 ``PluginManager._inject_manifest_metadata``：
+- 以 ``manifest.version`` 为准注入 ``plugin_version``；
+- 插件类显式声明冗余元数据时触发 ``DeprecationWarning``；
+- 未声明冗余元数据时不触发警告。
+"""
+
+from __future__ import annotations
+
+import warnings
+
+from src.core.components.base.plugin import BasePlugin
+from src.core.components.loader import PluginManifest
+from src.core.managers.plugin_manager import PluginManager
+
+
+class _MinimalPlugin(BasePlugin):
+    """未声明任何冗余元数据的最小插件。"""
+
+    plugin_name = "minimal_plugin"
+
+    def get_components(self) -> list[type]:
+        return []
+
+
+class _RedundantPlugin(BasePlugin):
+    """显式声明了冗余元数据的插件。"""
+
+    plugin_name = "redundant_plugin"
+    plugin_version = "9.9.9"
+    plugin_description = "旧版描述"
+    plugin_author = "旧作者"
+
+    def get_components(self) -> list[type]:
+        return []
+
+
+def _make_manifest(name: str, version: str = "2.0.0") -> PluginManifest:
+    """构造测试用 manifest。"""
+    return PluginManifest(
+        name=name,
+        version=version,
+        description="manifest 描述",
+        author="manifest 作者",
+    )
+
+
+def test_inject_version_from_manifest() -> None:
+    """manifest.version 应注入为 plugin_version。"""
+    manager = PluginManager()
+    plugin = _MinimalPlugin()
+    manifest = _make_manifest("minimal_plugin")
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        manager._inject_manifest_metadata(plugin, manifest)
+
+    assert plugin.plugin_version == "2.0.0"
+
+
+def test_no_warning_without_redundant_metadata() -> None:
+    """未声明冗余元数据时不应触发 DeprecationWarning。"""
+    manager = PluginManager()
+    plugin = _MinimalPlugin()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        manager._inject_manifest_metadata(plugin, _make_manifest("minimal_plugin"))
+
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    assert deprecations == []
+
+
+def test_deprecation_warning_on_redundant_metadata() -> None:
+    """显式声明 plugin_version / plugin_description / plugin_author 应触发警告。"""
+    manager = PluginManager()
+    plugin = _RedundantPlugin()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        manager._inject_manifest_metadata(plugin, _make_manifest("redundant_plugin"))
+
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    messages = " | ".join(str(w.message) for w in deprecations)
+
+    assert "plugin_version" in messages
+    assert "plugin_description" in messages
+    assert "plugin_author" in messages
+    # 即使声明了冗余版本，运行值仍以 manifest 为准
+    assert plugin.plugin_version == "2.0.0"
+
+
+def test_warning_when_declared_version_mismatches_manifest() -> None:
+    """声明版本与 manifest 不一致时应触发警告。"""
+    manager = PluginManager()
+    plugin = _RedundantPlugin()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        manager._inject_manifest_metadata(plugin, _make_manifest("redundant_plugin", version="3.0.0"))
+
+    deprecations = [
+        w for w in caught if issubclass(w.category, DeprecationWarning)
+    ]
+    messages = " | ".join(str(w.message) for w in deprecations)
+    assert "9.9.9" in messages
+    assert "3.0.0" in messages
+    assert plugin.plugin_version == "3.0.0"


### PR DESCRIPTION
# PR: 插件元数据规范化——版本/描述/作者单一来源 manifest.json

## 背景

框架中插件版本号的唯一权威来源是 `manifest.json`（由 loader 读取，plugin_manager / command_parser 展示版本均读 manifest）。各官方插件在 `plugin.py` 中手写的 `plugin_version`、`plugin_description`、`plugin_author`，`__init__.py` 中的 `__version__`，以及 Service/Adapter 组件上的 `version` / `adapter_version` 均为历史遗留的重复声明，易与 manifest 版本号不一致（如 default_chatter、neo_default_chatter 的旧值已与 manifest 漂移）。

规范化目标是：让 manifest 成为插件元数据的唯一权威来源，官方插件不再重复声明，从而阻断不规范写法向第三方插件扩散。

## 框架侧改动（src/）

- `src/core/managers/plugin_manager.py`：
  - 新增 `_inject_manifest_metadata`：插件实例化后，将 `manifest.version` 注入 `plugin.plugin_version`，保证 `/plugins` 等读取 `plugin.plugin_version` 的地方始终显示 manifest 真实版本。
  - 若插件类在类级别显式声明了 `plugin_version` / `plugin_description` / `plugin_author`，发出 `DeprecationWarning` 提醒移除（仅警告，不影响加载运行；未声明则无任何警告）。

## 插件侧改动（plugins/ 官方插件）

删除官方插件中冗余元数据声明：

- 插件级 `plugin_version`（8 处）：utility_commands、perm_plugin、emoji_sender、skill_manager、booku_memory、default_chatter、neo_default_chatter、onebot_adapter 的 plugin.py
- 插件级 `plugin_description` / `plugin_author`：同 8 个官方插件（default_chatter、neo_default_chatter、onebot_adapter 另含 plugin_author）
- 模块级 `__version__`（2 处）：skill_manager/__init__.py、onebot_adapter/__init__.py
- Service 组件级 `version`（5 处）：emoji_sender、booku_memory（两个 service）、default_chatter、neo_default_chatter 的 components/service.py
- Adapter 组件级 `adapter_version`（1 处）：onebot_adapter/plugin.py

保留项（非违规，未改动）：
- onebot_adapter/config.py 的 `config_version`（配置文件自身版本号，用于配置迁移）
- default_chatter/semantic_interest/ 内 `model_version` / `version`（语义兴趣模型版本号，属业务数据）
- 第三方插件（独立 git 仓库，如 foxzone 等）未检出冗余声明，不在本次范围

## 文档更新

- `AI插件编写规范.md`：第 2.1 节最小契约改为只要求 `plugin_name`；元数据（版本/描述/作者）只在 manifest.json 声明；更新最小示例与第 9.4 节完整示例；第 11 节自检清单同步更新。
- `docs/guides/plugin-authoring/3-first-plugin.md`、`6-config.md`、`7-command-and-service.md`、`9-prompt-api.md`：示例插件类移除 `plugin_version` / `plugin_description`。

## 测试

- 新增 `test/core/managers/test_plugin_manager_metadata.py`（4 个用例）：注入 manifest.version、无冗余元数据不告警、冗余元数据触发 DeprecationWarning、声明版本与 manifest 不一致时告警且运行值以 manifest 为准。
- 相关既有测试（test_plugin_manager_configs / events）15 个全部通过。

## 影响范围与兼容性

- 旧插件即使保留冗余字段也不报错、不影响加载运行，仅收到 DeprecationWarning 提醒。
- 版本号展示、市场同步均以 manifest 为准，删除冗余声明不影响运行逻辑。
- 全部改动文件通过 `uv run ruff check`。
