### PR TITLE
fix(media): 修复 VLM 图片描述被截断

### DIFF
--- a/src/core/managers/media_manager/engines.py
+++ b/src/core/managers/media_manager/engines.py
@@ -98,9 +98,6 @@ class VLMEngine:
 
             description = response.message.strip() if response.message else ""
 
-            if len(description) > 100:
-                description = description[:97] + "..."
-
             return description if description else None
 
         except Exception as e:

--- a/test/core/managers/test_media_engines.py
+++ b/test/core/managers/test_media_engines.py
@@ -1,0 +1,57 @@
+"""媒体识别引擎的回归测试。"""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.managers.media_manager.engines import VLMEngine
+
+
+class _AwaitableResponse:
+    """提供 VLM 引擎所需最小接口的响应对象。"""
+
+    def __init__(self, message: str) -> None:
+        self.message = message
+
+    def __await__(self) -> Generator[Any, None, "_AwaitableResponse"]:
+        async def _resolve() -> "_AwaitableResponse":
+            return self
+
+        return _resolve().__await__()
+
+
+@pytest.mark.asyncio
+async def test_vlm_recognize_preserves_long_model_description() -> None:
+    """模型返回超过 100 字符时，识别结果应保持完整。"""
+    model_set: list[dict[str, Any]] = [{}]
+    config = MagicMock()
+    config.vlm_available = True
+    config.vlm_model_set = model_set
+
+    request = MagicMock()
+    long_description = "图片文字与布局说明" * 20
+    response = _AwaitableResponse(f"  {long_description}  ")
+    request.send = AsyncMock(return_value=response)
+
+    template = MagicMock()
+    template.build = AsyncMock(return_value="请完整描述图片")
+    prompt_manager = MagicMock()
+    prompt_manager.get_template.return_value = template
+
+    with (
+        patch(
+            "src.core.managers.media_manager.engines.create_llm_request",
+            return_value=request,
+        ),
+        patch(
+            "src.core.managers.media_manager.engines.get_prompt_manager",
+            return_value=prompt_manager,
+        ),
+    ):
+        result = await VLMEngine(config).recognize("dGVzdA==", "image")
+
+    assert result == long_description


### PR DESCRIPTION
## 问题说明

VLM 识别图片后，媒体引擎会在本地把超过 100 字符的描述强制截断为 97 个字符加 `...`。因此，即使模型任务配置了更高的 `max_tokens`，下游收到的图片描述仍然固定在约 100 字符处中断。

## 修改内容

- 移除 VLM 图片描述的 100 字符硬截断，完整保留模型返回文本。
- 增加长描述回归测试，确保超过 100 字符的结果不会再次被本地截断。

## 验证结果

- 媒体管理与 VLM 引擎测试：`41 passed`
- Ruff 静态检查：通过
- Python 语法检查：通过
- Git 空白检查：通过

## 影响范围

仅移除图片与表情包 VLM 描述的本地长度限制，不修改缓存、模型请求参数、语音识别和视频识别行为。