### PR TITLE
feat: 文件消息在 LLM 可见文本中附带可读大小

### DIFF
--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import re
 import time
 from typing import Any
 
@@ -78,12 +79,17 @@ def _merge_message_extra_with_format_info(
     return extra_data
 
 
+# 预格式化大小文本（如 OneBot 回声中 "1.7MB"），直接透传
+_READABLE_SIZE_RE = re.compile(r"^\d+(?:\.\d+)?\s*[KMGTP]?i?B$", re.IGNORECASE)
+
+
 def _format_file_size(size: Any) -> str:
     """将字节数格式化为可读大小文本。
 
-    支持数值与数字字符串；无法解析（如 ``None``、空串或 OneBot 回声中
-    形如 ``"1.7MB"`` 的预格式化字符串）时原样返回，避免 LLM 文本中出现
-    无意义的 ``None``。单位以 1024 进制换算（B/KB/MB/GB/TB）。
+    支持数值、数字字符串（含千分位逗号）；无法解析（``None``、空串、
+    负数或非数字）时统一返回空字符串，避免 LLM 文本中出现无意义内容。
+    已是可读格式的字符串（如 ``"1.7MB"``）原样返回。单位以 1024 进制
+    换算（B/KB/MB/GB/TB）。
 
     Args:
         size: 文件大小（字节数或字符串）。
@@ -91,23 +97,28 @@ def _format_file_size(size: Any) -> str:
     Returns:
         可读大小文本；无法解析时返回空字符串。
     """
-    if size is None or size == "":
+    if size is None:
         return ""
     if isinstance(size, str):
         stripped = size.strip()
         if not stripped:
             return ""
         # 已是可读格式（如 "1.7MB"），直接原样使用
-        if not stripped.replace(".", "", 1).isdigit():
+        if _READABLE_SIZE_RE.match(stripped):
             return stripped
-        size = int(stripped)
+        # 兼容千分位逗号（如 "1,024"）
+        normalized = stripped.replace(",", "")
+        try:
+            size = int(normalized)
+        except ValueError:
+            return ""
     try:
         size = int(size)
     except (TypeError, ValueError):
-        return str(size)
+        return ""
 
     if size < 0:
-        return str(size)
+        return ""
     units = ("B", "KB", "MB", "GB", "TB")
     value = float(size)
     for unit in units:

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -79,7 +79,7 @@ def _merge_message_extra_with_format_info(
     return extra_data
 
 
-# 预格式化大小文本（如 OneBot 回声中 "1.7MB"），直接透传
+# 预格式化大小文本（如 "1.7MB"），直接透传
 _READABLE_SIZE_RE = re.compile(r"^\d+(?:\.\d+)?\s*[KMGTP]?i?B$", re.IGNORECASE)
 
 

--- a/src/core/transport/message_receive/converter.py
+++ b/src/core/transport/message_receive/converter.py
@@ -78,6 +78,47 @@ def _merge_message_extra_with_format_info(
     return extra_data
 
 
+def _format_file_size(size: Any) -> str:
+    """将字节数格式化为可读大小文本。
+
+    支持数值与数字字符串；无法解析（如 ``None``、空串或 OneBot 回声中
+    形如 ``"1.7MB"`` 的预格式化字符串）时原样返回，避免 LLM 文本中出现
+    无意义的 ``None``。单位以 1024 进制换算（B/KB/MB/GB/TB）。
+
+    Args:
+        size: 文件大小（字节数或字符串）。
+
+    Returns:
+        可读大小文本；无法解析时返回空字符串。
+    """
+    if size is None or size == "":
+        return ""
+    if isinstance(size, str):
+        stripped = size.strip()
+        if not stripped:
+            return ""
+        # 已是可读格式（如 "1.7MB"），直接原样使用
+        if not stripped.replace(".", "", 1).isdigit():
+            return stripped
+        size = int(stripped)
+    try:
+        size = int(size)
+    except (TypeError, ValueError):
+        return str(size)
+
+    if size < 0:
+        return str(size)
+    units = ("B", "KB", "MB", "GB", "TB")
+    value = float(size)
+    for unit in units:
+        if value < 1024.0 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(value)}{unit}"
+            return f"{value:.1f}{unit}"
+        value /= 1024.0
+    return f"{size}B"
+
+
 # ──────────────────────────────────────────────
 #  段解析返回结构
 # ──────────────────────────────────────────────
@@ -585,16 +626,21 @@ class MessageConverter:
             parsed = safe_json_loads(data)
 
         if isinstance(parsed, dict):
+            file_size = parsed.get("size") or parsed.get("file_size")
             result.media.append({
                 "type": "file",
                 "data": {
                     "name": parsed.get("name") or parsed.get("file", ""),
-                    "size": parsed.get("size") or parsed.get("file_size"),
+                    "size": file_size,
                     "id": parsed.get("id") or parsed.get("file_id"),
                 },
             })
             file_name = parsed.get("name") or parsed.get("file", "文件")
-            result.text_parts.append(f"[文件:{file_name}]")
+            size_text = _format_file_size(file_size)
+            # 文本占位符附带可读大小，使 LLM 在 processed_plain_text 中能感知文件大小
+            result.text_parts.append(
+                f"[文件:{file_name}({size_text})]" if size_text else f"[文件:{file_name}]"
+            )
         else:
             # 无法解析结构，保留原始信息
             result.media.append({"type": "file", "data": parsed})

--- a/test/core/transport/test_message_converter_file_size.py
+++ b/test/core/transport/test_message_converter_file_size.py
@@ -1,0 +1,86 @@
+"""测试 MessageConverter 对文件消息段（file）的大小渲染与解析。"""
+
+from __future__ import annotations
+
+from src.core.transport.message_receive.converter import (
+    MessageConverter,
+    _format_file_size,
+)
+
+
+def _parse_file(data: object) -> tuple[list[str], list[dict]]:
+    """构造 _ParseResult 并调用 _handle_file，返回文本与媒体列表。"""
+    from src.core.transport.message_receive.converter import _ParseResult
+
+    parse_result = _ParseResult()
+    MessageConverter._handle_file(data, parse_result)
+    return parse_result.text_parts, parse_result.media
+
+
+def test_format_file_size_bytes() -> None:
+    """字节单位直接展示，无小数。"""
+    assert _format_file_size(0) == "0B"
+    assert _format_file_size(512) == "512B"
+
+
+def test_format_file_size_units() -> None:
+    """大于等于 1024 时按 1024 进制换算并保留一位小数。"""
+    assert _format_file_size(1024) == "1.0KB"
+    assert _format_file_size(5119) == "5.0KB"
+    assert _format_file_size(83385540) == "79.5MB"
+    assert _format_file_size(1073741824) == "1.0GB"
+
+
+def test_format_file_size_numeric_string() -> None:
+    """数字字符串应被解析为字节数。"""
+    assert _format_file_size("3020") == "2.9KB"
+
+
+def test_format_file_size_preset_text() -> None:
+    """已是可读格式（如 OneBot 回声中 "1.7MB"）原样返回。"""
+    assert _format_file_size("1.7MB") == "1.7MB"
+
+
+def test_format_file_size_invalid() -> None:
+    """None / 空串 / 非法值返回空串，不污染 LLM 文本。"""
+    assert _format_file_size(None) == ""
+    assert _format_file_size("") == ""
+    assert _format_file_size("  ") == ""
+
+
+def test_handle_file_with_size() -> None:
+    """带 size 的文件段应把可读大小渲染进文本占位符。"""
+    text_parts, media = _parse_file(
+        {"name": "今日日记.txt", "size": 3020, "id": "f1"}
+    )
+    assert text_parts == ["[文件:今日日记.txt(2.9KB)]"]
+    assert media == [
+        {"type": "file", "data": {"name": "今日日记.txt", "size": 3020, "id": "f1"}}
+    ]
+
+
+def test_handle_file_without_size() -> None:
+    """无 size 时不追加大小括号，保持原占位符格式。"""
+    text_parts, _media = _parse_file({"name": "a.txt"})
+    assert text_parts == ["[文件:a.txt]"]
+
+
+def test_handle_file_legacy_file_field() -> None:
+    """兼容旧字段名 file（OneBot 用 file 字段承载文件名）。"""
+    text_parts, media = _parse_file({"file": "a.mp4", "file_size": 36492772})
+    assert text_parts == ["[文件:a.mp4(34.8MB)]"]
+    assert media[0]["data"]["name"] == "a.mp4"
+    assert media[0]["data"]["size"] == 36492772
+
+
+def test_handle_file_size_preset_text() -> None:
+    """file_size 已是可读文本（如 "1.7MB"）时直接展示。"""
+    text_parts, _media = _parse_file({"file": "x.zip", "file_size": "1.7MB"})
+    assert text_parts == ["[文件:x.zip(1.7MB)]"]
+
+
+def test_handle_file_non_dict() -> None:
+    """无法解析为 dict 时回退到占位符 [文件]，media 保留原始值。"""
+    text_parts, media = _parse_file("not-a-dict")
+    assert text_parts == ["[文件]"]
+    assert media == [{"type": "file", "data": "not-a-dict"}]

--- a/test/core/transport/test_message_converter_file_size.py
+++ b/test/core/transport/test_message_converter_file_size.py
@@ -46,6 +46,27 @@ def test_format_file_size_invalid() -> None:
     assert _format_file_size(None) == ""
     assert _format_file_size("") == ""
     assert _format_file_size("  ") == ""
+    assert _format_file_size("abc") == ""
+    assert _format_file_size(object()) == ""
+
+
+def test_format_file_size_negative() -> None:
+    """负数无法表示真实大小，返回空串。"""
+    assert _format_file_size(-1) == ""
+    assert _format_file_size("-1024") == ""
+
+
+def test_format_file_size_thousands_separator() -> None:
+    """千分位逗号字符串应被解析为字节数。"""
+    assert _format_file_size("1,024") == "1.0KB"
+    assert _format_file_size("83,385,540") == "79.5MB"
+
+
+def test_format_file_size_preset_text_case_insensitive() -> None:
+    """已是可读格式的字符串（含小写/二进制单位）原样返回。"""
+    assert _format_file_size("1.7MB") == "1.7MB"
+    assert _format_file_size("512kb") == "512kb"
+    assert _format_file_size("1.0GiB") == "1.0GiB"
 
 
 def test_handle_file_with_size() -> None:


### PR DESCRIPTION
# PR: 文件消息在 LLM 可见文本中附带可读大小

## 改动内容

修复框架消息转换层对文件消息段的处理：将文件大小渲染进 LLM 可见的 `processed_plain_text`，使 bot 在对话上下文中能感知文件大小。

### 修改文件

- `src/core/transport/message_receive/converter.py`
  - 新增模块级辅助函数 `_format_file_size`：将字节数格式化为可读文本（B/KB/MB/GB/TB，1024 进制）；对 `None`/空串返回空串；对已是可读文本（如 `"1.7MB"`）的字符串原样返回。
  - `_handle_file`：文本占位符由 `[文件:name]` 扩展为 `[文件:name(大小)]`（有大小信息时），`media` 结构化数据保持不变。

### 新增测试

- `test/core/transport/test_message_converter_file_size.py`
  - 覆盖 `_format_file_size` 各分支（字节/换算/数字字符串/预格式化文本/非法值）。
  - 覆盖 `_handle_file` 带大小、无大小、旧字段 `file`/`file_size`、预格式化大小、非 dict 回退等场景。

## 原因

bot 收到文件消息时，适配器层（含 SnowLuma / OneBot）均能提取到文件大小，但框架转换层 `_handle_file` 只把文件名写进 LLM 可见文本，大小仅存在结构化 `media` 数据中，导致 LLM 无法感知文件大小。此改动统一在两个适配器下生效。

## 影响范围

- 仅影响文件消息段的文本占位符渲染；`media` 结构化数据与存储逻辑不变。
- 无大小信息时保持原有 `[文件:name]` 格式，不引入回归。

## 验证

- `ruff check` 通过。
- `pytest` 新增测试 + 既有 converter 测试共 22 项全部通过。

## Summary by Sourcery

Render file sizes into LLM-visible text placeholders for file message segments while keeping structured media data unchanged.

New Features:
- Expose human-readable file sizes in processed_plain_text for file messages so LLMs can perceive attachment size from context.

Bug Fixes:
- Ensure file message conversion consistently carries available size information from adapter payloads into the textual placeholder.

Enhancements:
- Add a shared helper to normalize raw byte sizes or size strings into human-readable units and reuse it in file message handling.

Tests:
- Add unit tests covering file size formatting edge cases and file segment handling across sized, unsized, legacy, preset-text, and non-dict inputs.