### PR TITLE
fix(default_chatter): 修正会话测试 mock 未读消费语义避免测试死循环

### DIFF
--- a/test/plugins/test_default_chatter_session.py
+++ b/test/plugins/test_default_chatter_session.py
@@ -107,6 +107,7 @@ class _FakeRuntime:
         self._response = response
         self.create_request_calls: list[tuple[str, str | None]] = []
         self.stream_id = "s1"
+        self._fetch_count = 0
 
     def create_request(
         self,
@@ -129,7 +130,12 @@ class _FakeRuntime:
 
     async def fetch_unreads(self, time_format: str = "%H:%M") -> tuple[str, list[Any]]:
         _ = time_format
-        return "", [SimpleNamespace(message_id="m1")]
+        self._fetch_count += 1
+        # 模拟真实消费语义：首次返回一条待处理未读，之后未读被消费置空。
+        # 避免 pass_and_wait 前重新 fetch 恒非空导致状态机无限跳过 Wait 而死循环。
+        if self._fetch_count == 1:
+            return "", [SimpleNamespace(message_id="m1")]
+        return "", []
 
     def format_message_line(self, _msg: Any, _time_format: str = "%H:%M") -> str:
         return "line"
@@ -487,6 +493,7 @@ async def test_session_execute_with_stream_prints_actor_decision_panel_before_pr
     async def _fake_process_tool_calls(**_kwargs: Any) -> Any:
         return SimpleNamespace(
             should_wait=True,
+            wait_seconds=None,
             should_stop=False,
             stop_minutes=0.0,
             has_pending_tool_results=False,


### PR DESCRIPTION
# PR: 修正 default_chatter 会话测试 mock 未读消费语义避免死循环

## 背景

`pytest` 测试进程在运行 `test/plugins/` 时内存无限膨胀（约 20 GB 后被强制终止）。
经 faulthandler 定位，根因是 `default_chatter` 会话状态机在特定测试输入下陷入
无限循环，每轮循环都向 LLM 响应上下文追加 payload，导致内存无界增长。

## 根因（测试侧）

`test/plugins/test_default_chatter_session.py` 中 `_FakeRuntime.fetch_unreads`
**恒返回同一条未读消息**（`[SimpleNamespace(message_id="m1")]`），从不模拟未读被
消费。

`default_chatter` 的会话状态机在 `pass_and_wait` 进入 Wait 前会重新
`fetch_unreads()` 检查是否有新消息：只要有未读就跳过 `yield Wait` 并进入下一轮
模型回合（这是 `be8340d` 引入的竞态处理）。由于测试 mock 恒返回未读，状态机在
`WAIT_USER → MODEL_TURN → TOOL_EXEC → WAIT_USER` 间无限闭环，每次都向
`response.payloads` 追加 payload，内存无限膨胀。

## 修复内容（仅测试文件）

1. **`_FakeRuntime.fetch_unreads`**：改为首次返回一条待处理未读、之后返回空，
   模拟真实系统中未读被消费的语义。这样 `pass_and_wait` 前重新 fetch 会拿到空
   未读，状态机正常 `yield Wait`，不再死循环。
2. **`_fake_process_tool_calls`**：补 `wait_seconds=None`，与真实
   `ToolCallOutcome` 默认值对齐（修复后状态机能走到 `yield Wait(time=...)`，
   该字段被真实读取）。

## 改动文件

- `test/plugins/test_default_chatter_session.py`

## 验证

- `test/plugins/test_default_chatter_session.py`：19 个用例全部通过（修复前多个
  `execute_with_stream` 用例死循环挂死）。

## 说明

本 PR 仅调整测试 mock，不改动 `plugins/default_chatter/session.py` 等实现代码。

`test/plugins/booku_memory/test_booku_knowledge_service.py` 存在一个与本改动无关的
既有失败（测试断言 collection 名为 `booku_memory__knowledge__default`，实现已改为
`booku_memory__knowledge`），不在本 PR 处理范围。
