### PR TITLE
feat(core): 新增 LLMUsable 核心组件细粒度作用域与两阶段过滤体系

### DIFF
--- a/examples/src/app/plugin_system/api/action_api_example.py
+++ b/examples/src/app/plugin_system/api/action_api_example.py
@@ -59,7 +59,7 @@ async def main() -> None:
     schema = action_api.get_action_schema(first_signature)
     print(f"Action schema: {schema}")
 
-    actions_for_chat = await action_api.get_actions_for_chat(
+    actions_for_chat = await action_api.filter_actions_for_chat(
         chat_type=ChatType.PRIVATE
     )
     print(f"私聊可用 Action 数量: {len(actions_for_chat)}")

--- a/examples/src/app/plugin_system/api/action_api_example.py
+++ b/examples/src/app/plugin_system/api/action_api_example.py
@@ -59,18 +59,18 @@ async def main() -> None:
     schema = action_api.get_action_schema(first_signature)
     print(f"Action schema: {schema}")
 
-    actions_for_chat = action_api.get_actions_for_chat(chat_type=ChatType.PRIVATE)
+    actions_for_chat = await action_api.get_actions_for_chat(
+        chat_type=ChatType.PRIVATE
+    )
     print(f"私聊可用 Action 数量: {len(actions_for_chat)}")
 
-    schemas_for_chat = action_api.get_action_schemas(chat_type=ChatType.PRIVATE)
+    schemas_for_chat = await action_api.get_action_schemas(
+        chat_type=ChatType.PRIVATE
+    )
     print(f"私聊 Action schema 数量: {len(schemas_for_chat)}")
 
     stream_id = "demo_action_stream"
-    available_actions = await action_api.modify_actions(
-        stream_id=stream_id,
-        message_content="hello",
-    )
-    print(f"根据上下文可用 Action 数量: {len(available_actions)}")
+    print(f"基于给定组件类集合筛选 Action 数量: {len(actions_for_chat)}")
 
     plugin_name = first_signature.split(":")[0]
     plugin = get_plugin_manager().get_plugin(plugin_name)

--- a/examples/src/app/plugin_system/api/action_api_example.py
+++ b/examples/src/app/plugin_system/api/action_api_example.py
@@ -60,7 +60,8 @@ async def main() -> None:
     print(f"Action schema: {schema}")
 
     actions_for_chat = await action_api.filter_actions_for_chat(
-        chat_type=ChatType.PRIVATE
+        list(actions.values()),
+        chat_type=ChatType.PRIVATE,
     )
     print(f"私聊可用 Action 数量: {len(actions_for_chat)}")
 

--- a/examples/src/app/plugin_system/api/agent_api_example.py
+++ b/examples/src/app/plugin_system/api/agent_api_example.py
@@ -81,7 +81,10 @@ async def main() -> None:
         print(f"   - 参数: {func_schema.get('parameters', {}).get('properties', {}).keys()}")
 
     # 3. 获取特定聊天类型的 Agent
-    agents_for_chat = await agent_api.filter_agents_for_chat(chat_type=ChatType.PRIVATE)
+    agents_for_chat = await agent_api.filter_agents_for_chat(
+        list(agents.values()),
+        chat_type=ChatType.PRIVATE,
+    )
     print(f"\n4. 私聊可用 Agent 数量: {len(agents_for_chat)}")
 
     # 4. 获取 Agent Schemas

--- a/examples/src/app/plugin_system/api/agent_api_example.py
+++ b/examples/src/app/plugin_system/api/agent_api_example.py
@@ -81,11 +81,11 @@ async def main() -> None:
         print(f"   - 参数: {func_schema.get('parameters', {}).get('properties', {}).keys()}")
 
     # 3. 获取特定聊天类型的 Agent
-    agents_for_chat = agent_api.get_agents_for_chat(chat_type=ChatType.PRIVATE)
+    agents_for_chat = await agent_api.get_agents_for_chat(chat_type=ChatType.PRIVATE)
     print(f"\n4. 私聊可用 Agent 数量: {len(agents_for_chat)}")
 
     # 4. 获取 Agent Schemas
-    schemas_for_chat = agent_api.get_agent_schemas(chat_type=ChatType.PRIVATE)
+    schemas_for_chat = await agent_api.get_agent_schemas(chat_type=ChatType.PRIVATE)
     print(f"\n5. 私聊 Agent Schema 数量: {len(schemas_for_chat)}")
 
     # 5. 按插件获取 Agent

--- a/examples/src/app/plugin_system/api/agent_api_example.py
+++ b/examples/src/app/plugin_system/api/agent_api_example.py
@@ -81,7 +81,7 @@ async def main() -> None:
         print(f"   - 参数: {func_schema.get('parameters', {}).get('properties', {}).keys()}")
 
     # 3. 获取特定聊天类型的 Agent
-    agents_for_chat = await agent_api.get_agents_for_chat(chat_type=ChatType.PRIVATE)
+    agents_for_chat = await agent_api.filter_agents_for_chat(chat_type=ChatType.PRIVATE)
     print(f"\n4. 私聊可用 Agent 数量: {len(agents_for_chat)}")
 
     # 4. 获取 Agent Schemas

--- a/examples/src/core/components/usable_filter_example.py
+++ b/examples/src/core/components/usable_filter_example.py
@@ -1,0 +1,114 @@
+"""LLMUsable 细粒度过滤与作用域评估通用使用示例。
+
+本示例展示如何在 Action / Tool 组件中声明通用作用域规则
+（包括群组实体、聊天流、用户与平台白名单/黑名单等），并使用
+evaluate_usable_filter 引擎在不同上下文下进行静态评估。
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Annotated
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.core.components.base.action import BaseAction  # noqa: E402
+from src.core.components.base.tool import BaseTool  # noqa: E402
+from src.core.components.types import ChatType  # noqa: E402
+from src.core.components.usable_filter import (  # noqa: E402
+    UsableFilterContext,
+    evaluate_usable_filter,
+)
+
+
+class GroupScopedAction(BaseAction):
+    """受群组与用户作用域限制的通用 Action 示例。"""
+
+    name = "group_scoped_action"
+    description = "执行特定群组与指定用户作用域下的操作"
+
+    # 1. 聊天类型作用域：仅限群聊
+    chat_type = ChatType.GROUP
+
+    # 2. 群组作用域白名单：仅在指定群生效
+    group_allow = [100001, 100002]
+
+    # 3. 用户作用域白名单：仅限指定用户
+    user_allow = ["user_admin_01", "user_admin_02"]
+
+    # 4. Chatter 作用域黑名单：在特定测试 Chatter 中禁用
+    chatter_deny = ["mock_debug_chatter"]
+
+    async def execute(
+        self, target_id: Annotated[str, "目标实体标识"], action_type: Annotated[str, "操作类型"]
+    ) -> tuple[bool, str]:
+        """执行动作。"""
+        return True, f"已对 {target_id} 执行 {action_type}"
+
+
+class StreamScopedQueryTool(BaseTool):
+    """受聊天流唯一标识限制的通用 Tool 示例。"""
+
+    name = "stream_scoped_query_tool"
+    description = "执行特定聊天流作用域下的查询操作"
+
+    # 1. 聊天流白名单：仅在指定流中允许调用
+    stream_allow = ["dedicated_stream_001"]
+
+    async def execute(self) -> tuple[bool, dict[str, str]]:
+        """执行查询。"""
+        return True, {"status": "ok", "scope": "dedicated_stream_001"}
+
+
+def run_example() -> None:
+    """运行过滤引擎通用评估演示。"""
+    # 场景 1: 非授权用户在目标群组中触发
+    ctx_unauthorized_user = UsableFilterContext(
+        stream_id="stream_group_100001",
+        chat_type="group",
+        platform="qq",
+        group_id="100001",
+        user_id="user_guest_99",
+        chatter_name="default_chatter",
+    )
+
+    is_ok, reason = evaluate_usable_filter(
+        GroupScopedAction, ctx_unauthorized_user
+    )
+    print(f"[场景 1] 非授权用户在目标群: 可用={is_ok}, 拒绝原因={reason}")
+
+    # 场景 2: 授权用户在目标群组中触发
+    ctx_authorized_user = UsableFilterContext(
+        stream_id="stream_group_100001",
+        chat_type="group",
+        platform="qq",
+        group_id="100001",
+        user_id="user_admin_01",
+        chatter_name="default_chatter",
+    )
+
+    is_ok, reason = evaluate_usable_filter(
+        GroupScopedAction, ctx_authorized_user
+    )
+    print(f"[场景 2] 授权用户在目标群: 可用={is_ok}, 拒绝原因={reason}")
+
+    # 场景 3: 在专属流中调用专属查询工具
+    ctx_dedicated_stream = UsableFilterContext(
+        stream_id="dedicated_stream_001",
+        chat_type="private",
+        platform="qq",
+        user_id="user_admin_01",
+        chatter_name="default_chatter",
+    )
+
+    is_ok, reason = evaluate_usable_filter(
+        StreamScopedQueryTool, ctx_dedicated_stream
+    )
+    print(f"[场景 3] 专属流中调用工具: 可用={is_ok}, 拒绝原因={reason}")
+
+
+if __name__ == "__main__":
+    run_example()

--- a/examples/src/core/components/usable_filter_example.py
+++ b/examples/src/core/components/usable_filter_example.py
@@ -1,8 +1,12 @@
 """LLMUsable 细粒度过滤与作用域评估通用使用示例。
 
 本示例展示如何在 Action / Tool 组件中声明通用作用域规则
-（包括群组实体、聊天流、用户与平台白名单/黑名单等），并使用
-evaluate_usable_filter 引擎在不同上下文下进行静态评估。
+（聊天器、聊天类型、平台、聊天流、内容格式等部署/设计期静态维度），
+并使用 evaluate_usable_filter 引擎在不同上下文下进行静态评估。
+
+注意：群组 / 用户等运行时实体名单**不**通过组件类属性声明，也不由本引擎评估。
+它们由插件经配置 + 事件处理器（BEFORE_*_FILTER）或组件 ``go_activate``
+在运行时自行判定。
 """
 
 from __future__ import annotations
@@ -25,22 +29,20 @@ from src.core.components.usable_filter import (  # noqa: E402
 
 
 class GroupScopedAction(BaseAction):
-    """受群组与用户作用域限制的通用 Action 示例。"""
+    """受聊天类型与聊天器作用域限制的通用 Action 示例。"""
 
     name = "group_scoped_action"
-    description = "执行特定群组与指定用户作用域下的操作"
+    description = "执行特定群聊上下文下的操作"
 
     # 1. 聊天类型作用域：仅限群聊
     chat_type = ChatType.GROUP
 
-    # 2. 群组作用域白名单：仅在指定群生效
-    group_allow = [100001, 100002]
-
-    # 3. 用户作用域白名单：仅限指定用户
-    user_allow = ["user_admin_01", "user_admin_02"]
-
-    # 4. Chatter 作用域黑名单：在特定测试 Chatter 中禁用
+    # 2. Chatter 作用域黑名单：在特定测试 Chatter 中禁用
     chatter_deny = ["mock_debug_chatter"]
+
+    # 群组 / 用户实体名单不在此声明：
+    # 如需按群或按用户限制，请通过 BEFORE_ACTION_FILTER 事件处理器或
+    # 读取插件配置在 go_activate 中判定。
 
     async def execute(
         self, target_id: Annotated[str, "目标实体标识"], action_type: Annotated[str, "操作类型"]
@@ -65,8 +67,8 @@ class StreamScopedQueryTool(BaseTool):
 
 def run_example() -> None:
     """运行过滤引擎通用评估演示。"""
-    # 场景 1: 非授权用户在目标群组中触发
-    ctx_unauthorized_user = UsableFilterContext(
+    # 场景 1: 群聊上下文下的群聊 Action（仅校验 chat_type / chatter 等静态维度）
+    ctx_group = UsableFilterContext(
         stream_id="stream_group_100001",
         chat_type="group",
         platform="qq",
@@ -75,25 +77,20 @@ def run_example() -> None:
         chatter_name="default_chatter",
     )
 
-    is_ok, reason = evaluate_usable_filter(
-        GroupScopedAction, ctx_unauthorized_user
-    )
-    print(f"[场景 1] 非授权用户在目标群: 可用={is_ok}, 拒绝原因={reason}")
+    is_ok, reason = evaluate_usable_filter(GroupScopedAction, ctx_group)
+    print(f"[场景 1] 群聊中的群聊 Action: 可用={is_ok}, 拒绝原因={reason}")
 
-    # 场景 2: 授权用户在目标群组中触发
-    ctx_authorized_user = UsableFilterContext(
-        stream_id="stream_group_100001",
-        chat_type="group",
+    # 场景 2: 私聊上下文调用群聊 Action（chat_type 不匹配，应被拒绝）
+    ctx_private = UsableFilterContext(
+        stream_id="stream_private_1",
+        chat_type="private",
         platform="qq",
-        group_id="100001",
-        user_id="user_admin_01",
+        user_id="user_guest_99",
         chatter_name="default_chatter",
     )
 
-    is_ok, reason = evaluate_usable_filter(
-        GroupScopedAction, ctx_authorized_user
-    )
-    print(f"[场景 2] 授权用户在目标群: 可用={is_ok}, 拒绝原因={reason}")
+    is_ok, reason = evaluate_usable_filter(GroupScopedAction, ctx_private)
+    print(f"[场景 2] 私聊中的群聊 Action: 可用={is_ok}, 拒绝原因={reason}")
 
     # 场景 3: 在专属流中调用专属查询工具
     ctx_dedicated_stream = UsableFilterContext(
@@ -108,6 +105,10 @@ def run_example() -> None:
         StreamScopedQueryTool, ctx_dedicated_stream
     )
     print(f"[场景 3] 专属流中调用工具: 可用={is_ok}, 拒绝原因={reason}")
+
+    # 群组 / 用户实体名单不再由引擎评估：
+    # 需要按群或按用户做运行时过滤时，订阅 BEFORE_*_FILTER 事件改写组件集合，
+    # 或在组件 go_activate 中读取配置判定（参见 snowluma_extension 插件）。
 
 
 if __name__ == "__main__":

--- a/src/app/plugin_system/api/__init__.py
+++ b/src/app/plugin_system/api/__init__.py
@@ -26,6 +26,7 @@ from src.app.plugin_system.api import send_api
 from src.app.plugin_system.api import service_api
 from src.app.plugin_system.api import storage_api
 from src.app.plugin_system.api import stream_api
+from src.app.plugin_system.api import tool_api
 
 #: 各 ``*_api`` 模块的 API 版本号聚合表。
 #:
@@ -56,6 +57,7 @@ PLUGIN_API_VERSIONS: dict[str, str] = {
     "service_api": service_api.API_VERSION,
     "storage_api": storage_api.API_VERSION,
     "stream_api": stream_api.API_VERSION,
+    "tool_api": tool_api.API_VERSION,
 }
 
 __all__ = [
@@ -80,5 +82,6 @@ __all__ = [
     "service_api",
     "storage_api",
     "stream_api",
+    "tool_api",
     "PLUGIN_API_VERSIONS",
 ]

--- a/src/app/plugin_system/api/action_api.py
+++ b/src/app/plugin_system/api/action_api.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.core.components.types import ChatType
 
-API_VERSION = "1.0.0"
+API_VERSION = "1.1.0"
 
 if TYPE_CHECKING:
     from src.core.components.base.action import BaseAction

--- a/src/app/plugin_system/api/action_api.py
+++ b/src/app/plugin_system/api/action_api.py
@@ -105,7 +105,7 @@ def get_actions_for_plugin(plugin_name: str) -> dict[str, type["BaseAction"]]:
 
 
 async def filter_actions_for_chat(
-    usables: list[type["LLMUsable"]] | None = None,
+    usables: list[type["LLMUsable"]],
     *,
     chat_type: ChatType | str = ChatType.ALL,
     chatter_name: str = "",
@@ -119,12 +119,12 @@ async def filter_actions_for_chat(
 ) -> list[type["LLMUsable"]]:
     """筛选适用于特定聊天上下文的 Action 组件类列表。
 
-    一个函数完成完整筛选流程（静态过滤 + 筛选前事件钩子 + 动态 go_activate
-    激活）。传入 ``usables`` 则直接筛给定集合；否则从注册表拉取全部 Action
-    （拉取另由 ``get_all_actions`` 负责）。
+    只负责筛选：对传入的 ``usables`` 完成静态过滤 + 筛选前事件钩子 + 动态
+    go_activate 激活。拉取全量由 ``get_all_actions`` 单独承担，调用方需先
+    获取再传入。
 
     Args:
-        usables: 待筛选的组件类列表；不传则取全量注册 Action
+        usables: 待筛选的组件类列表（必填，由调用方传入）
         chat_type: 聊天类型
         chatter_name: Chatter 名称
         platform: 平台名称
@@ -200,6 +200,8 @@ async def get_action_schemas(
     Returns:
         Tool Schema 列表
     """
+    if usables is None:
+        usables = list(get_all_actions().values())
     actions = await filter_actions_for_chat(
         usables,
         chat_type=chat_type,

--- a/src/app/plugin_system/api/action_api.py
+++ b/src/app/plugin_system/api/action_api.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.core.components.types import ChatType
 
-API_VERSION = "1.1.0"
+API_VERSION = "1.0.0"
 
 if TYPE_CHECKING:
     from src.core.components.base.action import BaseAction

--- a/src/app/plugin_system/api/action_api.py
+++ b/src/app/plugin_system/api/action_api.py
@@ -104,7 +104,7 @@ def get_actions_for_plugin(plugin_name: str) -> dict[str, type["BaseAction"]]:
     return _get_action_manager().get_actions_for_plugin(plugin_name)
 
 
-async def get_actions_for_chat(
+async def filter_actions_for_chat(
     usables: list[type["LLMUsable"]] | None = None,
     *,
     chat_type: ChatType | str = ChatType.ALL,
@@ -114,11 +114,14 @@ async def get_actions_for_chat(
     chat_stream: "ChatStream | None" = None,
     stream_context: Any = None,
     chatter: Any = None,
+    plugin: "BasePlugin | None" = None,
+    message_content: str = "",
 ) -> list[type["LLMUsable"]]:
-    """获取适用于特定聊天上下文的 Action 组件类列表。
+    """筛选适用于特定聊天上下文的 Action 组件类列表。
 
-    若传入 ``usables`` 则直接对给定集合筛选（默认不传 stream_id）；
-    否则从注册表拉取全部 Action。
+    一个函数完成完整筛选流程（静态过滤 + 筛选前事件钩子 + 动态 go_activate
+    激活）。传入 ``usables`` 则直接筛给定集合；否则从注册表拉取全部 Action
+    （拉取另由 ``get_all_actions`` 负责）。
 
     Args:
         usables: 待筛选的组件类列表；不传则取全量注册 Action
@@ -126,15 +129,18 @@ async def get_actions_for_chat(
         chatter_name: Chatter 名称
         platform: 平台名称
         stream_id: 聊天流 ID
-        chat_stream: 候选聊天流实例
+        chat_stream: 候选聊天流实例（提供后由其派生完整上下文并触发激活）
         stream_context: 聊天流上下文
+        chatter: 当前驱动执行的 Chatter 实例
+        plugin: 归属插件实例（go_activate 签名解析失败时的兜底）
+        message_content: 当前消息内容，供激活判定使用
 
     Returns:
         Action 组件类列表
     """
     _validate_optional(chatter_name, "chatter_name")
     _validate_optional(platform, "platform")
-    return await _get_action_manager().get_actions_for_chat(
+    return await _get_action_manager().filter_actions_for_chat(
         usables,
         chat_type=_normalize_chat_type(chat_type).value,
         chatter_name=chatter_name,
@@ -143,30 +149,6 @@ async def get_actions_for_chat(
         chat_stream=chat_stream,
         stream_context=stream_context,
         chatter=chatter,
-    )
-
-
-async def activate_actions_for_chat(
-    actions: list[type["LLMUsable"]],
-    *,
-    chat_stream: "ChatStream",
-    plugin: "BasePlugin | None" = None,
-    message_content: str = "",
-) -> list[type["LLMUsable"]]:
-    """对 Action 组件类执行动态激活判定（go_activate）。
-
-    Args:
-        actions: 待判定的 Action 组件类列表
-        chat_stream: 当前聊天流实例
-        plugin: 所属插件实例（缺省时按组件签名解析）
-        message_content: 当前消息内容，供激活判定使用
-
-    Returns:
-        激活通过的组件类列表
-    """
-    return await _get_action_manager().activate_actions_for_chat(
-        actions,
-        chat_stream=chat_stream,
         plugin=plugin,
         message_content=message_content,
     )
@@ -218,7 +200,7 @@ async def get_action_schemas(
     Returns:
         Tool Schema 列表
     """
-    actions = await get_actions_for_chat(
+    actions = await filter_actions_for_chat(
         usables,
         chat_type=chat_type,
         chatter_name=chatter_name,
@@ -281,8 +263,7 @@ __all__ = [
     "API_VERSION",
     "get_all_actions",
     "get_actions_for_plugin",
-    "get_actions_for_chat",
-    "activate_actions_for_chat",
+    "filter_actions_for_chat",
     "get_action_class",
     "get_action_schema",
     "get_action_schemas",

--- a/src/app/plugin_system/api/agent_api.py
+++ b/src/app/plugin_system/api/agent_api.py
@@ -104,7 +104,7 @@ def get_agents_for_plugin(plugin_name: str) -> dict[str, type["BaseAgent"]]:
 
 
 async def filter_agents_for_chat(
-    usables: list[type["LLMUsable"]] | None = None,
+    usables: list[type["LLMUsable"]],
     *,
     chat_type: ChatType | str = ChatType.ALL,
     chatter_name: str = "",
@@ -117,12 +117,12 @@ async def filter_agents_for_chat(
 ) -> list[type["LLMUsable"]]:
     """筛选适用于特定聊天上下文的 Agent 组件类列表。
 
-    一个函数完成完整筛选流程（静态过滤 + 筛选前事件钩子 + 动态 go_activate
-    激活）。传入 ``usables`` 则直接筛给定集合；否则从注册表拉取全部 Agent
-    （拉取另由 ``get_all_agents`` 负责）。
+    只负责筛选：对传入的 ``usables`` 完成静态过滤 + 筛选前事件钩子 + 动态
+    go_activate 激活。拉取全量由 ``get_all_agents`` 单独承担，调用方需先
+    获取再传入。
 
     Args:
-        usables: 待筛选的组件类列表；不传则取全量注册 Agent
+        usables: 待筛选的组件类列表（必填，由调用方传入）
         chat_type: 聊天类型
         chatter_name: Chatter 名称
         platform: 平台名称
@@ -196,6 +196,8 @@ async def get_agent_schemas(
     Returns:
         Tool Schema 列表
     """
+    if usables is None:
+        usables = list(get_all_agents().values())
     agents = await filter_agents_for_chat(
         usables,
         chat_type=chat_type,

--- a/src/app/plugin_system/api/agent_api.py
+++ b/src/app/plugin_system/api/agent_api.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.core.components.types import ChatType
 
-API_VERSION = "1.1.0"
+API_VERSION = "1.0.0"
 
 if TYPE_CHECKING:
     from src.core.components.base.agent import BaseAgent

--- a/src/app/plugin_system/api/agent_api.py
+++ b/src/app/plugin_system/api/agent_api.py
@@ -1,26 +1,40 @@
 """
-Agent API模块
-专门负责Agent组件的查询、过滤和执行操作。
+Agent API 模块
+专门负责 Agent 组件的查询、筛选、激活、schema 与执行操作，是
+``AgentManager`` 的薄封装。
 """
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from src.core.components.types import ChatType, ComponentType
-from src.core.components.registry import get_global_registry
-from src.core.components.utils import should_strip_auto_reason_argument
+from src.core.components.types import ChatType
 
-API_VERSION = "1.0.0"
+API_VERSION = "1.1.0"
 
 if TYPE_CHECKING:
     from src.core.components.base.agent import BaseAgent
     from src.core.components.base.plugin import BasePlugin
+    from src.core.managers.agent_manager import AgentManager
+    from src.core.models.stream import ChatStream
     from src.kernel.llm import LLMUsable
+
+
+def _get_agent_manager() -> "AgentManager":
+    """延迟获取 AgentManager，避免循环依赖。
+
+    Returns:
+        AgentManager: Agent 组件管理器实例
+    """
+    from src.core.managers.agent_manager import get_agent_manager
+
+    return get_agent_manager()
 
 
 def _normalize_chat_type(chat_type: ChatType | str) -> ChatType:
     """规范化 chat_type 输入为 ChatType。
+
+    无法识别的字符串回退为 ChatType.ALL。
 
     Args:
         chat_type: 聊天类型
@@ -31,7 +45,10 @@ def _normalize_chat_type(chat_type: ChatType | str) -> ChatType:
     if isinstance(chat_type, ChatType):
         return chat_type
     if isinstance(chat_type, str):
-        return ChatType(chat_type)
+        try:
+            return ChatType(chat_type)
+        except ValueError:
+            return ChatType.ALL
     raise TypeError("chat_type 必须是 ChatType 或 str")
 
 
@@ -70,8 +87,7 @@ def get_all_agents() -> dict[str, type["BaseAgent"]]:
     Returns:
         Agent 签名到类的映射
     """
-    registry = get_global_registry()
-    return registry.get_by_type(ComponentType.AGENT)
+    return _get_agent_manager().get_all_agents()
 
 
 def get_agents_for_plugin(plugin_name: str) -> dict[str, type["BaseAgent"]]:
@@ -84,49 +100,72 @@ def get_agents_for_plugin(plugin_name: str) -> dict[str, type["BaseAgent"]]:
         Agent 签名到类的映射
     """
     _validate_non_empty(plugin_name, "plugin_name")
-    registry = get_global_registry()
-    return registry.get_by_plugin_and_type(plugin_name, ComponentType.AGENT)
+    return _get_agent_manager().get_agents_for_plugin(plugin_name)
 
 
-def get_agents_for_chat(
+async def get_agents_for_chat(
+    usables: list[type["LLMUsable"]] | None = None,
+    *,
     chat_type: ChatType | str = ChatType.ALL,
     chatter_name: str = "",
     platform: str = "",
+    stream_id: str = "",
+    chat_stream: "ChatStream | None" = None,
+    stream_context: Any = None,
+    chatter: Any = None,
 ) -> list[type["LLMUsable"]]:
-    """获取适用于特定聊天上下文的 Agent 组件列表。
+    """获取适用于特定聊天上下文的 Agent 组件类列表。
+
+    若传入 ``usables`` 则直接对给定集合筛选（默认不传 stream_id）；
+    否则从注册表拉取全部 Agent。
 
     Args:
+        usables: 待筛选的组件类列表；不传则取全量注册 Agent
         chat_type: 聊天类型
         chatter_name: Chatter 名称
         platform: 平台名称
+        stream_id: 聊天流 ID
+        chat_stream: 候选聊天流实例
+        stream_context: 聊天流上下文
 
     Returns:
-        Agent 组件列表
+        Agent 组件类列表
     """
     _validate_optional(chatter_name, "chatter_name")
     _validate_optional(platform, "platform")
-    
-    from src.core.components.usable_filter import (
-        UsableFilterContext,
-        evaluate_usable_filter,
-    )
-
-    norm_chat_type = _normalize_chat_type(chat_type)
-    all_agents = get_all_agents()
-    ctx = UsableFilterContext(
-        stream_id="",
-        chat_type=norm_chat_type.value,
-        platform=platform,
+    return await _get_agent_manager().get_agents_for_chat(
+        usables,
+        chat_type=_normalize_chat_type(chat_type).value,
         chatter_name=chatter_name,
+        platform=platform,
+        stream_id=stream_id,
+        chat_stream=chat_stream,
+        stream_context=stream_context,
+        chatter=chatter,
     )
 
-    filtered_agents = []
-    for signature, agent_cls in all_agents.items():
-        is_eligible, _ = evaluate_usable_filter(agent_cls, ctx)
-        if is_eligible:
-            filtered_agents.append(agent_cls)
 
-    return filtered_agents
+async def activate_agents_for_chat(
+    agents: list[type["LLMUsable"]],
+    *,
+    chat_stream: "ChatStream",
+    plugin: "BasePlugin | None" = None,
+) -> list[type["LLMUsable"]]:
+    """对 Agent 组件类执行动态激活判定（go_activate）。
+
+    Args:
+        agents: 待判定的 Agent 组件类列表
+        chat_stream: 当前聊天流实例
+        plugin: 所属插件实例（缺省时按组件签名解析）
+
+    Returns:
+        激活通过的组件类列表
+    """
+    return await _get_agent_manager().activate_agents_for_chat(
+        agents,
+        chat_stream=chat_stream,
+        plugin=plugin,
+    )
 
 
 def get_agent_class(signature: str) -> type["BaseAgent"] | None:
@@ -139,8 +178,7 @@ def get_agent_class(signature: str) -> type["BaseAgent"] | None:
         Agent 类，未找到则返回 None
     """
     _validate_non_empty(signature, "signature")
-    registry = get_global_registry()
-    return registry.get(signature)
+    return _get_agent_manager().get_agent_class(signature)
 
 
 def get_agent_schema(signature: str) -> dict[str, Any] | None:
@@ -153,39 +191,68 @@ def get_agent_schema(signature: str) -> dict[str, Any] | None:
         Tool Schema，未找到则返回 None
     """
     _validate_non_empty(signature, "signature")
-    agent_cls = get_agent_class(signature)
-    if not agent_cls:
-        return None
-    return agent_cls.to_schema()
+    return _get_agent_manager().get_agent_schema(signature)
 
 
-def get_agent_schemas(
+async def get_agent_schemas(
+    usables: list[type["LLMUsable"]] | None = None,
+    *,
     chat_type: ChatType | str = ChatType.ALL,
     chatter_name: str = "",
     platform: str = "",
+    stream_id: str = "",
 ) -> list[dict[str, Any]]:
     """获取适用于特定聊天上下文的所有 Agent Schema。
 
     Args:
+        usables: 待筛选的组件类列表
         chat_type: 聊天类型
         chatter_name: Chatter 名称
         platform: 平台名称
+        stream_id: 聊天流 ID
 
     Returns:
         Tool Schema 列表
     """
-    _validate_optional(chatter_name, "chatter_name")
-    _validate_optional(platform, "platform")
-    
-    agents = get_agents_for_chat(chat_type, chatter_name, platform)
+    agents = await get_agents_for_chat(
+        usables,
+        chat_type=chat_type,
+        chatter_name=chatter_name,
+        platform=platform,
+        stream_id=stream_id,
+    )
     schemas = []
-
     for agent_cls in agents:
-        schema = agent_cls.to_schema()
+        schema = agent_cls.to_schema()  # type: ignore[attr-defined]
         if schema:
             schemas.append(schema)
-
     return schemas
+
+
+def get_agent_usables(signature: str) -> list[type["LLMUsable"]]:
+    """获取 Agent 的专属 usables 列表。
+
+    Args:
+        signature: Agent 组件签名
+
+    Returns:
+        Agent 专属的 usables 类列表
+    """
+    _validate_non_empty(signature, "signature")
+    return _get_agent_manager().get_agent_usables(signature)
+
+
+def get_agent_usable_schemas(signature: str) -> list[dict[str, Any]]:
+    """获取 Agent 专属 usables 的 Schema 列表。
+
+    Args:
+        signature: Agent 组件签名
+
+    Returns:
+        usables 的 Tool Schema 列表
+    """
+    _validate_non_empty(signature, "signature")
+    return _get_agent_manager().get_agent_usable_schemas(signature)
 
 
 async def execute_agent(
@@ -205,68 +272,16 @@ async def execute_agent(
     Returns:
         执行是否成功与结果描述
     """
-    from src.kernel.logger import get_logger
-    
-    logger = get_logger("agent_api")
-    
     _validate_non_empty(signature, "signature")
     if plugin is None:
         raise ValueError("plugin 不能为空")
     _validate_non_empty(stream_id, "stream_id")
-    
-    agent_cls = get_agent_class(signature)
-    if not agent_cls:
-        raise ValueError(f"Agent 类未找到: {signature}")
-    
-    # 创建 Agent 实例
-    agent_instance = agent_cls(stream_id=stream_id, plugin=plugin)
-    
-    # 仅剥离系统自动注入的 reason；组件原生声明 reason 时必须保留。
-    if should_strip_auto_reason_argument(agent_instance.execute, kwargs):
-        kwargs.pop("reason", None)
-    
-    # 执行 Agent
-    try:
-        result = await agent_instance._wrap_execute(**kwargs).wait_done()
-        return result
-    except Exception as e:
-        logger.error(
-            f"执行 Agent 失败 ({signature}): {e}",
-            exc_info=True,
-        )
-        raise RuntimeError(f"Agent 执行失败: {e}") from e
-
-
-def get_agent_usables(signature: str) -> list[type["LLMUsable"]]:
-    """获取 Agent 的专属 usables 列表。
-
-    Args:
-        signature: Agent 组件签名
-
-    Returns:
-        Agent 专属的 usables 类列表
-    """
-    _validate_non_empty(signature, "signature")
-    agent_cls = get_agent_class(signature)
-    if not agent_cls:
-        return []
-    return agent_cls.get_local_usables()
-
-
-def get_agent_usable_schemas(signature: str) -> list[dict[str, Any]]:
-    """获取 Agent 专属 usables 的 Schema 列表。
-
-    Args:
-        signature: Agent 组件签名
-
-    Returns:
-        usables 的 Tool Schema 列表
-    """
-    _validate_non_empty(signature, "signature")
-    agent_cls = get_agent_class(signature)
-    if not agent_cls:
-        return []
-    return agent_cls.get_local_usable_schemas()
+    return await _get_agent_manager().execute_agent(
+        signature=signature,
+        plugin=plugin,
+        stream_id=stream_id,
+        **kwargs,
+    )
 
 
 async def execute_agent_usable(
@@ -288,36 +303,29 @@ async def execute_agent_usable(
     Returns:
         执行是否成功与结果
     """
-    from src.kernel.logger import get_logger
-    
-    logger = get_logger("agent_api")
-    
     _validate_non_empty(signature, "signature")
     if plugin is None:
         raise ValueError("plugin 不能为空")
     _validate_non_empty(stream_id, "stream_id")
     _validate_non_empty(usable_name, "usable_name")
-    
-    agent_cls = get_agent_class(signature)
-    if not agent_cls:
-        raise ValueError(f"Agent 类未找到: {signature}")
-    
-    # 创建 Agent 实例
-    agent_instance = agent_cls(stream_id=stream_id, plugin=plugin)
-    
-    # 执行专属 usable
-    try:
-        result = await agent_instance.execute_local_usable(
-            usable_name=usable_name,
-            **kwargs
-        )
-        return result
-    except Exception as e:
-        logger.error(
-            f"执行 Agent usable 失败 ({signature}.{usable_name}): {e}",
-            exc_info=True,
-        )
-        raise RuntimeError(f"Agent usable 执行失败: {e}") from e
+    return await _get_agent_manager().execute_agent_usable(
+        signature=signature,
+        plugin=plugin,
+        stream_id=stream_id,
+        usable_name=usable_name,
+        **kwargs,
+    )
+
+
+def clear_schema_cache(signature: str | None = None) -> None:
+    """清除 schema 缓存。
+
+    Args:
+        signature: Agent 组件签名，可选
+    """
+    if signature is not None:
+        _validate_non_empty(signature, "signature")
+    _get_agent_manager().clear_schema_cache(signature)
 
 
 __all__ = [
@@ -325,11 +333,13 @@ __all__ = [
     "get_all_agents",
     "get_agents_for_plugin",
     "get_agents_for_chat",
+    "activate_agents_for_chat",
     "get_agent_class",
     "get_agent_schema",
     "get_agent_schemas",
-    "execute_agent",
     "get_agent_usables",
     "get_agent_usable_schemas",
+    "execute_agent",
     "execute_agent_usable",
+    "clear_schema_cache",
 ]

--- a/src/app/plugin_system/api/agent_api.py
+++ b/src/app/plugin_system/api/agent_api.py
@@ -106,29 +106,25 @@ def get_agents_for_chat(
     _validate_optional(chatter_name, "chatter_name")
     _validate_optional(platform, "platform")
     
-    chat_type = _normalize_chat_type(chat_type)
+    from src.core.components.usable_filter import (
+        UsableFilterContext,
+        evaluate_usable_filter,
+    )
+
+    norm_chat_type = _normalize_chat_type(chat_type)
     all_agents = get_all_agents()
+    ctx = UsableFilterContext(
+        stream_id="",
+        chat_type=norm_chat_type.value,
+        platform=platform,
+        chatter_name=chatter_name,
+    )
+
     filtered_agents = []
-
     for signature, agent_cls in all_agents.items():
-        # 检查 chat_type 兼容性
-        if (
-            agent_cls.chat_type != ChatType.ALL
-            and agent_cls.chat_type != chat_type
-        ):
-            continue
-
-        # 检查 chatter_allow
-        if chatter_name and agent_cls.chatter_allow:
-            if chatter_name not in agent_cls.chatter_allow:
-                continue
-
-        # 检查平台关联
-        if platform and agent_cls.associated_platforms:
-            if platform not in agent_cls.associated_platforms:
-                continue
-
-        filtered_agents.append(agent_cls)
+        is_eligible, _ = evaluate_usable_filter(agent_cls, ctx)
+        if is_eligible:
+            filtered_agents.append(agent_cls)
 
     return filtered_agents
 

--- a/src/app/plugin_system/api/agent_api.py
+++ b/src/app/plugin_system/api/agent_api.py
@@ -103,7 +103,7 @@ def get_agents_for_plugin(plugin_name: str) -> dict[str, type["BaseAgent"]]:
     return _get_agent_manager().get_agents_for_plugin(plugin_name)
 
 
-async def get_agents_for_chat(
+async def filter_agents_for_chat(
     usables: list[type["LLMUsable"]] | None = None,
     *,
     chat_type: ChatType | str = ChatType.ALL,
@@ -113,11 +113,13 @@ async def get_agents_for_chat(
     chat_stream: "ChatStream | None" = None,
     stream_context: Any = None,
     chatter: Any = None,
+    plugin: "BasePlugin | None" = None,
 ) -> list[type["LLMUsable"]]:
-    """获取适用于特定聊天上下文的 Agent 组件类列表。
+    """筛选适用于特定聊天上下文的 Agent 组件类列表。
 
-    若传入 ``usables`` 则直接对给定集合筛选（默认不传 stream_id）；
-    否则从注册表拉取全部 Agent。
+    一个函数完成完整筛选流程（静态过滤 + 筛选前事件钩子 + 动态 go_activate
+    激活）。传入 ``usables`` 则直接筛给定集合；否则从注册表拉取全部 Agent
+    （拉取另由 ``get_all_agents`` 负责）。
 
     Args:
         usables: 待筛选的组件类列表；不传则取全量注册 Agent
@@ -125,15 +127,17 @@ async def get_agents_for_chat(
         chatter_name: Chatter 名称
         platform: 平台名称
         stream_id: 聊天流 ID
-        chat_stream: 候选聊天流实例
+        chat_stream: 候选聊天流实例（提供后由其派生完整上下文并触发激活）
         stream_context: 聊天流上下文
+        chatter: 当前驱动执行的 Chatter 实例
+        plugin: 归属插件实例（go_activate 签名解析失败时的兜底）
 
     Returns:
         Agent 组件类列表
     """
     _validate_optional(chatter_name, "chatter_name")
     _validate_optional(platform, "platform")
-    return await _get_agent_manager().get_agents_for_chat(
+    return await _get_agent_manager().filter_agents_for_chat(
         usables,
         chat_type=_normalize_chat_type(chat_type).value,
         chatter_name=chatter_name,
@@ -142,28 +146,6 @@ async def get_agents_for_chat(
         chat_stream=chat_stream,
         stream_context=stream_context,
         chatter=chatter,
-    )
-
-
-async def activate_agents_for_chat(
-    agents: list[type["LLMUsable"]],
-    *,
-    chat_stream: "ChatStream",
-    plugin: "BasePlugin | None" = None,
-) -> list[type["LLMUsable"]]:
-    """对 Agent 组件类执行动态激活判定（go_activate）。
-
-    Args:
-        agents: 待判定的 Agent 组件类列表
-        chat_stream: 当前聊天流实例
-        plugin: 所属插件实例（缺省时按组件签名解析）
-
-    Returns:
-        激活通过的组件类列表
-    """
-    return await _get_agent_manager().activate_agents_for_chat(
-        agents,
-        chat_stream=chat_stream,
         plugin=plugin,
     )
 
@@ -214,7 +196,7 @@ async def get_agent_schemas(
     Returns:
         Tool Schema 列表
     """
-    agents = await get_agents_for_chat(
+    agents = await filter_agents_for_chat(
         usables,
         chat_type=chat_type,
         chatter_name=chatter_name,
@@ -332,8 +314,7 @@ __all__ = [
     "API_VERSION",
     "get_all_agents",
     "get_agents_for_plugin",
-    "get_agents_for_chat",
-    "activate_agents_for_chat",
+    "filter_agents_for_chat",
     "get_agent_class",
     "get_agent_schema",
     "get_agent_schemas",

--- a/src/app/plugin_system/api/agent_api.py
+++ b/src/app/plugin_system/api/agent_api.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 
 from src.core.components.types import ChatType
 
-API_VERSION = "1.0.0"
+API_VERSION = "1.1.0"
 
 if TYPE_CHECKING:
     from src.core.components.base.agent import BaseAgent

--- a/src/app/plugin_system/api/tool_api.py
+++ b/src/app/plugin_system/api/tool_api.py
@@ -1,7 +1,7 @@
 """
-Action API 模块
-专门负责 Action 组件的查询、筛选、激活、schema 与执行操作，是
-``ActionManager`` 的薄封装。
+Tool API 模块
+专门负责 Tool 组件的查询、筛选、激活、schema 与执行操作，是
+``ToolComponentManager`` 的薄封装。
 """
 
 from __future__ import annotations
@@ -10,26 +10,26 @@ from typing import TYPE_CHECKING, Any
 
 from src.core.components.types import ChatType
 
-API_VERSION = "1.1.0"
+API_VERSION = "1.0.0"
 
 if TYPE_CHECKING:
-    from src.core.components.base.action import BaseAction
     from src.core.components.base.plugin import BasePlugin
-    from src.core.managers.action_manager import ActionManager
+    from src.core.components.base.tool import BaseTool
+    from src.core.managers.tool_manager.manager import ToolComponentManager
     from src.core.models.message import Message
     from src.core.models.stream import ChatStream
     from src.kernel.llm import LLMUsable
 
 
-def _get_action_manager() -> "ActionManager":
-    """延迟获取 ActionManager，避免循环依赖。
+def _get_tool_manager() -> "ToolComponentManager":
+    """延迟获取 ToolComponentManager，避免循环依赖。
 
     Returns:
-        Action 管理器实例
+        ToolComponentManager: 工具组件管理器实例
     """
-    from src.core.managers.action_manager import get_action_manager
+    from src.core.managers.tool_manager.manager import get_tool_component_manager
 
-    return get_action_manager()
+    return get_tool_component_manager()
 
 
 def _normalize_chat_type(chat_type: ChatType | str) -> ChatType:
@@ -82,29 +82,29 @@ def _validate_optional(value: str, name: str) -> None:
     _validate_non_empty(value, name)
 
 
-def get_all_actions() -> dict[str, type["BaseAction"]]:
-    """获取所有已注册的 Action 组件。
+def get_all_tools() -> dict[str, type["BaseTool"]]:
+    """获取所有已注册的 Tool 组件。
 
     Returns:
-        Action 签名到类的映射
+        Tool 签名到类的映射
     """
-    return _get_action_manager().get_all_actions()
+    return _get_tool_manager().get_all_tools()
 
 
-def get_actions_for_plugin(plugin_name: str) -> dict[str, type["BaseAction"]]:
-    """获取指定插件的所有 Action 组件。
+def get_tools_for_plugin(plugin_name: str) -> dict[str, type["BaseTool"]]:
+    """获取指定插件的所有 Tool 组件。
 
     Args:
         plugin_name: 插件名称
 
     Returns:
-        Action 签名到类的映射
+        Tool 签名到类的映射
     """
     _validate_non_empty(plugin_name, "plugin_name")
-    return _get_action_manager().get_actions_for_plugin(plugin_name)
+    return _get_tool_manager().get_tools_for_plugin(plugin_name)
 
 
-async def get_actions_for_chat(
+async def get_tools_for_chat(
     usables: list[type["LLMUsable"]] | None = None,
     *,
     chat_type: ChatType | str = ChatType.ALL,
@@ -115,13 +115,13 @@ async def get_actions_for_chat(
     stream_context: Any = None,
     chatter: Any = None,
 ) -> list[type["LLMUsable"]]:
-    """获取适用于特定聊天上下文的 Action 组件类列表。
+    """获取适用于特定聊天上下文的 Tool 组件类列表。
 
     若传入 ``usables`` 则直接对给定集合筛选（默认不传 stream_id）；
-    否则从注册表拉取全部 Action。
+    否则从注册表拉取全部 Tool。
 
     Args:
-        usables: 待筛选的组件类列表；不传则取全量注册 Action
+        usables: 待筛选的组件类列表；不传则取全量注册 Tool
         chat_type: 聊天类型
         chatter_name: Chatter 名称
         platform: 平台名称
@@ -130,11 +130,11 @@ async def get_actions_for_chat(
         stream_context: 聊天流上下文
 
     Returns:
-        Action 组件类列表
+        Tool 组件类列表
     """
     _validate_optional(chatter_name, "chatter_name")
     _validate_optional(platform, "platform")
-    return await _get_action_manager().get_actions_for_chat(
+    return await _get_tool_manager().get_tools_for_chat(
         usables,
         chat_type=_normalize_chat_type(chat_type).value,
         chatter_name=chatter_name,
@@ -146,59 +146,59 @@ async def get_actions_for_chat(
     )
 
 
-async def activate_actions_for_chat(
-    actions: list[type["LLMUsable"]],
+async def activate_tools_for_chat(
+    tools: list[type["LLMUsable"]],
     *,
     chat_stream: "ChatStream",
     plugin: "BasePlugin | None" = None,
-    message_content: str = "",
+    message: "Message | None" = None,
 ) -> list[type["LLMUsable"]]:
-    """对 Action 组件类执行动态激活判定（go_activate）。
+    """对 Tool 组件类执行动态激活判定（go_activate）。
 
     Args:
-        actions: 待判定的 Action 组件类列表
+        tools: 待判定的 Tool 组件类列表
         chat_stream: 当前聊天流实例
         plugin: 所属插件实例（缺省时按组件签名解析）
-        message_content: 当前消息内容，供激活判定使用
+        message: 触发消息
 
     Returns:
         激活通过的组件类列表
     """
-    return await _get_action_manager().activate_actions_for_chat(
-        actions,
+    return await _get_tool_manager().activate_tools_for_chat(
+        tools,
         chat_stream=chat_stream,
         plugin=plugin,
-        message_content=message_content,
+        message=message,
     )
 
 
-def get_action_class(signature: str) -> type["BaseAction"] | None:
-    """通过签名获取 Action 类。
+def get_tool_class(signature: str) -> type["BaseTool"] | None:
+    """通过签名获取 Tool 类。
 
     Args:
-        signature: Action 组件签名
+        signature: Tool 组件签名
 
     Returns:
-        Action 类，未找到则返回 None
+        Tool 类，未找到则返回 None
     """
     _validate_non_empty(signature, "signature")
-    return _get_action_manager().get_action_class(signature)
+    return _get_tool_manager().get_tool_class(signature)
 
 
-def get_action_schema(signature: str) -> dict[str, Any] | None:
-    """获取 Action 的 Tool Schema。
+def get_tool_schema(signature: str) -> dict[str, Any] | None:
+    """获取 Tool 的 Tool Schema。
 
     Args:
-        signature: Action 组件签名
+        signature: Tool 组件签名
 
     Returns:
         Tool Schema，未找到则返回 None
     """
     _validate_non_empty(signature, "signature")
-    return _get_action_manager().get_action_schema(signature)
+    return _get_tool_manager().get_tool_schema(signature)
 
 
-async def get_action_schemas(
+async def get_tool_schemas(
     usables: list[type["LLMUsable"]] | None = None,
     *,
     chat_type: ChatType | str = ChatType.ALL,
@@ -206,7 +206,7 @@ async def get_action_schemas(
     platform: str = "",
     stream_id: str = "",
 ) -> list[dict[str, Any]]:
-    """获取适用于特定聊天上下文的所有 Action Schema。
+    """获取适用于特定聊天上下文的所有 Tool Schema。
 
     Args:
         usables: 待筛选的组件类列表
@@ -218,7 +218,7 @@ async def get_action_schemas(
     Returns:
         Tool Schema 列表
     """
-    actions = await get_actions_for_chat(
+    tools = await get_tools_for_chat(
         usables,
         chat_type=chat_type,
         chatter_name=chatter_name,
@@ -226,36 +226,38 @@ async def get_action_schemas(
         stream_id=stream_id,
     )
     schemas = []
-    for action_cls in actions:
-        schema = action_cls.to_schema()  # type: ignore[attr-defined]
+    for tool_cls in tools:
+        schema = tool_cls.to_schema()  # type: ignore[attr-defined]
         if schema:
             schemas.append(schema)
     return schemas
 
 
-async def execute_action(
+async def execute_tool(
     signature: str,
     plugin: "BasePlugin",
     message: "Message",
     **kwargs: Any,
-) -> tuple[bool, str]:
-    """执行 Action。创建 Action 实例并调用其 execute 方法。
+) -> tuple[bool, Any]:
+    """执行 Tool，委托给 ToolUse 并记录历史。
 
     Args:
-        signature: Action 组件签名
+        signature: Tool 组件签名
         plugin: 插件实例
-        message: 消息对象
-        **kwargs: 传递给 Action 的参数
+        message: 触发的消息
+        **kwargs: 传递给 Tool 的参数
 
     Returns:
-        执行是否成功与结果描述
+        执行是否成功与结果
     """
     _validate_non_empty(signature, "signature")
     if plugin is None:
         raise ValueError("plugin 不能为空")
     if message is None:
         raise ValueError("message 不能为空")
-    return await _get_action_manager().execute_action(
+    from src.core.managers.tool_manager.tool_use import get_tool_use
+
+    return await get_tool_use().execute_tool(
         signature=signature,
         plugin=plugin,
         message=message,
@@ -267,25 +269,22 @@ def clear_schema_cache(signature: str | None = None) -> None:
     """清除 schema 缓存。
 
     Args:
-        signature: Action 组件签名，可选
-
-    Returns:
-        None
+        signature: Tool 组件签名，可选
     """
     if signature is not None:
         _validate_non_empty(signature, "signature")
-    _get_action_manager().clear_schema_cache(signature)
+    _get_tool_manager().clear_schema_cache(signature)
 
 
 __all__ = [
     "API_VERSION",
-    "get_all_actions",
-    "get_actions_for_plugin",
-    "get_actions_for_chat",
-    "activate_actions_for_chat",
-    "get_action_class",
-    "get_action_schema",
-    "get_action_schemas",
-    "execute_action",
+    "get_all_tools",
+    "get_tools_for_plugin",
+    "get_tools_for_chat",
+    "activate_tools_for_chat",
+    "get_tool_class",
+    "get_tool_schema",
+    "get_tool_schemas",
+    "execute_tool",
     "clear_schema_cache",
 ]

--- a/src/app/plugin_system/api/tool_api.py
+++ b/src/app/plugin_system/api/tool_api.py
@@ -104,7 +104,7 @@ def get_tools_for_plugin(plugin_name: str) -> dict[str, type["BaseTool"]]:
     return _get_tool_manager().get_tools_for_plugin(plugin_name)
 
 
-async def get_tools_for_chat(
+async def filter_tools_for_chat(
     usables: list[type["LLMUsable"]] | None = None,
     *,
     chat_type: ChatType | str = ChatType.ALL,
@@ -115,10 +115,11 @@ async def get_tools_for_chat(
     stream_context: Any = None,
     chatter: Any = None,
 ) -> list[type["LLMUsable"]]:
-    """获取适用于特定聊天上下文的 Tool 组件类列表。
+    """筛选适用于特定聊天上下文的 Tool 组件类列表。
 
-    若传入 ``usables`` 则直接对给定集合筛选（默认不传 stream_id）；
-    否则从注册表拉取全部 Tool。
+    Tool 组件仅做部署期静态维度过滤（含筛选前事件钩子），不涉及动态激活。
+    传入 ``usables`` 则直接筛给定集合；否则从注册表拉取全部 Tool
+    （拉取另由 ``get_all_tools`` 负责）。
 
     Args:
         usables: 待筛选的组件类列表；不传则取全量注册 Tool
@@ -128,13 +129,14 @@ async def get_tools_for_chat(
         stream_id: 聊天流 ID
         chat_stream: 候选聊天流实例
         stream_context: 聊天流上下文
+        chatter: 当前驱动执行的 Chatter 实例
 
     Returns:
         Tool 组件类列表
     """
     _validate_optional(chatter_name, "chatter_name")
     _validate_optional(platform, "platform")
-    return await _get_tool_manager().get_tools_for_chat(
+    return await _get_tool_manager().filter_tools_for_chat(
         usables,
         chat_type=_normalize_chat_type(chat_type).value,
         chatter_name=chatter_name,
@@ -143,32 +145,6 @@ async def get_tools_for_chat(
         chat_stream=chat_stream,
         stream_context=stream_context,
         chatter=chatter,
-    )
-
-
-async def activate_tools_for_chat(
-    tools: list[type["LLMUsable"]],
-    *,
-    chat_stream: "ChatStream",
-    plugin: "BasePlugin | None" = None,
-    message: "Message | None" = None,
-) -> list[type["LLMUsable"]]:
-    """对 Tool 组件类执行动态激活判定（go_activate）。
-
-    Args:
-        tools: 待判定的 Tool 组件类列表
-        chat_stream: 当前聊天流实例
-        plugin: 所属插件实例（缺省时按组件签名解析）
-        message: 触发消息
-
-    Returns:
-        激活通过的组件类列表
-    """
-    return await _get_tool_manager().activate_tools_for_chat(
-        tools,
-        chat_stream=chat_stream,
-        plugin=plugin,
-        message=message,
     )
 
 
@@ -218,7 +194,7 @@ async def get_tool_schemas(
     Returns:
         Tool Schema 列表
     """
-    tools = await get_tools_for_chat(
+    tools = await filter_tools_for_chat(
         usables,
         chat_type=chat_type,
         chatter_name=chatter_name,
@@ -280,8 +256,7 @@ __all__ = [
     "API_VERSION",
     "get_all_tools",
     "get_tools_for_plugin",
-    "get_tools_for_chat",
-    "activate_tools_for_chat",
+    "filter_tools_for_chat",
     "get_tool_class",
     "get_tool_schema",
     "get_tool_schemas",

--- a/src/app/plugin_system/api/tool_api.py
+++ b/src/app/plugin_system/api/tool_api.py
@@ -105,7 +105,7 @@ def get_tools_for_plugin(plugin_name: str) -> dict[str, type["BaseTool"]]:
 
 
 async def filter_tools_for_chat(
-    usables: list[type["LLMUsable"]] | None = None,
+    usables: list[type["LLMUsable"]],
     *,
     chat_type: ChatType | str = ChatType.ALL,
     chatter_name: str = "",
@@ -117,12 +117,12 @@ async def filter_tools_for_chat(
 ) -> list[type["LLMUsable"]]:
     """筛选适用于特定聊天上下文的 Tool 组件类列表。
 
-    Tool 组件仅做部署期静态维度过滤（含筛选前事件钩子），不涉及动态激活。
-    传入 ``usables`` 则直接筛给定集合；否则从注册表拉取全部 Tool
-    （拉取另由 ``get_all_tools`` 负责）。
+    只负责筛选：Tool 组件仅做部署期静态维度过滤（含筛选前事件钩子），
+    不涉及动态激活。拉取全量由 ``get_all_tools`` 单独承担，调用方需先
+    获取再传入。
 
     Args:
-        usables: 待筛选的组件类列表；不传则取全量注册 Tool
+        usables: 待筛选的组件类列表（必填，由调用方传入）
         chat_type: 聊天类型
         chatter_name: Chatter 名称
         platform: 平台名称
@@ -194,6 +194,8 @@ async def get_tool_schemas(
     Returns:
         Tool Schema 列表
     """
+    if usables is None:
+        usables = list(get_all_tools().values())
     tools = await filter_tools_for_chat(
         usables,
         chat_type=chat_type,

--- a/src/core/components/__init__.py
+++ b/src/core/components/__init__.py
@@ -20,6 +20,11 @@ from .base import (
 from .loader import PluginLoader, register_plugin, get_plugin_loader, PluginManifest
 from .registry import ComponentRegistry, get_global_registry
 from .state_manager import StateManager, get_global_state_manager
+from .usable_filter import (
+    UsableFilterContext,
+    build_filter_context_from_stream,
+    evaluate_usable_filter,
+)
 from .types import (
     ChatType,
     ComponentState,
@@ -52,12 +57,14 @@ __all__ = [
     "get_global_registry",
     "get_global_state_manager",
     "StateManager",
+    "UsableFilterContext",
+    "build_filter_context_from_stream",
+    "evaluate_usable_filter",
     "ChatType",
     "ComponentState",
     "ComponentType",
     "EventType",
     "MediaEngine",
     "PermissionLevel",
-    "RecognitionMode",
     "PluginManifest",
 ]

--- a/src/core/components/base/action.py
+++ b/src/core/components/base/action.py
@@ -77,12 +77,6 @@ class BaseAction(BaseComponent, LLMUsable):
     stream_allow: list[str] = []
     stream_deny: list[str] = []
 
-    group_allow: list[str | int] = []
-    group_deny: list[str | int] = []
-
-    user_allow: list[str | int] = []
-    user_deny: list[str | int] = []
-
     associated_types: list[str] = []
 
     # 组件级依赖（精确到组件签名）

--- a/src/core/components/base/action.py
+++ b/src/core/components/base/action.py
@@ -67,9 +67,22 @@ class BaseAction(BaseComponent, LLMUsable):
 
     primary_action: bool = False
     chatter_allow: list[str] = []
-    chat_type: ChatType = ChatType.ALL
+    chatter_deny: list[str] = []
+    chat_type: ChatType | list[ChatType] = ChatType.ALL
 
     associated_platforms: list[str] = []
+    platform_allow: list[str] = []
+    platform_deny: list[str] = []
+
+    stream_allow: list[str] = []
+    stream_deny: list[str] = []
+
+    group_allow: list[str | int] = []
+    group_deny: list[str | int] = []
+
+    user_allow: list[str | int] = []
+    user_deny: list[str | int] = []
+
     associated_types: list[str] = []
 
     # 组件级依赖（精确到组件签名）

--- a/src/core/components/base/agent.py
+++ b/src/core/components/base/agent.py
@@ -97,12 +97,6 @@ class BaseAgent(BaseComponent, LLMUsable):
     stream_allow: list[str] = []
     stream_deny: list[str] = []
 
-    group_allow: list[str | int] = []
-    group_deny: list[str | int] = []
-
-    user_allow: list[str | int] = []
-    user_deny: list[str | int] = []
-
     associated_types: list[str] = []
 
     dependencies: list[str] = []

--- a/src/core/components/base/agent.py
+++ b/src/core/components/base/agent.py
@@ -87,9 +87,22 @@ class BaseAgent(BaseComponent, LLMUsable):
     description: str = ""
 
     chatter_allow: list[str] = []
-    chat_type: ChatType = ChatType.ALL
+    chatter_deny: list[str] = []
+    chat_type: ChatType | list[ChatType] = ChatType.ALL
 
     associated_platforms: list[str] = []
+    platform_allow: list[str] = []
+    platform_deny: list[str] = []
+
+    stream_allow: list[str] = []
+    stream_deny: list[str] = []
+
+    group_allow: list[str | int] = []
+    group_deny: list[str | int] = []
+
+    user_allow: list[str | int] = []
+    user_deny: list[str | int] = []
+
     associated_types: list[str] = []
 
     dependencies: list[str] = []

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -21,7 +21,6 @@ from src.core.components.base.action import BaseAction
 from src.core.components.base.agent import BaseAgent
 from src.core.components.base.tool import BaseTool
 from src.core.utils.context_compression import default_chat_context_compression_handler
-from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger, COLOR
 
 
@@ -194,9 +193,9 @@ class BaseChatter(BaseComponent):
     ) -> list[type[LLMUsable]]:
         """修改 LLMUsable 组件列表。
 
-        采用两阶段过滤流水线：
-        1. Phase 1（Fast-Path 静态过滤）：基于 UsableFilterEngine 评估各维度作用域，无需实例化。
-        2. Phase 2（Slow-Path 动态激活）：仅对存活组件实例化并异步执行 go_activate 判定。
+        将筛选与激活全部委托给各组件管理器经 API 封装的流程：
+        1. 静态筛选（Fast-Path）：按组件类型调用各 API 的 get_*_for_chat。
+        2. 动态激活（Slow-Path）：对存活组件调用各 API 的 activate_*_for_chat。
 
         Args:
             llm_usables: 原始 LLMUsable 组件列表
@@ -204,124 +203,91 @@ class BaseChatter(BaseComponent):
         Returns:
             list[type[LLMUsable]]: 修改后的可用组件类列表
         """
-        from src.core.components.usable_filter import (
-            build_filter_context_from_stream,
-            evaluate_usable_filter,
-        )
-
         logger = get_logger("chatter", display="聊天器", color=COLOR.MAGENTA)
         chat_stream = await get_stream_manager().get_or_create_stream(
             stream_id=self.stream_id
         )
         chat_context = chat_stream.context
 
-        removals: list[tuple[str, str]] = []
-        filtered: list[type[LLMUsable]] = []
-
         # 构造当前流的通用过滤快照
+        from src.core.components.usable_filter import build_filter_context_from_stream
+
         filter_ctx = build_filter_context_from_stream(chat_stream, self)
 
-        # ── Phase 1: Fast-Path 纯静态元数据过滤 ──
+        # 按组件类型分组待筛选列表
+        action_usables: list[type[LLMUsable]] = []
+        tool_usables: list[type[LLMUsable]] = []
+        agent_usables: list[type[LLMUsable]] = []
+
         for usable_cls in llm_usables:
             usable_cls = cast(type["BaseAction|BaseAgent|BaseTool"], usable_cls)  # 类型提示
-            signature = usable_cls.get_signature() or usable_cls.__name__
+            if issubclass(usable_cls, BaseAction):
+                action_usables.append(usable_cls)
+            elif issubclass(usable_cls, BaseTool):
+                tool_usables.append(usable_cls)
+            elif issubclass(usable_cls, BaseAgent):
+                agent_usables.append(usable_cls)
 
-            is_eligible, reject_reason = evaluate_usable_filter(
-                usable_cls, filter_ctx
-            )
-            if not is_eligible:
-                reason = reject_reason or "静态作用域不匹配"
-                removals.append((signature, reason))
-                logger.debug(f"[移除组件] {signature}：{reason}")
-                continue
+        # Phase 1：静态筛选（全走 API）
+        from src.app.plugin_system.api import action_api, agent_api, tool_api
 
-            filtered.append(usable_cls)
+        kept_actions = await action_api.get_actions_for_chat(
+            action_usables,
+            chat_type=filter_ctx.chat_type,
+            chatter_name=filter_ctx.chatter_name,
+            platform=filter_ctx.platform,
+            stream_id=self.stream_id,
+            chat_stream=chat_stream,
+            stream_context=chat_context,
+            chatter=self,
+        )
+        kept_tools = await tool_api.get_tools_for_chat(
+            tool_usables,
+            chat_type=filter_ctx.chat_type,
+            chatter_name=filter_ctx.chatter_name,
+            platform=filter_ctx.platform,
+            stream_id=self.stream_id,
+            chat_stream=chat_stream,
+            stream_context=chat_context,
+            chatter=self,
+        )
+        kept_agents = await agent_api.get_agents_for_chat(
+            agent_usables,
+            chat_type=filter_ctx.chat_type,
+            chatter_name=filter_ctx.chatter_name,
+            platform=filter_ctx.platform,
+            stream_id=self.stream_id,
+            chat_stream=chat_stream,
+            stream_context=chat_context,
+            chatter=self,
+        )
 
-        # ── Phase 2: Slow-Path 动态实例化与 go_activate 判定 ──
-        tasks = []
-        signatures = []
-        for usable_cls in filtered:
-            usable_cls = cast(type["BaseAction|BaseAgent|BaseTool"], usable_cls)  # 类型提示
-            signature = usable_cls.get_signature() or usable_cls.__name__
+        # Phase 2：动态激活（全走 API，plugin 作为签名解析失败的兜底）
+        kept_actions = await action_api.activate_actions_for_chat(
+            kept_actions,
+            chat_stream=chat_stream,
+            plugin=self.plugin,
+            message_content=(
+                chat_context.current_message.processed_plain_text
+                if chat_context.current_message and chat_context.current_message.processed_plain_text
+                else str(chat_context.current_message.content or "")
+                if chat_context.current_message
+                else ""
+            ),
+        )
+        kept_tools = await tool_api.activate_tools_for_chat(
+            kept_tools,
+            chat_stream=chat_stream,
+            plugin=self.plugin,
+            message=chat_context.current_message,
+        )
+        kept_agents = await agent_api.activate_agents_for_chat(
+            kept_agents,
+            chat_stream=chat_stream,
+            plugin=self.plugin,
+        )
 
-            try:
-                component_plugin = self._resolve_component_plugin(signature)
-                instance: BaseAction | BaseAgent | BaseTool
-                if issubclass(usable_cls, BaseAction):
-                    instance = usable_cls(
-                        chat_stream=chat_stream, plugin=component_plugin
-                    )
-
-                    current_msg = chat_context.current_message
-                    if current_msg:
-                        instance._last_message = (
-                            current_msg.processed_plain_text
-                            if current_msg.processed_plain_text
-                            else str(current_msg.content or "")
-                        )
-                elif issubclass(usable_cls, BaseTool):
-                    instance = usable_cls(plugin=component_plugin)
-                    instance._bind_runtime_context(
-                        stream_id=self.stream_id,
-                        message=chat_context.current_message,
-                    )
-                elif issubclass(usable_cls, BaseAgent):
-                    instance = usable_cls(
-                        stream_id=self.stream_id, plugin=component_plugin
-                    )
-                else:
-                    continue
-
-                go_activate = getattr(instance, "go_activate", None)
-                if not callable(go_activate):
-                    continue
-
-                tasks.append(go_activate())
-                signatures.append(signature)
-
-            except Exception as e:
-                logger.error(f"创建 LLMUsable 实例 {signature} 失败: {e}")
-                removals.append((signature, f"创建实例失败: {e}"))
-
-        if tasks:
-            logger.debug(
-                f"[{chat_stream.stream_id}] 并行执行激活判断，任务数: {len(tasks)}"
-            )
-            try:
-                results = await get_task_manager().gather(
-                    *tasks, return_exceptions=True
-                )
-
-                for signature, result in zip(signatures, results, strict=False):
-                    if isinstance(result, Exception):
-                        logger.error(
-                            f"[{chat_stream.stream_id}] 激活判断 {signature} 时出错: {result}"
-                        )
-                        removals.append((signature, f"激活判断出错: {result}"))
-                    elif not result:
-                        removals.append((signature, "go_activate 返回 False"))
-                        logger.debug(
-                            f"[{chat_stream.stream_id}] 未激活组件: {signature}"
-                        )
-                    else:
-                        logger.debug(f"[{chat_stream.stream_id}] 激活组件: {signature}")
-
-            except Exception as e:
-                logger.error(f"[{chat_stream.stream_id}] 并行激活判断失败: {e}")
-                removals.extend((sig, f"并行判断失败: {e}") for sig in signatures)
-
-        if removals:
-            removals_summary = " | ".join(
-                [f"{name}({reason})" for name, reason in removals]
-            )
-            logger.info(f"[{chat_stream.stream_id}] 移除组件: {removals_summary}")
-
-        removal_names = {name for name, _ in removals}
-        available = [
-            usable_cls
-            for usable_cls in filtered
-            if (usable_cls.get_signature() or usable_cls.__name__) not in removal_names  # type: ignore
-        ]
+        available = [*kept_actions, *kept_tools, *kept_agents]
 
         logger.info(
             f"[{chat_stream.stream_id}] 可用组件: {len(available)}/{len(llm_usables)}"

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -261,6 +261,10 @@ class BaseChatter(BaseComponent):
                         )
                 elif issubclass(usable_cls, BaseTool):
                     instance = usable_cls(plugin=component_plugin)
+                    instance._bind_runtime_context(
+                        stream_id=self.stream_id,
+                        message=chat_context.current_message,
+                    )
                 elif issubclass(usable_cls, BaseAgent):
                     instance = usable_cls(
                         stream_id=self.stream_id, plugin=component_plugin

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -193,9 +193,9 @@ class BaseChatter(BaseComponent):
     ) -> list[type[LLMUsable]]:
         """修改 LLMUsable 组件列表。
 
-        将筛选与激活全部委托给各组件管理器经 API 封装的流程：
-        1. 静态筛选（Fast-Path）：按组件类型调用各 API 的 get_*_for_chat。
-        2. 动态激活（Slow-Path）：对存活组件调用各 API 的 activate_*_for_chat。
+        将各类组件的筛选与激活全部委托给对应管理器经 API 封装的单个
+        ``filter_*_for_chat`` 流程：Action/Agent 完成静态过滤与动态
+        go_activate 激活，Tool 仅做静态过滤（``BaseTool`` 无 ``go_activate``）。
 
         Args:
             llm_usables: 原始 LLMUsable 组件列表
@@ -214,6 +214,14 @@ class BaseChatter(BaseComponent):
 
         filter_ctx = build_filter_context_from_stream(chat_stream, self)
 
+        message_content = (
+            chat_context.current_message.processed_plain_text
+            if chat_context.current_message and chat_context.current_message.processed_plain_text
+            else str(chat_context.current_message.content or "")
+            if chat_context.current_message
+            else ""
+        )
+
         # 按组件类型分组待筛选列表
         action_usables: list[type[LLMUsable]] = []
         tool_usables: list[type[LLMUsable]] = []
@@ -228,10 +236,10 @@ class BaseChatter(BaseComponent):
             elif issubclass(usable_cls, BaseAgent):
                 agent_usables.append(usable_cls)
 
-        # Phase 1：静态筛选（全走 API）
+        # 筛选 + 激活（全走 API）
         from src.app.plugin_system.api import action_api, agent_api, tool_api
 
-        kept_actions = await action_api.get_actions_for_chat(
+        kept_actions = await action_api.filter_actions_for_chat(
             action_usables,
             chat_type=filter_ctx.chat_type,
             chatter_name=filter_ctx.chatter_name,
@@ -240,8 +248,10 @@ class BaseChatter(BaseComponent):
             chat_stream=chat_stream,
             stream_context=chat_context,
             chatter=self,
+            plugin=self.plugin,
+            message_content=message_content,
         )
-        kept_tools = await tool_api.get_tools_for_chat(
+        kept_tools = await tool_api.filter_tools_for_chat(
             tool_usables,
             chat_type=filter_ctx.chat_type,
             chatter_name=filter_ctx.chatter_name,
@@ -251,7 +261,7 @@ class BaseChatter(BaseComponent):
             stream_context=chat_context,
             chatter=self,
         )
-        kept_agents = await agent_api.get_agents_for_chat(
+        kept_agents = await agent_api.filter_agents_for_chat(
             agent_usables,
             chat_type=filter_ctx.chat_type,
             chatter_name=filter_ctx.chatter_name,
@@ -260,30 +270,6 @@ class BaseChatter(BaseComponent):
             chat_stream=chat_stream,
             stream_context=chat_context,
             chatter=self,
-        )
-
-        # Phase 2：动态激活（全走 API，plugin 作为签名解析失败的兜底）
-        kept_actions = await action_api.activate_actions_for_chat(
-            kept_actions,
-            chat_stream=chat_stream,
-            plugin=self.plugin,
-            message_content=(
-                chat_context.current_message.processed_plain_text
-                if chat_context.current_message and chat_context.current_message.processed_plain_text
-                else str(chat_context.current_message.content or "")
-                if chat_context.current_message
-                else ""
-            ),
-        )
-        kept_tools = await tool_api.activate_tools_for_chat(
-            kept_tools,
-            chat_stream=chat_stream,
-            plugin=self.plugin,
-            message=chat_context.current_message,
-        )
-        kept_agents = await agent_api.activate_agents_for_chat(
-            kept_agents,
-            chat_stream=chat_stream,
             plugin=self.plugin,
         )
 

--- a/src/core/components/base/chatter.py
+++ b/src/core/components/base/chatter.py
@@ -24,6 +24,20 @@ from src.core.utils.context_compression import default_chat_context_compression_
 from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger, COLOR
 
+
+def get_stream_manager() -> Any:
+    """获取 StreamManager 单例（延迟导入避免模块循环依赖）。"""
+    from src.core.managers import get_stream_manager as _get_sm
+
+    return _get_sm()
+
+
+def get_plugin_manager() -> Any:
+    """获取 PluginManager 单例（延迟导入避免模块循环依赖）。"""
+    from src.core.managers import get_plugin_manager as _get_pm
+
+    return _get_pm()
+
 if TYPE_CHECKING:
     from src.core.components.base.action import BaseAction
     from src.core.components.base.agent import BaseAgent
@@ -180,17 +194,21 @@ class BaseChatter(BaseComponent):
     ) -> list[type[LLMUsable]]:
         """修改 LLMUsable 组件列表。
 
-        调用其go_activate方法进行激活判定，并核对associate_type，返回最终可用的组件列表。
+        采用两阶段过滤流水线：
+        1. Phase 1（Fast-Path 静态过滤）：基于 UsableFilterEngine 评估各维度作用域，无需实例化。
+        2. Phase 2（Slow-Path 动态激活）：仅对存活组件实例化并异步执行 go_activate 判定。
 
         Args:
             llm_usables: 原始 LLMUsable 组件列表
 
         Returns:
-            list[type[LLMUsable]]: 修改后的组件列表
+            list[type[LLMUsable]]: 修改后的可用组件类列表
         """
+        from src.core.components.usable_filter import (
+            build_filter_context_from_stream,
+            evaluate_usable_filter,
+        )
 
-        from src.core.managers import get_stream_manager
-        
         logger = get_logger("chatter", display="聊天器", color=COLOR.MAGENTA)
         chat_stream = await get_stream_manager().get_or_create_stream(
             stream_id=self.stream_id
@@ -200,36 +218,26 @@ class BaseChatter(BaseComponent):
         removals: list[tuple[str, str]] = []
         filtered: list[type[LLMUsable]] = []
 
+        # 构造当前流的通用过滤快照
+        filter_ctx = build_filter_context_from_stream(chat_stream, self)
+
+        # ── Phase 1: Fast-Path 纯静态元数据过滤 ──
         for usable_cls in llm_usables:
             usable_cls = cast(type["BaseAction|BaseAgent|BaseTool"], usable_cls)  # 类型提示
             signature = usable_cls.get_signature() or usable_cls.__name__
 
-            chatter_allow = getattr(usable_cls, "chatter_allow", [])
-            if chatter_allow:
-                chatter_signature = self.get_signature()
-                allowed = self.name in chatter_allow
-                if chatter_signature and not allowed:
-                    allowed = chatter_signature in chatter_allow
-
-                if not allowed:
-                    allow_str = ", ".join(chatter_allow)
-                    reason = f"chatter 不匹配（允许: {allow_str}）"
-                    removals.append((signature, reason))
-                    logger.debug(f"[移除组件] {signature}：{reason}")
-                    continue
-
-            if issubclass(usable_cls, BaseAction):
-                required_types = usable_cls.validate_associated_types()
-                if not chat_context.check_types(required_types):
-                    types_str = ", ".join(required_types)
-                    reason = f"适配器不支持（需要: {types_str}）"
-                    removals.append((signature, reason))
-                    logger.debug(f"[移除组件] {signature}：{reason}")
-                    continue
+            is_eligible, reject_reason = evaluate_usable_filter(
+                usable_cls, filter_ctx
+            )
+            if not is_eligible:
+                reason = reject_reason or "静态作用域不匹配"
+                removals.append((signature, reason))
+                logger.debug(f"[移除组件] {signature}：{reason}")
+                continue
 
             filtered.append(usable_cls)
 
-        # 并行执行 go_activate（如果组件提供）
+        # ── Phase 2: Slow-Path 动态实例化与 go_activate 判定 ──
         tasks = []
         signatures = []
         for usable_cls in filtered:
@@ -240,7 +248,9 @@ class BaseChatter(BaseComponent):
                 component_plugin = self._resolve_component_plugin(signature)
                 instance: BaseAction | BaseAgent | BaseTool
                 if issubclass(usable_cls, BaseAction):
-                    instance = usable_cls(chat_stream=chat_stream, plugin=component_plugin)
+                    instance = usable_cls(
+                        chat_stream=chat_stream, plugin=component_plugin
+                    )
 
                     current_msg = chat_context.current_message
                     if current_msg:
@@ -252,7 +262,9 @@ class BaseChatter(BaseComponent):
                 elif issubclass(usable_cls, BaseTool):
                     instance = usable_cls(plugin=component_plugin)
                 elif issubclass(usable_cls, BaseAgent):
-                    instance = usable_cls(stream_id=self.stream_id, plugin=component_plugin)
+                    instance = usable_cls(
+                        stream_id=self.stream_id, plugin=component_plugin
+                    )
                 else:
                     continue
 
@@ -304,7 +316,7 @@ class BaseChatter(BaseComponent):
         available = [
             usable_cls
             for usable_cls in filtered
-            if (usable_cls.get_signature() or usable_cls.__name__) not in removal_names # type: ignore
+            if (usable_cls.get_signature() or usable_cls.__name__) not in removal_names  # type: ignore
         ]
 
         logger.info(
@@ -323,12 +335,21 @@ class BaseChatter(BaseComponent):
             from src.core.components.types import parse_signature
 
             plugin_name = parse_signature(signature)["plugin_name"]
+            target_plugin = plugin_api.get_plugin(plugin_name)
+            if target_plugin:
+                return target_plugin
         except Exception:
-            return self.plugin
+            pass
 
-        target_plugin = plugin_api.get_plugin(plugin_name)
-        if target_plugin:
-            return target_plugin
+        try:
+            from src.core.components.types import parse_signature
+
+            plugin_name = parse_signature(signature)["plugin_name"]
+            target_plugin = get_plugin_manager().get_plugin(plugin_name)
+            if target_plugin:
+                return target_plugin
+        except Exception:
+            pass
 
         return self.plugin
 

--- a/src/core/components/base/config.py
+++ b/src/core/components/base/config.py
@@ -5,7 +5,6 @@
 自动默认路径生成和默认配置文件生成。
 """
 
-from abc import ABC
 from pathlib import Path
 from typing import ClassVar, Self
 

--- a/src/core/components/base/tool.py
+++ b/src/core/components/base/tool.py
@@ -58,9 +58,23 @@ class BaseTool(BaseComponent, LLMUsable):
     description: str = ""
 
     chatter_allow: list[str] = []
-    chat_type: ChatType = ChatType.ALL
+    chatter_deny: list[str] = []
+    chat_type: ChatType | list[ChatType] = ChatType.ALL
 
     associated_platforms: list[str] = []
+    platform_allow: list[str] = []
+    platform_deny: list[str] = []
+
+    stream_allow: list[str] = []
+    stream_deny: list[str] = []
+
+    group_allow: list[str | int] = []
+    group_deny: list[str | int] = []
+
+    user_allow: list[str | int] = []
+    user_deny: list[str | int] = []
+
+    associated_types: list[str] = []
 
     # 组件级依赖（精确到组件签名）
     dependencies: list[str] = []  # 例如 ["other_plugin:tool:database"]

--- a/src/core/components/base/tool.py
+++ b/src/core/components/base/tool.py
@@ -68,12 +68,6 @@ class BaseTool(BaseComponent, LLMUsable):
     stream_allow: list[str] = []
     stream_deny: list[str] = []
 
-    group_allow: list[str | int] = []
-    group_deny: list[str | int] = []
-
-    user_allow: list[str | int] = []
-    user_deny: list[str | int] = []
-
     associated_types: list[str] = []
 
     # 组件级依赖（精确到组件签名）

--- a/src/core/components/types.py
+++ b/src/core/components/types.py
@@ -87,6 +87,11 @@ class EventType(str, Enum):
     AFTER_COMMAND_EXECUTE = "after_command_execute"
     ON_COMMAND_EXECUTE_FAILED = "on_command_execute_failed"
 
+    # 组件筛选生命周期事件（筛选发生前发布，处理器可改写组件类集合）
+    BEFORE_ACTION_FILTER = "before_action_filter"
+    BEFORE_TOOL_FILTER = "before_tool_filter"
+    BEFORE_AGENT_FILTER = "before_agent_filter"
+
     # 媒体识别事件（落盘入库后触发，处理器可回写 description）
     ON_MEDIA_RECOGNIZE = "on_media_recognize"
 

--- a/src/core/components/usable_filter.py
+++ b/src/core/components/usable_filter.py
@@ -229,7 +229,11 @@ def build_filter_context_from_stream(
         UsableFilterContext: 构造好的过滤上下文快照
     """
     stream_id = str(chat_stream.stream_id or "").strip()
-    chat_type = str(chat_stream.chat_type or "private").strip().lower()
+    raw_chat_type = chat_stream.chat_type or "private"
+    if isinstance(raw_chat_type, ChatType):
+        chat_type = raw_chat_type.value.strip().lower()
+    else:
+        chat_type = str(raw_chat_type).strip().lower()
     platform = str(chat_stream.platform or "").strip()
 
     group_id: str | None = None

--- a/src/core/components/usable_filter.py
+++ b/src/core/components/usable_filter.py
@@ -1,0 +1,308 @@
+"""LLMUsable 组件细粒度过滤与作用域评估引擎。
+
+本模块提供 UsableFilterContext 上下文快照与 evaluate_usable_filter 纯函数，
+用于在不实例化组件的前提下，根据运行时上下文对 Action / Tool / Agent 进行
+多维度（Chatter、ChatType、Platform、Stream、Group、User、Content Types）
+的静态过滤，消除无谓的对象创建与协程调度开销。
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from src.core.components.types import ChatType
+
+if TYPE_CHECKING:
+    from src.core.components.base.chatter import BaseChatter
+    from src.core.models.stream import ChatStream
+
+
+@dataclass(frozen=True, slots=True)
+class UsableFilterContext:
+    """LLMUsable 过滤与作用域评估上下文快照。
+
+    Attributes:
+        stream_id: 当前会话流唯一标识符
+        chat_type: 聊天流类型 (private / group / discuss 等)
+        platform: 消息接入平台标识 (qq / telegram / discord 等)
+        group_id: 群组实体 ID (群聊时有效)
+        user_id: 发送者或目标用户实体 ID
+        chatter_name: 当前 Chatter 组件名称
+        chatter_signature: 当前 Chatter 组件全局唯一签名
+        accept_formats: 当前流/适配器支持的内容格式列表 (如 ["text", "image"])
+    """
+
+    stream_id: str
+    chat_type: str
+    platform: str
+    group_id: str | None = None
+    user_id: str | None = None
+    chatter_name: str = ""
+    chatter_signature: str = ""
+    accept_formats: list[str] | None = None
+
+
+def _normalize_str_list(items: Any) -> list[str]:
+    """将包含字符串或整数的列表规范化为非空字符串列表。
+
+    Args:
+        items: 待转换的数据列表或单个值
+
+    Returns:
+        list[str]: 规范化后的字符串列表
+    """
+    if items is None:
+        return []
+    if isinstance(items, (str, int)):
+        items = [items]
+    if not isinstance(items, (list, tuple, set)):
+        return []
+    result: list[str] = []
+    for item in items:
+        s = str(item).strip()
+        if s:
+            result.append(s)
+    return result
+
+
+def _resolve_allowed_chat_types(chat_type_decl: Any) -> set[str]:
+    """解析组件声明的 chat_type，返回允许的 chat_type 字符串集合。
+
+    若声明为 ChatType.ALL 或未限制，则返回空集合表示匹配所有类型。
+
+    Args:
+        chat_type_decl: 组件类属性中的 chat_type 声明
+
+    Returns:
+        set[str]: 允许的 chat_type 小写字符串集合；空集合表示全部允许
+    """
+    if chat_type_decl is None or chat_type_decl == ChatType.ALL:
+        return set()
+
+    decl_list = (
+        chat_type_decl
+        if isinstance(chat_type_decl, (list, tuple, set))
+        else [chat_type_decl]
+    )
+
+    allowed: set[str] = set()
+    for item in decl_list:
+        if item == ChatType.ALL or item == "all":
+            return set()
+        val = item.value if isinstance(item, ChatType) else str(item)
+        norm = str(val).strip().lower()
+        if norm:
+            allowed.add(norm)
+    return allowed
+
+
+def evaluate_usable_filter(
+    usable_cls: type[Any], ctx: UsableFilterContext
+) -> tuple[bool, str | None]:
+    """评估单个 LLMUsable 组件是否在指定上下文中可用（Fast-Path 静态过滤）。
+
+    按顺序依次校验 Chatter、ChatType、Platform、Stream、Group、User、Content Types
+    7 个维度。黑名单优先于白名单；任意维度不匹配即返回 False 及具体原因。
+
+    Args:
+        usable_cls: 要评估的 Tool / Action / Agent 组件类
+        ctx: 包含当前会话流与调用者状态的上下文快照
+
+    Returns:
+        tuple[bool, str | None]: (是否可用, 不可用原因描述/None)
+    """
+    # ── 1. Chatter 维度 ──
+    chatter_deny = _normalize_str_list(getattr(usable_cls, "chatter_deny", []))
+    if chatter_deny:
+        if (
+            ctx.chatter_name
+            and ctx.chatter_name in chatter_deny
+            or ctx.chatter_signature
+            and ctx.chatter_signature in chatter_deny
+        ):
+            return False, f"chatter 在黑名单中 (拒绝: {', '.join(chatter_deny)})"
+
+    chatter_allow = _normalize_str_list(
+        getattr(usable_cls, "chatter_allow", [])
+    )
+    if chatter_allow and (ctx.chatter_name or ctx.chatter_signature):
+        allowed = (
+            ctx.chatter_name in chatter_allow
+            or ctx.chatter_signature in chatter_allow
+        )
+        if not allowed:
+            return (
+                False,
+                f"chatter 不匹配 (允许: {', '.join(chatter_allow)})",
+            )
+
+    # ── 2. ChatType 维度 ──
+    chat_type_decl = getattr(usable_cls, "chat_type", None)
+    legacy_supported = getattr(usable_cls, "supported_chat_types", None)
+    if legacy_supported is not None:
+        chat_type_decl = legacy_supported
+    elif chat_type_decl is None:
+        chat_type_decl = ChatType.ALL
+
+    allowed_chat_types = _resolve_allowed_chat_types(chat_type_decl)
+    if allowed_chat_types:
+        ctx_chat_type = str(ctx.chat_type or "").strip().lower()
+        if (
+            ctx_chat_type
+            and ctx_chat_type != "all"
+            and ctx_chat_type not in allowed_chat_types
+        ):
+            req_str = ", ".join(sorted(allowed_chat_types))
+            return (
+                False,
+                f"聊天类型不匹配 (需要: {req_str}, 当前: {ctx_chat_type})",
+            )
+
+    # ── 3. Platform 维度 ──
+    platform_deny = _normalize_str_list(
+        getattr(usable_cls, "platform_deny", [])
+    )
+    if platform_deny and ctx.platform and ctx.platform in platform_deny:
+        return False, f"平台在黑名单中 (拒绝: {', '.join(platform_deny)})"
+
+    platform_allow = _normalize_str_list(
+        getattr(usable_cls, "platform_allow", [])
+    )
+    associated_platforms = _normalize_str_list(
+        getattr(usable_cls, "associated_platforms", [])
+    )
+    combined_platform_allow = list(
+        dict.fromkeys(platform_allow + associated_platforms)
+    )
+    if combined_platform_allow and ctx.platform and ctx.platform not in combined_platform_allow:
+        return (
+            False,
+            f"平台不匹配 (允许: {', '.join(combined_platform_allow)})",
+        )
+
+    # ── 4. Stream 维度 ──
+    stream_deny = _normalize_str_list(getattr(usable_cls, "stream_deny", []))
+    if stream_deny and ctx.stream_id in stream_deny:
+        return False, f"聊天流在黑名单中 (拒绝: {', '.join(stream_deny)})"
+
+    stream_allow = _normalize_str_list(getattr(usable_cls, "stream_allow", []))
+    if stream_allow and ctx.stream_id not in stream_allow:
+        return False, f"聊天流不匹配 (允许: {', '.join(stream_allow)})"
+
+    # ── 5. Group 维度 (仅群聊/群实体存在时生效) ──
+    if str(ctx.chat_type).lower() == "group" and ctx.group_id:
+        group_deny = _normalize_str_list(getattr(usable_cls, "group_deny", []))
+        if group_deny and ctx.group_id in group_deny:
+            return False, f"群组在黑名单中 (拒绝: {', '.join(group_deny)})"
+
+        group_allow = _normalize_str_list(
+            getattr(usable_cls, "group_allow", [])
+        )
+        if group_allow and ctx.group_id not in group_allow:
+            return False, f"群组不匹配 (允许: {', '.join(group_allow)})"
+
+    # ── 6. User 维度 ──
+    if ctx.user_id:
+        user_deny = _normalize_str_list(getattr(usable_cls, "user_deny", []))
+        if user_deny and ctx.user_id in user_deny:
+            return False, f"用户在黑名单中 (拒绝: {', '.join(user_deny)})"
+
+        user_allow = _normalize_str_list(getattr(usable_cls, "user_allow", []))
+        if user_allow and ctx.user_id not in user_allow:
+            return False, f"用户不匹配 (允许: {', '.join(user_allow)})"
+
+    # ── 7. Content Types 维度 ──
+    raw_req_types: Any
+    val_method = getattr(usable_cls, "validate_associated_types", None)
+    if callable(val_method):
+        try:
+            raw_req_types = val_method()
+        except Exception:
+            raw_req_types = getattr(usable_cls, "associated_types", [])
+    else:
+        raw_req_types = getattr(usable_cls, "associated_types", [])
+
+    req_types: list[str] = _normalize_str_list(raw_req_types)
+
+    if req_types and ctx.accept_formats is not None:
+        missing = [t for t in req_types if t not in ctx.accept_formats]
+        if missing:
+            return False, f"适配器不支持内容格式 (需要: {', '.join(req_types)})"
+
+    return True, None
+
+
+def build_filter_context_from_stream(
+    chat_stream: "ChatStream", chatter: "BaseChatter"
+) -> UsableFilterContext:
+    """从 ChatStream 与 BaseChatter 实例构造 UsableFilterContext 快照。
+
+    Args:
+        chat_stream: 聊天流实例
+        chatter: 当前驱动执行的 Chatter 实例
+
+    Returns:
+        UsableFilterContext: 构造好的过滤上下文快照
+    """
+    stream_id = str(chat_stream.stream_id or "").strip()
+    chat_type = str(chat_stream.chat_type or "private").strip().lower()
+    platform = str(chat_stream.platform or "").strip()
+
+    group_id: str | None = None
+    user_id: str | None = None
+    accept_formats: list[str] | None = None
+
+    context = chat_stream.context
+    current_msg = (
+        context.current_message
+        if context.current_message
+        else (
+            context.unread_messages[-1] if context.unread_messages else None
+        )
+    )
+
+    if current_msg:
+        if current_msg.sender_id:
+            user_id = str(current_msg.sender_id).strip()
+        format_info = current_msg.extra.get("format_info")
+        if isinstance(format_info, dict):
+            raw_accept = format_info.get("accept_format")
+            if isinstance(raw_accept, list):
+                accept_formats = [str(x) for x in raw_accept]
+            elif isinstance(raw_accept, str):
+                accept_formats = [raw_accept]
+
+        if chat_type == "group":
+            msg_group_id = current_msg.extra.get("group_id") or getattr(
+                current_msg, "group_id", None
+            )
+            if msg_group_id:
+                group_id = str(msg_group_id).strip()
+
+    if chat_type == "group" and not group_id and hasattr(chat_stream, "group_id"):
+        stream_gid = getattr(chat_stream, "group_id", None)
+        if stream_gid:
+            group_id = str(stream_gid).strip()
+
+    chatter_name = str(getattr(chatter, "name", "") or "").strip()
+    sig_getter = getattr(chatter, "get_signature", None)
+    chatter_sig = str(sig_getter() or "") if callable(sig_getter) else ""
+
+    return UsableFilterContext(
+        stream_id=stream_id,
+        chat_type=chat_type,
+        platform=platform,
+        group_id=group_id,
+        user_id=user_id,
+        chatter_name=chatter_name,
+        chatter_signature=chatter_sig,
+        accept_formats=accept_formats,
+    )
+
+
+__all__ = [
+    "UsableFilterContext",
+    "build_filter_context_from_stream",
+    "evaluate_usable_filter",
+]

--- a/src/core/components/usable_filter.py
+++ b/src/core/components/usable_filter.py
@@ -2,8 +2,11 @@
 
 本模块提供 UsableFilterContext 上下文快照与 evaluate_usable_filter 纯函数，
 用于在不实例化组件的前提下，根据运行时上下文对 Action / Tool / Agent 进行
-多维度（Chatter、ChatType、Platform、Stream、Group、User、Content Types）
-的静态过滤，消除无谓的对象创建与协程调度开销。
+部署/设计期静态维度（Chatter、ChatType、Platform、Stream、Content Types）
+的过滤，消除无谓的对象创建与协程调度开销。
+
+Group / User 等运行时实体名单不在此引擎内判定——它们由插件经配置 +
+事件处理器（BEFORE_*_FILTER）或组件 ``go_activate`` 在运行时自行处理。
 """
 
 from __future__ import annotations
@@ -102,8 +105,10 @@ def evaluate_usable_filter(
 ) -> tuple[bool, str | None]:
     """评估单个 LLMUsable 组件是否在指定上下文中可用（Fast-Path 静态过滤）。
 
-    按顺序依次校验 Chatter、ChatType、Platform、Stream、Group、User、Content Types
-    7 个维度。黑名单优先于白名单；任意维度不匹配即返回 False 及具体原因。
+    仅处理部署/设计期静态维度：Chatter、ChatType、Platform、Stream、Content Types
+    共 5 个。Group / User 等运行时实体名单不在此评估——它们由插件经配置 +
+    事件处理器（BEFORE_*_FILTER）或组件 ``go_activate`` 在运行时自行判定。
+    黑名单优先于白名单；任意维度不匹配即返回 False 及具体原因。
 
     Args:
         usable_cls: 要评估的 Tool / Action / Agent 组件类
@@ -190,29 +195,7 @@ def evaluate_usable_filter(
     if stream_allow and ctx.stream_id not in stream_allow:
         return False, f"聊天流不匹配 (允许: {', '.join(stream_allow)})"
 
-    # ── 5. Group 维度 (仅群聊/群实体存在时生效) ──
-    if str(ctx.chat_type).lower() == "group" and ctx.group_id:
-        group_deny = _normalize_str_list(getattr(usable_cls, "group_deny", []))
-        if group_deny and ctx.group_id in group_deny:
-            return False, f"群组在黑名单中 (拒绝: {', '.join(group_deny)})"
-
-        group_allow = _normalize_str_list(
-            getattr(usable_cls, "group_allow", [])
-        )
-        if group_allow and ctx.group_id not in group_allow:
-            return False, f"群组不匹配 (允许: {', '.join(group_allow)})"
-
-    # ── 6. User 维度 ──
-    if ctx.user_id:
-        user_deny = _normalize_str_list(getattr(usable_cls, "user_deny", []))
-        if user_deny and ctx.user_id in user_deny:
-            return False, f"用户在黑名单中 (拒绝: {', '.join(user_deny)})"
-
-        user_allow = _normalize_str_list(getattr(usable_cls, "user_allow", []))
-        if user_allow and ctx.user_id not in user_allow:
-            return False, f"用户不匹配 (允许: {', '.join(user_allow)})"
-
-    # ── 7. Content Types 维度 ──
+    # ── 5. Content Types 维度 ──
     raw_req_types: Any
     val_method = getattr(usable_cls, "validate_associated_types", None)
     if callable(val_method):

--- a/src/core/managers/__init__.py
+++ b/src/core/managers/__init__.py
@@ -7,6 +7,7 @@
 from src.core.managers.plugin_manager import get_plugin_manager, PluginManager
 from src.core.managers.adapter_manager import get_adapter_manager, initialize_adapter_manager, AdapterManager
 from src.core.managers.action_manager import get_action_manager, ActionManager
+from src.core.managers.agent_manager import get_agent_manager, AgentManager
 from src.core.managers.chatter_manager import get_chatter_manager, ChatterManager
 from src.core.managers.command_manager import get_command_manager, CommandManager
 from src.core.managers.service_manager import get_service_manager, ServiceManager
@@ -14,7 +15,14 @@ from src.core.managers.permission_manager import get_permission_manager, Permiss
 from src.core.managers.stream_manager import get_stream_manager, StreamManager
 from src.core.managers.event_manager import get_event_manager, initialize_event_manager, EventManager
 from src.core.managers.router_manager import get_router_manager, initialize_router_manager, RouterManager
-from src.core.managers.tool_manager import ToolUse, get_tool_use, MCPManager, get_mcp_manager
+from src.core.managers.tool_manager import (
+    ToolUse,
+    get_tool_use,
+    MCPManager,
+    get_mcp_manager,
+    ToolComponentManager,
+    get_tool_component_manager,
+)
 from src.core.managers.media_manager import get_media_manager, initialize_media_manager, MediaManager
 from src.core.transport.distribution import (
     get_stream_loop_manager,
@@ -26,6 +34,7 @@ __all__ = [
     # 主要管理器
     "get_plugin_manager",
     "get_action_manager",
+    "get_agent_manager",
     "get_adapter_manager",
     "get_chatter_manager",
     "get_command_manager",
@@ -46,6 +55,7 @@ __all__ = [
     "PluginManager",
     "AdapterManager",
     "ActionManager",
+    "AgentManager",
     "ChatterManager",
     "CommandManager",
     "ServiceManager",
@@ -59,4 +69,6 @@ __all__ = [
     "get_tool_use",
     "MCPManager",
     "get_mcp_manager",
+    "ToolComponentManager",
+    "get_tool_component_manager",
 ]

--- a/src/core/managers/action_manager.py
+++ b/src/core/managers/action_manager.py
@@ -101,31 +101,27 @@ class ActionManager:
             ...     chatter_name="my_chatter"
             ... )
         """
+        from src.core.components.usable_filter import (
+            UsableFilterContext,
+            evaluate_usable_filter,
+        )
+
         all_actions = self.get_all_actions()
+        ctx = UsableFilterContext(
+            stream_id="",
+            chat_type=chat_type.value if isinstance(chat_type, ChatType) else str(chat_type),
+            platform=platform,
+            chatter_name=chatter_name,
+        )
+
         filtered_actions = []
-
         for signature, action_cls in all_actions.items():
-            # 检查 chat_type 兼容性
-            if (
-                action_cls.chat_type != ChatType.ALL
-                and action_cls.chat_type != chat_type
-            ):
-                continue
-
-            # 检查 chatter_allow
-            if chatter_name and action_cls.chatter_allow:
-                if chatter_name not in action_cls.chatter_allow:
-                    continue
-
-            # 检查平台关联
-            if platform and action_cls.associated_platforms:
-                if platform not in action_cls.associated_platforms:
-                    continue
-
-            filtered_actions.append(action_cls)
+            is_eligible, _ = evaluate_usable_filter(action_cls, ctx)
+            if is_eligible:
+                filtered_actions.append(action_cls)
 
         logger.debug(
-            f"为聊天上下文筛选 Action: chat_type={chat_type.value}, "
+            f"为聊天上下文筛选 Action: chat_type={ctx.chat_type}, "
             f"chatter={chatter_name}, platform={platform}, "
             f"结果: {len(filtered_actions)}/{len(all_actions)}"
         )

--- a/src/core/managers/action_manager.py
+++ b/src/core/managers/action_manager.py
@@ -97,7 +97,7 @@ class ActionManager:
 
     async def filter_actions_for_chat(
         self,
-        usables: list[type["LLMUsable"]] | None = None,
+        usables: list[type["LLMUsable"]],
         *,
         chat_type: "ChatType | str" = "all",
         chatter_name: str = "",
@@ -111,12 +111,12 @@ class ActionManager:
     ) -> list[type["LLMUsable"]]:
         """筛选适用于特定聊天上下文的 Action 组件类列表。
 
-        一个函数完成完整筛选流程：静态维度过滤（部署期）+ 筛选前事件钩子 +
-        动态 go_activate 激活。传入 ``usables`` 则直接筛给定集合；否则从注册表
-        拉取全部 Action（获取另由 ``get_all_actions`` 负责）。
+        只负责筛选：对传入的 ``usables`` 完成静态维度过滤（部署期）+
+        筛选前事件钩子 + 动态 go_activate 激活。拉取全量由 ``get_all_actions``
+        单独承担，调用方需自行获取后传入。
 
         Args:
-            usables: 待筛选的组件类列表；不传则取全量注册 Action
+            usables: 待筛选的组件类列表（必填，由调用方传入）
             chat_type: 聊天类型（private / group / all）
             chatter_name: Chatter 名称
             platform: 平台名称
@@ -132,9 +132,6 @@ class ActionManager:
         """
         if isinstance(chat_type, ChatType):
             chat_type = chat_type.value
-
-        if usables is None:
-            usables = list(self.get_all_actions().values())
 
         # 筛选前事件钩子：外部处理器可改写组件集合
         usables = await publish_before_filter_event(
@@ -268,6 +265,7 @@ class ActionManager:
             list[dict[str, Any]]: Action schema 列表
         """
         actions = await self.filter_actions_for_chat(
+            list(self.get_all_actions().values()),
             chat_type=chat_type,
             chatter_name=chatter_name,
             platform=platform,

--- a/src/core/managers/action_manager.py
+++ b/src/core/managers/action_manager.py
@@ -47,7 +47,7 @@ class ActionManager:
 
     Examples:
         >>> manager = ActionManager()
-        >>> actions = await manager.get_actions_for_chat(
+        >>> actions = await manager.filter_actions_for_chat(
         ...     usables=[MyAction],
         ...     chat_type="private",
         ...     chatter_name="my_chatter",
@@ -93,9 +93,9 @@ class ActionManager:
         registry = get_global_registry()
         return registry.get(signature)
 
-    # ── 筛选与激活 ──
+    # ── 筛选 ──
 
-    async def get_actions_for_chat(
+    async def filter_actions_for_chat(
         self,
         usables: list[type["LLMUsable"]] | None = None,
         *,
@@ -106,11 +106,14 @@ class ActionManager:
         chat_stream: "ChatStream | None" = None,
         stream_context: "StreamContext | None" = None,
         chatter: "BaseChatter | None" = None,
+        plugin: "BasePlugin | None" = None,
+        message_content: str = "",
     ) -> list[type["LLMUsable"]]:
-        """获取适用于特定聊天上下文的 Action 组件类列表。
+        """筛选适用于特定聊天上下文的 Action 组件类列表。
 
-        若传入 ``usables`` 则直接对给定集合筛选（默认筛选不传 stream_id、
-        不获取流，仅按静态维度）；否则从注册表拉取全部 Action。
+        一个函数完成完整筛选流程：静态维度过滤（部署期）+ 筛选前事件钩子 +
+        动态 go_activate 激活。传入 ``usables`` 则直接筛给定集合；否则从注册表
+        拉取全部 Action（获取另由 ``get_all_actions`` 负责）。
 
         Args:
             usables: 待筛选的组件类列表；不传则取全量注册 Action
@@ -120,9 +123,12 @@ class ActionManager:
             stream_id: 聊天流 ID（空表示不按流筛选）
             chat_stream: 候选聊天流实例（提供后由其派生完整上下文）
             stream_context: 聊天流上下文（提供后按内容类型过滤）
+            chatter: 当前驱动执行的 Chatter 实例
+            plugin: 归属插件实例（go_activate 签名解析失败时的兜底）
+            message_content: 当前消息内容，供 go_activate 使用
 
         Returns:
-            list[type[LLMUsable]]: 筛选后的 Action 组件类列表
+            list[type[LLMUsable]]: 筛选并激活通过的 Action 组件类列表
         """
         if isinstance(chat_type, ChatType):
             chat_type = chat_type.value
@@ -155,45 +161,27 @@ class ActionManager:
         if stream_context is not None:
             removals.extend(filter_by_associated_types(filtered, stream_context))
 
-        removal_names = {name for name, _ in removals}
-        available = [
-            cls
-            for cls in filtered
-            if (cls.get_signature() or cls.__name__) not in removal_names  # type: ignore[attr-defined]
-        ]
-
+        # 恢复筛选结果日志
+        logger.debug(
+            f"为聊天上下文筛选 Action: chat_type={chat_type}, "
+            f"chatter={chatter_name}, platform={platform}, "
+            f"结果: {len(filtered)}/{len(usables)}"
+        )
         if removals:
             summary = " | ".join(f"{n}({r})" for n, r in removals)
             logger.debug(f"移除 Action 组件: {summary}")
 
-        return available
-
-    async def activate_actions_for_chat(
-        self,
-        actions: list[type["LLMUsable"]],
-        *,
-        chat_stream: "ChatStream",
-        plugin: "BasePlugin | None" = None,
-        message_content: str = "",
-    ) -> list[type["LLMUsable"]]:
-        """对 Action 组件类执行动态激活判定（go_activate）。
-
-        Args:
-            actions: 待判定的 Action 组件类列表
-            chat_stream: 当前聊天流实例
-            plugin: 所属插件实例（缺省时按组件签名解析）
-            message_content: 当前消息内容，供激活判定使用
-
-        Returns:
-            list[type[LLMUsable]]: 激活通过的组件类列表
-        """
+        # 动态激活判定（go_activate）；未提供流上下文时仅做静态筛选
         from src.core.managers import get_plugin_manager
+
+        if chat_stream is None:
+            return filtered
 
         tasks: list[Any] = []
         signatures: list[str] = []
-        kept: list[type["LLMUsable"]] = []
+        available: list[type["LLMUsable"]] = []
 
-        for action_cls in actions:
+        for action_cls in filtered:
             signature = action_cls.get_signature() or action_cls.__name__  # type: ignore[attr-defined]
             # 优先按组件签名解析所属插件；无法解析时回退到传入的 plugin
             action_plugin = None
@@ -211,7 +199,7 @@ class ActionManager:
                 instance._last_message = message_content  # type: ignore[attr-defined]
                 go_activate = getattr(instance, "go_activate", None)
                 if not callable(go_activate):
-                    kept.append(action_cls)
+                    available.append(action_cls)
                     continue
                 tasks.append(go_activate())
                 signatures.append(signature)
@@ -227,15 +215,15 @@ class ActionManager:
                 action_cls = next(
                     (
                         c
-                        for c in actions
+                        for c in filtered
                         if (c.get_signature() or c.__name__) == signature  # type: ignore[attr-defined]
                     ),
                     None,
                 )
                 if action_cls is not None:
-                    kept.append(action_cls)
+                    available.append(action_cls)
 
-        return kept
+        return available
 
     # ── Schema ──
 
@@ -279,7 +267,7 @@ class ActionManager:
         Returns:
             list[dict[str, Any]]: Action schema 列表
         """
-        actions = await self.get_actions_for_chat(
+        actions = await self.filter_actions_for_chat(
             chat_type=chat_type,
             chatter_name=chatter_name,
             platform=platform,

--- a/src/core/managers/action_manager.py
+++ b/src/core/managers/action_manager.py
@@ -1,8 +1,8 @@
 """Action 管理器。
 
-本模块提供 Action 管理器，负责 Action 组件的注册、发现、激活判定和执行。
-Action 是"主动的响应"，通过 LLM Tool Calling 调用。
-管理器维护 Action 组件的全局集合，并根据聊天上下文过滤可用的 Action。
+本模块提供 Action 管理器，负责 Action 组件的注册、发现、作用域筛选、
+动态激活判定、schema 与执行。Action 是"主动的响应"，通过 LLM Tool Calling 调用。
+管理器维护 Action 组件的全局集合，并按传入的组件类集合进行筛选。
 """
 
 from __future__ import annotations
@@ -14,16 +14,23 @@ from src.kernel.llm import LLMUsable
 from src.kernel.concurrency import get_task_manager
 
 from src.core.components.registry import get_global_registry
-from src.core.components.types import ChatType, ComponentType
+from src.core.components.types import ChatType, ComponentType, EventType
 from src.core.components.utils import should_strip_auto_reason_argument
 from src.core.managers.stream_manager import get_stream_manager
 
+from src.core.managers.utils import (
+    build_usable_static_context,
+    filter_by_associated_types,
+    publish_before_filter_event,
+    static_filter_usables,
+)
+
 if TYPE_CHECKING:
     from src.core.components.base.action import BaseAction
+    from src.core.components.base.chatter import BaseChatter
     from src.core.components.base.plugin import BasePlugin
     from src.core.models.message import Message
     from src.core.models.stream import ChatStream, StreamContext
-
 
 logger = get_logger("action_manager")
 
@@ -31,33 +38,33 @@ logger = get_logger("action_manager")
 class ActionManager:
     """Action 管理器。
 
-    负责管理所有 Action 组件，提供查询、过滤和执行接口。
-    根据 ChatType、Chatter 名称等条件过滤可用的 Action。
+    负责管理所有 Action 组件，提供查询、筛选、激活与执行接口。
+    筛选前发布 ``BEFORE_ACTION_FILTER`` 事件，允许外部事件处理器改写组件类集合。
+    筛选逻辑从"按聊天流获取"改为"按传入组件类筛选"，并支持聊天器名称参数。
 
     Attributes:
         _schema_cache: Action schema 缓存
 
     Examples:
         >>> manager = ActionManager()
-        >>> actions = manager.get_actions_for_chat(
-        ...     chat_type=ChatType.PRIVATE,
-        ...     chatter_name="my_chatter"
+        >>> actions = await manager.get_actions_for_chat(
+        ...     usables=[MyAction],
+        ...     chat_type="private",
+        ...     chatter_name="my_chatter",
         ... )
-        >>> schema = manager.get_action_schema("my_plugin:action:send_message")
     """
 
     def __init__(self) -> None:
         """初始化 Action 管理器。"""
         self._schema_cache: dict[str, dict[str, Any]] = {}
 
+    # ── 查询 ──
+
     def get_all_actions(self) -> dict[str, type["BaseAction"]]:
         """获取所有已注册的 Action 组件。
 
         Returns:
             dict[str, type[BaseAction]]: 将签名映射到 Action 类的字典
-
-        Examples:
-            >>> actions = manager.get_all_actions()
         """
         registry = get_global_registry()
         return registry.get_by_type(ComponentType.ACTION)
@@ -70,63 +77,9 @@ class ActionManager:
 
         Returns:
             dict[str, type[BaseAction]]: 将签名映射到 Action 类的字典
-
-        Examples:
-            >>> actions = manager.get_actions_for_plugin("my_plugin")
         """
         registry = get_global_registry()
         return registry.get_by_plugin_and_type(plugin_name, ComponentType.ACTION)
-
-    def get_actions_for_chat(
-        self,
-        chat_type: ChatType = ChatType.ALL,
-        chatter_name: str = "",
-        platform: str = "",
-    ) -> list[type[LLMUsable]]:
-        """获取适用于特定聊天上下文的 Action 组件列表。
-
-        根据 ChatType、Chatter 名称和平台过滤 Action。
-
-        Args:
-            chat_type: 聊天类型（私聊/群聊/全部）
-            chatter_name: Chatter 名称（空字符串表示不限制）
-            platform: 平台名称（空字符串表示不限制）
-
-        Returns:
-            list[type[LLMUsable]]: 可用的 Action 类列表
-
-        Examples:
-            >>> actions = manager.get_actions_for_chat(
-            ...     chat_type=ChatType.PRIVATE,
-            ...     chatter_name="my_chatter"
-            ... )
-        """
-        from src.core.components.usable_filter import (
-            UsableFilterContext,
-            evaluate_usable_filter,
-        )
-
-        all_actions = self.get_all_actions()
-        ctx = UsableFilterContext(
-            stream_id="",
-            chat_type=chat_type.value if isinstance(chat_type, ChatType) else str(chat_type),
-            platform=platform,
-            chatter_name=chatter_name,
-        )
-
-        filtered_actions = []
-        for signature, action_cls in all_actions.items():
-            is_eligible, _ = evaluate_usable_filter(action_cls, ctx)
-            if is_eligible:
-                filtered_actions.append(action_cls)
-
-        logger.debug(
-            f"为聊天上下文筛选 Action: chat_type={ctx.chat_type}, "
-            f"chatter={chatter_name}, platform={platform}, "
-            f"结果: {len(filtered_actions)}/{len(all_actions)}"
-        )
-
-        return filtered_actions
 
     def get_action_class(self, signature: str) -> type["BaseAction"] | None:
         """通过签名获取 Action 类。
@@ -136,12 +89,155 @@ class ActionManager:
 
         Returns:
             type[BaseAction] | None: Action 类，如果未找到则返回 None
-
-        Examples:
-            >>> action_cls = manager.get_action_class("my_plugin:action:send_message")
         """
         registry = get_global_registry()
         return registry.get(signature)
+
+    # ── 筛选与激活 ──
+
+    async def get_actions_for_chat(
+        self,
+        usables: list[type["LLMUsable"]] | None = None,
+        *,
+        chat_type: "ChatType | str" = "all",
+        chatter_name: str = "",
+        platform: str = "",
+        stream_id: str = "",
+        chat_stream: "ChatStream | None" = None,
+        stream_context: "StreamContext | None" = None,
+        chatter: "BaseChatter | None" = None,
+    ) -> list[type["LLMUsable"]]:
+        """获取适用于特定聊天上下文的 Action 组件类列表。
+
+        若传入 ``usables`` 则直接对给定集合筛选（默认筛选不传 stream_id、
+        不获取流，仅按静态维度）；否则从注册表拉取全部 Action。
+
+        Args:
+            usables: 待筛选的组件类列表；不传则取全量注册 Action
+            chat_type: 聊天类型（private / group / all）
+            chatter_name: Chatter 名称
+            platform: 平台名称
+            stream_id: 聊天流 ID（空表示不按流筛选）
+            chat_stream: 候选聊天流实例（提供后由其派生完整上下文）
+            stream_context: 聊天流上下文（提供后按内容类型过滤）
+
+        Returns:
+            list[type[LLMUsable]]: 筛选后的 Action 组件类列表
+        """
+        if isinstance(chat_type, ChatType):
+            chat_type = chat_type.value
+
+        if usables is None:
+            usables = list(self.get_all_actions().values())
+
+        # 筛选前事件钩子：外部处理器可改写组件集合
+        usables = await publish_before_filter_event(
+            EventType.BEFORE_ACTION_FILTER,
+            component_kind="action",
+            usables=usables,
+            stream_id=stream_id or (getattr(chat_stream, "stream_id", "") or ""),
+            chatter_name=chatter_name,
+            stream_context=stream_context,
+        )
+
+        ctx = build_usable_static_context(
+            usables=usables,
+            chat_type=chat_type,
+            chatter_name=chatter_name,
+            platform=platform,
+            stream_id=stream_id,
+            chat_stream=chat_stream,
+            chatter=chatter,
+        )
+
+        filtered, removals = static_filter_usables(usables, ctx)
+
+        if stream_context is not None:
+            removals.extend(filter_by_associated_types(filtered, stream_context))
+
+        removal_names = {name for name, _ in removals}
+        available = [
+            cls
+            for cls in filtered
+            if (cls.get_signature() or cls.__name__) not in removal_names  # type: ignore[attr-defined]
+        ]
+
+        if removals:
+            summary = " | ".join(f"{n}({r})" for n, r in removals)
+            logger.debug(f"移除 Action 组件: {summary}")
+
+        return available
+
+    async def activate_actions_for_chat(
+        self,
+        actions: list[type["LLMUsable"]],
+        *,
+        chat_stream: "ChatStream",
+        plugin: "BasePlugin | None" = None,
+        message_content: str = "",
+    ) -> list[type["LLMUsable"]]:
+        """对 Action 组件类执行动态激活判定（go_activate）。
+
+        Args:
+            actions: 待判定的 Action 组件类列表
+            chat_stream: 当前聊天流实例
+            plugin: 所属插件实例（缺省时按组件签名解析）
+            message_content: 当前消息内容，供激活判定使用
+
+        Returns:
+            list[type[LLMUsable]]: 激活通过的组件类列表
+        """
+        from src.core.managers import get_plugin_manager
+
+        tasks: list[Any] = []
+        signatures: list[str] = []
+        kept: list[type["LLMUsable"]] = []
+
+        for action_cls in actions:
+            signature = action_cls.get_signature() or action_cls.__name__  # type: ignore[attr-defined]
+            # 优先按组件签名解析所属插件；无法解析时回退到传入的 plugin
+            action_plugin = None
+            parts = signature.split(":") if signature else []
+            plugin_name = parts[0] if len(parts) >= 3 else ""
+            if plugin_name:
+                action_plugin = get_plugin_manager().get_plugin(plugin_name)
+            if action_plugin is None:
+                action_plugin = plugin
+            if action_plugin is None:
+                logger.warning(f"未找到 Action 所属插件实例: {signature}，跳过激活判定")
+                continue
+            try:
+                instance = action_cls(chat_stream=chat_stream, plugin=action_plugin)  # type: ignore[call-arg]
+                instance._last_message = message_content  # type: ignore[attr-defined]
+                go_activate = getattr(instance, "go_activate", None)
+                if not callable(go_activate):
+                    kept.append(action_cls)
+                    continue
+                tasks.append(go_activate())
+                signatures.append(signature)
+            except Exception as e:
+                logger.error(f"创建 Action 实例 {signature} 失败: {e}")
+                continue
+
+        if tasks:
+            results = await get_task_manager().gather(*tasks, return_exceptions=True)
+            for signature, result in zip(signatures, results, strict=False):
+                if isinstance(result, Exception) or not result:
+                    continue
+                action_cls = next(
+                    (
+                        c
+                        for c in actions
+                        if (c.get_signature() or c.__name__) == signature  # type: ignore[attr-defined]
+                    ),
+                    None,
+                )
+                if action_cls is not None:
+                    kept.append(action_cls)
+
+        return kept
+
+    # ── Schema ──
 
     def get_action_schema(self, signature: str) -> dict[str, Any] | None:
         """获取 Action 的 Tool Schema。
@@ -153,17 +249,6 @@ class ActionManager:
 
         Returns:
             dict[str, Any] | None: OpenAI Tool Calling 格式的 schema
-
-        Examples:
-            >>> schema = manager.get_action_schema("my_plugin:action:send_message")
-            >>> {
-            ...     "type": "function",
-            ...     "function": {
-            ...         "name": "send_message",
-            ...         "description": "发送消息",
-            ...         "parameters": {...}
-            ...     }
-            ... }
         """
         if signature in self._schema_cache:
             return self._schema_cache[signature]
@@ -176,29 +261,30 @@ class ActionManager:
         self._schema_cache[signature] = schema
         return schema
 
-    def get_action_schemas(
+    async def get_action_schemas(
         self,
-        chat_type: ChatType = ChatType.ALL,
+        chat_type: "ChatType | str" = "all",
         chatter_name: str = "",
         platform: str = "",
+        stream_id: str = "",
     ) -> list[dict[str, Any]]:
         """获取适用于特定聊天上下文的所有 Action Schema。
 
         Args:
-            chat_type: 聊天类型
+            chat_type: 聊天类型（private / group / all）
             chatter_name: Chatter 名称
             platform: 平台名称
+            stream_id: 聊天流 ID
 
         Returns:
             list[dict[str, Any]]: Action schema 列表
-
-        Examples:
-            >>> schemas = manager.get_action_schemas(
-            ...     chat_type=ChatType.PRIVATE,
-            ...     chatter_name="my_chatter"
-            ... )
         """
-        actions = self.get_actions_for_chat(chat_type, chatter_name, platform)
+        actions = await self.get_actions_for_chat(
+            chat_type=chat_type,
+            chatter_name=chatter_name,
+            platform=platform,
+            stream_id=stream_id,
+        )
         schemas = []
 
         for action_cls in actions:
@@ -209,6 +295,19 @@ class ActionManager:
                 schemas.append(schema)
 
         return schemas
+
+    def clear_schema_cache(self, signature: str | None = None) -> None:
+        """清除 schema 缓存。
+
+        Args:
+            signature: 要清除的 Action 签名，None 表示清除全部
+        """
+        if signature:
+            self._schema_cache.pop(signature, None)
+        else:
+            self._schema_cache.clear()
+
+    # ── 执行 ──
 
     async def execute_action(
         self,
@@ -234,14 +333,6 @@ class ActionManager:
         Raises:
             ValueError: 如果 Action 类未找到
             RuntimeError: 如果 Action 执行失败
-
-        Examples:
-            >>> success, result = await manager.execute_action(
-            ...     "my_plugin:action:send_message",
-            ...     plugin,
-            ...     message,
-            ...     content="你好"
-            ... )
         """
         action_cls = self.get_action_class(signature)
         if not action_cls:
@@ -277,19 +368,17 @@ class ActionManager:
 
         # 触发动作调用执行前事件
         try:
-            from src.core.components.types import EventType
+            from src.core.components.types import EventType as _EventType
             from src.kernel.event import get_event_bus
 
             event_bus = get_event_bus()
-            if event_bus.get_subscribers(EventType.BEFORE_ACTION_CALL):
+            if event_bus.get_subscribers(_EventType.BEFORE_ACTION_CALL):
                 _, modified_params = await event_bus.publish(
-                    EventType.BEFORE_ACTION_CALL,
+                    _EventType.BEFORE_ACTION_CALL,
                     {
                         "signature": signature,
-                        "action_name": action_instance.action_name,
-                        "action_description": getattr(
-                            action_instance, "action_description", ""
-                        ),
+                        "action_name": action_instance.name,
+                        "action_description": action_instance.description,
                         "args": dict(kwargs),
                         "message": message,
                     },
@@ -319,19 +408,17 @@ class ActionManager:
 
             # 触发动作调用执行后事件
             try:
-                from src.core.components.types import EventType
+                from src.core.components.types import EventType as _EventType
                 from src.kernel.event import get_event_bus
 
                 event_bus = get_event_bus()
-                if event_bus.get_subscribers(EventType.AFTER_ACTION_CALL):
+                if event_bus.get_subscribers(_EventType.AFTER_ACTION_CALL):
                     _, modified_params = await event_bus.publish(
-                        EventType.AFTER_ACTION_CALL,
+                        _EventType.AFTER_ACTION_CALL,
                         {
                             "signature": signature,
                             "action_name": action_instance.name,
-                            "action_description": getattr(
-                                action_instance, "description", ""
-                            ),
+                            "action_description": action_instance.description,
                             "args": dict(kwargs),
                             "result": result[1],
                             "success": result[0],
@@ -362,13 +449,13 @@ class ActionManager:
 
             # 触发动作调用失败事件
             try:
-                from src.core.components.types import EventType
+                from src.core.components.types import EventType as _EventType
                 from src.kernel.event import get_event_bus
 
                 event_bus = get_event_bus()
-                if event_bus.get_subscribers(EventType.ON_ACTION_CALL_FAILED):
+                if event_bus.get_subscribers(_EventType.ON_ACTION_CALL_FAILED):
                     await event_bus.publish(
-                        EventType.ON_ACTION_CALL_FAILED,
+                        _EventType.ON_ACTION_CALL_FAILED,
                         {
                             "signature": signature,
                             "action_name": action_instance.name,
@@ -389,225 +476,7 @@ class ActionManager:
 
             raise RuntimeError(f"Action 执行失败: {e}") from e
 
-    def clear_schema_cache(self, signature: str | None = None) -> None:
-        """清除 schema 缓存。
-
-        Args:
-            signature: 要清除的 Action 签名，None 表示清除全部
-
-        Examples:
-            >>> # 清除特定 Action 的缓存
-            >>> manager.clear_schema_cache("my_plugin:action:send_message")
-            >>> # 清除全部缓存
-            >>> manager.clear_schema_cache()
-        """
-        if signature:
-            self._schema_cache.pop(signature, None)
-        else:
-            self._schema_cache.clear()
-
-    async def modify_actions(
-        self,
-        stream_id: str,
-        message_content: str = "",
-    ) -> list[str]:
-        """修改动作列表，根据上下文过滤和激活动作。
-
-        这是主方法，协调多个阶段的动作过滤和激活判定：
-        1. 检查动作的关联类型（associated_types）
-        2. 调用 go_activate 方法进行激活判定
-
-        Args:
-            stream_id: 聊天流 ID
-            message_content: 当前消息内容，用于激活判定
-
-        Returns:
-            list[str]: 最终可用的动作签名列表
-
-        Examples:
-            >>> available_actions = await manager.modify_actions(
-            ...     stream_id=stream.stream_id,
-            ...     message_content="你好"
-            ... )
-        """
-        logger.debug(f"[{stream_id}] 开始动作修改流程")
-
-        from src.core.managers.stream_manager import get_stream_manager
-
-        chat_stream = await get_stream_manager().get_or_create_stream(
-            stream_id=stream_id
-        )
-        # 获取所有动作类
-        all_actions = self.get_all_actions()
-        removals: list[tuple[str, str]] = []
-
-        # 第二阶段：检查关联类型
-        type_mismatched = self._check_action_associated_types(
-            all_actions, chat_stream.context
-        )
-        removals.extend(type_mismatched)
-
-        # 第三阶段：激活判定
-        deactivated = await self._get_deactivated_actions_by_type(
-            all_actions, chat_stream, message_content
-        )
-        removals.extend(deactivated)
-
-        # 构建最终可用动作列表
-        available_actions = []
-        for signature in all_actions.keys():
-            if not any(r[0] == signature for r in removals):
-                available_actions.append(signature)
-
-        # 日志记录
-        if removals:
-            removals_summary = " | ".join(
-                [f"{name}({reason})" for name, reason in removals]
-            )
-            logger.info(f"[{stream_id}] 移除动作: {removals_summary}")
-
-        available_text = "、".join(available_actions) if available_actions else "无"
-        logger.info(f"[{chat_stream.stream_id}] 可用动作: {available_text}")
-
-        return available_actions
-
-    def _check_action_associated_types(
-        self,
-        all_actions: dict[str, type["BaseAction"]],
-        chat_context: "StreamContext",
-    ) -> list[tuple[str, str]]:
-        """检查动作的关联类型。
-
-        Args:
-            all_actions: 所有动作类字典
-            chat_context: 聊天流上下文
-
-        Returns:
-            list[tuple[str, str]]: 需要移除的 (动作签名, 原因) 列表
-
-        Examples:
-            >>> removals = manager._check_action_associated_types(
-            ...     actions, context
-            ... )
-        """
-        type_mismatched: list[tuple[str, str]] = []
-
-        for signature, action_cls in all_actions.items():
-            required_types = action_cls.validate_associated_types()
-            if not chat_context.check_types(required_types):
-                types_str = ", ".join(required_types)
-                reason = f"适配器不支持（需要: {types_str}）"
-                type_mismatched.append((signature, reason))
-                logger.debug(f"[移除动作] {signature}：{reason}")
-
-        return type_mismatched
-
-    async def _get_deactivated_actions_by_type(
-        self,
-        actions_dict: dict[str, type["BaseAction"]],
-        chat_stream: "ChatStream",
-        message_content: str = "",
-    ) -> list[tuple[str, str]]:
-        """根据激活类型判定返回需要停用的动作列表。
-
-        并行调用每个 Action 的 go_activate 方法进行激活判定。
-
-        Args:
-            actions_dict: 动作字典
-            chat_stream: 聊天流实例
-            message_content: 消息内容
-
-        Returns:
-            list[tuple[str, str]]: 需要停用的 (动作签名, 原因) 列表
-
-        Examples:
-            >>> deactivated = await manager._get_deactivated_actions_by_type(
-            ...     actions, stream, "你好"
-            ... )
-        """
-        from src.core.managers import get_plugin_manager
-
-        deactivated_actions: list[tuple[str, str]] = []
-        plugin_manager = get_plugin_manager()
-
-        # 创建并行任务列表
-        tasks = []
-        signatures = []
-
-        for signature, action_cls in actions_dict.items():
-            # 从签名中提取 plugin_name（格式：plugin_name:component_type:component_name）
-            parts = signature.split(":")
-            if len(parts) < 3:
-                logger.warning(f"无效的 Action 签名格式: {signature}，跳过")
-                continue
-
-            plugin_name = parts[0]
-
-            # 获取真实的 plugin 实例
-            plugin = plugin_manager.get_plugin(plugin_name)
-            if not plugin:
-                logger.warning(
-                    f"未找到 Plugin 实例: {plugin_name}，跳过 Action: {signature}"
-                )
-                deactivated_actions.append(
-                    (signature, f"未找到 Plugin 实例: {plugin_name}")
-                )
-                continue
-
-            # 创建 Action 实例
-            try:
-                action_instance = action_cls(chat_stream=chat_stream, plugin=plugin)
-                # 设置消息内容供 go_activate 使用
-                action_instance._last_message = message_content
-
-                # 创建 go_activate 任务
-                task = action_instance.go_activate()
-                tasks.append(task)
-                signatures.append(signature)
-
-            except Exception as e:
-                logger.error(f"创建 Action 实例 {signature} 失败: {e}")
-                deactivated_actions.append((signature, f"创建实例失败: {e}"))
-
-        # 并行执行所有激活判断
-        if tasks:
-            logger.debug(
-                f"[{chat_stream.stream_id}] 并行执行激活判断，任务数: {len(tasks)}"
-            )
-            try:
-                results = await get_task_manager().gather(
-                    *tasks, return_exceptions=True
-                )
-
-                # 处理结果
-                for signature, result in zip(signatures, results, strict=False):
-                    if isinstance(result, Exception):
-                        logger.error(
-                            f"[{chat_stream.stream_id}] 激活判断 {signature} 时出错: {result}"
-                        )
-                        deactivated_actions.append(
-                            (signature, f"激活判断出错: {result}")
-                        )
-                    elif not result:
-                        # go_activate 返回 False，不激活
-                        deactivated_actions.append(
-                            (signature, "go_activate 返回 False")
-                        )
-                        logger.debug(
-                            f"[{chat_stream.stream_id}] 未激活动作: {signature}"
-                        )
-                    else:
-                        # go_activate 返回 True，激活
-                        logger.debug(f"[{chat_stream.stream_id}] 激活动作: {signature}")
-
-            except Exception as e:
-                logger.error(f"[{chat_stream.stream_id}] 并行激活判断失败: {e}")
-                # 如果并行执行失败，将所有动作标记为不激活
-                deactivated_actions.extend(
-                    (sig, f"并行判断失败: {e}") for sig in signatures
-                )
-
-        return deactivated_actions
+    # ── 内部 ──
 
     def _build_signature(self, action_cls: type["BaseAction"]) -> str:
         """构建 Action 组件签名。
@@ -647,10 +516,6 @@ def get_action_manager() -> ActionManager:
 
     Returns:
         ActionManager: 全局 Action 管理器单例
-
-    Examples:
-        >>> manager = get_action_manager()
-        >>> actions = manager.get_actions_for_chat(ChatType.PRIVATE)
     """
     global _global_action_manager
     if _global_action_manager is None:

--- a/src/core/managers/agent_manager.py
+++ b/src/core/managers/agent_manager.py
@@ -1,0 +1,395 @@
+"""Agent 组件管理器。
+
+本模块提供 AgentManager，负责 Agent 组件类的查询、作用域筛选、动态激活判定、
+筛选前事件发布、schema 查询与执行，是 agent_api 的底层实现。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.core.components.registry import get_global_registry
+from src.core.components.types import ChatType, ComponentType, EventType
+from src.core.components.utils import should_strip_auto_reason_argument
+from src.kernel.concurrency import get_task_manager
+from src.kernel.logger import get_logger
+
+from src.core.managers.utils import (
+    build_usable_static_context,
+    filter_by_associated_types,
+    publish_before_filter_event,
+    static_filter_usables,
+)
+
+if TYPE_CHECKING:
+    from src.core.components.base.agent import BaseAgent
+    from src.core.components.base.chatter import BaseChatter
+    from src.core.components.base.plugin import BasePlugin
+    from src.core.models.stream import ChatStream, StreamContext
+    from src.kernel.llm import LLMUsable
+
+logger = get_logger("agent_manager")
+
+
+class AgentManager:
+    """Agent 组件管理器。
+
+    管理 Agent 组件类的注册查询、作用域筛选、动态激活判定、schema 查询与执行。
+    筛选前发布 ``BEFORE_AGENT_FILTER`` 事件，允许外部事件处理器改写组件类集合。
+
+    Examples:
+        >>> manager = AgentManager()
+        >>> agents = await manager.get_agents_for_chat(
+        ...     usables=[AssistantAgent],
+        ...     chat_type="private",
+        ...     chatter_name="my_chatter",
+        ...     stream_id="",
+        ... )
+    """
+
+    def __init__(self) -> None:
+        """初始化 Agent 组件管理器。"""
+        self._schema_cache: dict[str, dict[str, Any]] = {}
+
+    # ── 查询 ──
+
+    def get_all_agents(self) -> dict[str, type["BaseAgent"]]:
+        """获取所有已注册的 Agent 组件类。
+
+        Returns:
+            dict[str, type[BaseAgent]]: 签名到 Agent 类的映射
+        """
+        registry = get_global_registry()
+        return registry.get_by_type(ComponentType.AGENT)
+
+    def get_agents_for_plugin(self, plugin_name: str) -> dict[str, type["BaseAgent"]]:
+        """获取指定插件的所有 Agent 组件类。
+
+        Args:
+            plugin_name: 插件名称
+
+        Returns:
+            dict[str, type[BaseAgent]]: 签名到 Agent 类的映射
+        """
+        registry = get_global_registry()
+        return registry.get_by_plugin_and_type(plugin_name, ComponentType.AGENT)
+
+    def get_agent_class(self, signature: str) -> type["BaseAgent"] | None:
+        """通过签名获取 Agent 类。
+
+        Args:
+            signature: Agent 组件签名
+
+        Returns:
+            type[BaseAgent] | None: Agent 类，未找到则返回 None
+        """
+        registry = get_global_registry()
+        return registry.get(signature)
+
+    # ── 筛选与激活 ──
+
+    async def get_agents_for_chat(
+        self,
+        usables: list[type["LLMUsable"]] | None = None,
+        *,
+        chat_type: "ChatType | str" = "all",
+        chatter_name: str = "",
+        platform: str = "",
+        stream_id: str = "",
+        chat_stream: "ChatStream | None" = None,
+        stream_context: "StreamContext | None" = None,
+        chatter: "BaseChatter | None" = None,
+    ) -> list[type["LLMUsable"]]:
+        """获取适用于指定聊天上下文的 Agent 组件类列表。
+
+        若传入 ``usables`` 则直接对给定集合筛选（默认筛选不传 stream_id、
+        不获取流，仅按静态维度）；否则从注册表拉取全部 Agent。
+
+        Args:
+            usables: 待筛选的组件类列表；不传则取全量注册 Agent
+            chat_type: 聊天类型（private / group / all）
+            chatter_name: Chatter 名称
+            platform: 平台标识
+            stream_id: 聊天流 ID（空表示不按流筛选）
+            chat_stream: 候选聊天流实例（提供后由其派生完整上下文）
+            stream_context: 聊天流上下文（提供后按内容类型过滤）
+
+        Returns:
+            list[type[LLMUsable]]: 筛选后的 Agent 组件类列表
+        """
+        if isinstance(chat_type, ChatType):
+            chat_type = chat_type.value
+
+        if usables is None:
+            usables = list(self.get_all_agents().values())
+
+        usables = await publish_before_filter_event(
+            EventType.BEFORE_AGENT_FILTER,
+            component_kind="agent",
+            usables=usables,
+            stream_id=stream_id or (getattr(chat_stream, "stream_id", "") or ""),
+            chatter_name=chatter_name,
+            stream_context=stream_context,
+        )
+
+        ctx = build_usable_static_context(
+            usables=usables,
+            chat_type=chat_type,
+            chatter_name=chatter_name,
+            platform=platform,
+            stream_id=stream_id,
+            chat_stream=chat_stream,
+            chatter=chatter,
+        )
+
+        filtered, removals = static_filter_usables(usables, ctx)
+
+        if stream_context is not None:
+            removals.extend(filter_by_associated_types(filtered, stream_context))
+
+        removal_names = {name for name, _ in removals}
+        available = [
+            cls for cls in filtered if (cls.get_signature() or cls.__name__) not in removal_names  # type: ignore[attr-defined]
+        ]
+
+        if removals:
+            summary = " | ".join(f"{n}({r})" for n, r in removals)
+            logger.debug(f"移除 Agent 组件: {summary}")
+
+        return available
+
+    async def activate_agents_for_chat(
+        self,
+        agents: list[type["LLMUsable"]],
+        *,
+        chat_stream: "ChatStream",
+        plugin: "BasePlugin | None" = None,
+    ) -> list[type["LLMUsable"]]:
+        """对 Agent 组件类执行动态激活判定（go_activate）。
+
+        Args:
+            agents: 待判定的 Agent 组件类列表
+            chat_stream: 当前聊天流实例
+            plugin: 所属插件实例（缺省时按组件签名解析）
+
+        Returns:
+            list[type[LLMUsable]]: 激活通过的组件类列表
+        """
+        tasks = []
+        signatures = []
+        kept = []
+
+        for agent_cls in agents:
+            signature = agent_cls.get_signature() or agent_cls.__name__  # type: ignore[attr-defined]
+            # 优先按组件签名解析所属插件；无法解析时回退到传入的 plugin
+            agent_plugin = self._resolve_agent_plugin(signature)
+            if agent_plugin is None:
+                agent_plugin = plugin
+            if agent_plugin is None:
+                logger.warning(f"未找到 Agent 所属插件实例: {signature}，跳过激活判定")
+                continue
+            try:
+                instance = agent_cls(stream_id=chat_stream.stream_id, plugin=agent_plugin)  # type: ignore[call-arg]
+                go_activate = getattr(instance, "go_activate", None)
+                if not callable(go_activate):
+                    kept.append(agent_cls)
+                    continue
+                tasks.append(go_activate())
+                signatures.append(signature)
+            except Exception as e:
+                logger.error(f"创建 Agent 实例 {signature} 失败: {e}")
+                continue
+
+        if tasks:
+            results = await get_task_manager().gather(*tasks, return_exceptions=True)
+            for signature, result in zip(signatures, results, strict=False):
+                if isinstance(result, Exception) or not result:
+                    continue
+                agent_cls = next(
+                    (
+                        c
+                        for c in agents
+                        if (c.get_signature() or c.__name__) == signature  # type: ignore[attr-defined]
+                    ),
+                    None,
+                )
+                if agent_cls is not None:
+                    kept.append(agent_cls)
+
+        return kept
+
+    # ── Schema ──
+
+    def get_agent_schema(self, signature: str) -> dict[str, Any] | None:
+        """获取 Agent 的 Tool Schema。
+
+        Args:
+            signature: Agent 组件签名
+
+        Returns:
+            dict[str, Any] | None: Tool Schema，未找到则返回 None
+        """
+        if signature in self._schema_cache:
+            return self._schema_cache[signature]
+
+        agent_cls = self.get_agent_class(signature)
+        if not agent_cls:
+            return None
+        schema = agent_cls.to_schema()
+        self._schema_cache[signature] = schema
+        return schema
+
+    def get_agent_usables(self, signature: str) -> list[type["LLMUsable"]]:
+        """获取 Agent 的专属 usables 列表。
+
+        Args:
+            signature: Agent 组件签名
+
+        Returns:
+            list[type[LLMUsable]]: Agent 专属的 usables 类列表
+        """
+        agent_cls = self.get_agent_class(signature)
+        if not agent_cls:
+            return []
+        return agent_cls.get_local_usables()
+
+    def get_agent_usable_schemas(self, signature: str) -> list[dict[str, Any]]:
+        """获取 Agent 专属 usables 的 Schema 列表。
+
+        Args:
+            signature: Agent 组件签名
+
+        Returns:
+            list[dict[str, Any]]: usables 的 Tool Schema 列表
+        """
+        agent_cls = self.get_agent_class(signature)
+        if not agent_cls:
+            return []
+        return agent_cls.get_local_usable_schemas()
+
+    def clear_schema_cache(self, signature: str | None = None) -> None:
+        """清除 schema 缓存。
+
+        Args:
+            signature: 要清除的 Agent 签名；None 表示清除全部
+        """
+        if signature:
+            self._schema_cache.pop(signature, None)
+        else:
+            self._schema_cache.clear()
+
+    # ── 执行 ──
+
+    async def execute_agent(
+        self,
+        signature: str,
+        plugin: "BasePlugin",
+        stream_id: str,
+        **kwargs: Any,
+    ) -> tuple[bool, str | dict]:
+        """执行 Agent。创建 Agent 实例并调用其 execute 方法。
+
+        Args:
+            signature: Agent 组件签名
+            plugin: 插件实例
+            stream_id: 聊天流 ID
+            **kwargs: 传递给 Agent 的参数
+
+        Returns:
+            tuple[bool, str | dict]: (是否成功, 结果) 或 (是否成功, 错误消息)
+
+        Raises:
+            ValueError: Agent 类未找到时抛出
+            RuntimeError: Agent 执行失败时抛出
+        """
+        agent_cls = self.get_agent_class(signature)
+        if not agent_cls:
+            raise ValueError(f"Agent 类未找到: {signature}")
+
+        agent_instance = agent_cls(stream_id=stream_id, plugin=plugin)
+
+        if should_strip_auto_reason_argument(agent_instance.execute, kwargs):
+            kwargs.pop("reason", None)
+
+        try:
+            result = await agent_instance._wrap_execute(**kwargs).wait_done()
+            return result
+        except Exception as e:
+            logger.error(f"执行 Agent 失败 ({signature}): {e}", exc_info=True)
+            raise RuntimeError(f"Agent 执行失败: {e}") from e
+
+    async def execute_agent_usable(
+        self,
+        signature: str,
+        plugin: "BasePlugin",
+        stream_id: str,
+        usable_name: str,
+        **kwargs: Any,
+    ) -> tuple[bool, Any]:
+        """执行 Agent 的专属 usable。
+
+        Args:
+            signature: Agent 组件签名
+            plugin: 插件实例
+            stream_id: 聊天流 ID
+            usable_name: usable 名称
+            **kwargs: 传递给 usable 的参数
+
+        Returns:
+            tuple[bool, Any]: 执行是否成功与结果
+
+        Raises:
+            ValueError: Agent 类未找到时抛出
+            RuntimeError: Agent usable 执行失败时抛出
+        """
+        agent_cls = self.get_agent_class(signature)
+        if not agent_cls:
+            raise ValueError(f"Agent 类未找到: {signature}")
+
+        agent_instance = agent_cls(stream_id=stream_id, plugin=plugin)
+
+        try:
+            result = await agent_instance.execute_local_usable(usable_name=usable_name, **kwargs)
+            return result
+        except Exception as e:
+            logger.error(f"执行 Agent usable 失败 ({signature}.{usable_name}): {e}", exc_info=True)
+            raise RuntimeError(f"Agent usable 执行失败: {e}") from e
+
+    # ── 内部 ──
+
+    def _resolve_agent_plugin(self, signature: str) -> "BasePlugin | None":
+        """根据组件签名解析其所属插件实例。
+
+        Args:
+            signature: Agent 组件签名
+
+        Returns:
+            BasePlugin | None: 解析到的插件实例；无法解析时返回 None
+        """
+        try:
+            from src.core.managers import get_plugin_manager
+            from src.core.components.types import parse_signature
+
+            plugin_name = parse_signature(signature)["plugin_name"]
+            return get_plugin_manager().get_plugin(plugin_name)
+        except Exception:
+            return None
+
+
+# 全局 Agent 管理器实例
+_global_agent_manager: AgentManager | None = None
+
+
+def get_agent_manager() -> AgentManager:
+    """获取全局 Agent 管理器实例。
+
+    Returns:
+        AgentManager: 全局 Agent 管理器单例
+    """
+    global _global_agent_manager
+    if _global_agent_manager is None:
+        _global_agent_manager = AgentManager()
+    return _global_agent_manager
+
+
+__all__ = ["AgentManager", "get_agent_manager"]

--- a/src/core/managers/agent_manager.py
+++ b/src/core/managers/agent_manager.py
@@ -90,7 +90,7 @@ class AgentManager:
 
     async def filter_agents_for_chat(
         self,
-        usables: list[type["LLMUsable"]] | None = None,
+        usables: list[type["LLMUsable"]],
         *,
         chat_type: "ChatType | str" = "all",
         chatter_name: str = "",
@@ -103,13 +103,12 @@ class AgentManager:
     ) -> list[type["LLMUsable"]]:
         """筛选适用于特定聊天上下文的 Agent 组件类列表。
 
-        一个函数完成完整筛选流程：静态维度过滤（部署期）+ 筛选前事件钩子 +
-        动态 go_activate 激活。传入 ``usables`` 则直接筛给定集合；否则从注册表
-        拉取全部 Agent（获取另由 ``get_all_agents`` 负责）。未提供流上下文时
-        仅做静态筛选。
+        只负责筛选：对传入的 ``usables`` 完成静态维度过滤（部署期）+
+        筛选前事件钩子 + 动态 go_activate 激活。拉取全量由 ``get_all_agents``
+        单独承担，调用方需自行获取后传入。未提供流上下文时仅做静态筛选。
 
         Args:
-            usables: 待筛选的组件类列表；不传则取全量注册 Agent
+            usables: 待筛选的组件类列表（必填，由调用方传入）
             chat_type: 聊天类型（private / group / all）
             chatter_name: Chatter 名称
             platform: 平台标识
@@ -124,9 +123,6 @@ class AgentManager:
         """
         if isinstance(chat_type, ChatType):
             chat_type = chat_type.value
-
-        if usables is None:
-            usables = list(self.get_all_agents().values())
 
         usables = await publish_before_filter_event(
             EventType.BEFORE_AGENT_FILTER,

--- a/src/core/managers/agent_manager.py
+++ b/src/core/managers/agent_manager.py
@@ -39,7 +39,7 @@ class AgentManager:
 
     Examples:
         >>> manager = AgentManager()
-        >>> agents = await manager.get_agents_for_chat(
+        >>> agents = await manager.filter_agents_for_chat(
         ...     usables=[AssistantAgent],
         ...     chat_type="private",
         ...     chatter_name="my_chatter",
@@ -86,9 +86,9 @@ class AgentManager:
         registry = get_global_registry()
         return registry.get(signature)
 
-    # ── 筛选与激活 ──
+    # ── 筛选 ──
 
-    async def get_agents_for_chat(
+    async def filter_agents_for_chat(
         self,
         usables: list[type["LLMUsable"]] | None = None,
         *,
@@ -99,11 +99,14 @@ class AgentManager:
         chat_stream: "ChatStream | None" = None,
         stream_context: "StreamContext | None" = None,
         chatter: "BaseChatter | None" = None,
+        plugin: "BasePlugin | None" = None,
     ) -> list[type["LLMUsable"]]:
-        """获取适用于指定聊天上下文的 Agent 组件类列表。
+        """筛选适用于特定聊天上下文的 Agent 组件类列表。
 
-        若传入 ``usables`` 则直接对给定集合筛选（默认筛选不传 stream_id、
-        不获取流，仅按静态维度）；否则从注册表拉取全部 Agent。
+        一个函数完成完整筛选流程：静态维度过滤（部署期）+ 筛选前事件钩子 +
+        动态 go_activate 激活。传入 ``usables`` 则直接筛给定集合；否则从注册表
+        拉取全部 Agent（获取另由 ``get_all_agents`` 负责）。未提供流上下文时
+        仅做静态筛选。
 
         Args:
             usables: 待筛选的组件类列表；不传则取全量注册 Agent
@@ -113,9 +116,11 @@ class AgentManager:
             stream_id: 聊天流 ID（空表示不按流筛选）
             chat_stream: 候选聊天流实例（提供后由其派生完整上下文）
             stream_context: 聊天流上下文（提供后按内容类型过滤）
+            chatter: 当前驱动执行的 Chatter 实例
+            plugin: 归属插件实例（go_activate 签名解析失败时的兜底）
 
         Returns:
-            list[type[LLMUsable]]: 筛选后的 Agent 组件类列表
+            list[type[LLMUsable]]: 筛选并激活通过的 Agent 组件类列表
         """
         if isinstance(chat_type, ChatType):
             chat_type = chat_type.value
@@ -147,39 +152,25 @@ class AgentManager:
         if stream_context is not None:
             removals.extend(filter_by_associated_types(filtered, stream_context))
 
-        removal_names = {name for name, _ in removals}
-        available = [
-            cls for cls in filtered if (cls.get_signature() or cls.__name__) not in removal_names  # type: ignore[attr-defined]
-        ]
-
+        # 恢复筛选结果日志
+        logger.debug(
+            f"为聊天上下文筛选 Agent: chat_type={chat_type}, "
+            f"chatter={chatter_name}, platform={platform}, "
+            f"结果: {len(filtered)}/{len(usables)}"
+        )
         if removals:
             summary = " | ".join(f"{n}({r})" for n, r in removals)
             logger.debug(f"移除 Agent 组件: {summary}")
 
-        return available
+        # 动态激活判定（go_activate）；未提供流上下文时仅做静态筛选
+        if chat_stream is None:
+            return filtered
 
-    async def activate_agents_for_chat(
-        self,
-        agents: list[type["LLMUsable"]],
-        *,
-        chat_stream: "ChatStream",
-        plugin: "BasePlugin | None" = None,
-    ) -> list[type["LLMUsable"]]:
-        """对 Agent 组件类执行动态激活判定（go_activate）。
+        tasks: list[Any] = []
+        signatures: list[str] = []
+        available: list[type["LLMUsable"]] = []
 
-        Args:
-            agents: 待判定的 Agent 组件类列表
-            chat_stream: 当前聊天流实例
-            plugin: 所属插件实例（缺省时按组件签名解析）
-
-        Returns:
-            list[type[LLMUsable]]: 激活通过的组件类列表
-        """
-        tasks = []
-        signatures = []
-        kept = []
-
-        for agent_cls in agents:
+        for agent_cls in filtered:
             signature = agent_cls.get_signature() or agent_cls.__name__  # type: ignore[attr-defined]
             # 优先按组件签名解析所属插件；无法解析时回退到传入的 plugin
             agent_plugin = self._resolve_agent_plugin(signature)
@@ -192,7 +183,7 @@ class AgentManager:
                 instance = agent_cls(stream_id=chat_stream.stream_id, plugin=agent_plugin)  # type: ignore[call-arg]
                 go_activate = getattr(instance, "go_activate", None)
                 if not callable(go_activate):
-                    kept.append(agent_cls)
+                    available.append(agent_cls)
                     continue
                 tasks.append(go_activate())
                 signatures.append(signature)
@@ -208,15 +199,15 @@ class AgentManager:
                 agent_cls = next(
                     (
                         c
-                        for c in agents
+                        for c in filtered
                         if (c.get_signature() or c.__name__) == signature  # type: ignore[attr-defined]
                     ),
                     None,
                 )
                 if agent_cls is not None:
-                    kept.append(agent_cls)
+                    available.append(agent_cls)
 
-        return kept
+        return available
 
     # ── Schema ──
 

--- a/src/core/managers/tool_manager/__init__.py
+++ b/src/core/managers/tool_manager/__init__.py
@@ -2,5 +2,16 @@
 
 from .tool_use import ToolUse, get_tool_use
 from .mcp_manager import MCPManager, get_mcp_manager
+from .manager import (
+    ToolComponentManager,
+    get_tool_component_manager,
+)
 
-__all__ = ["ToolUse", "get_tool_use", "MCPManager", "get_mcp_manager"]
+__all__ = [
+    "ToolUse",
+    "get_tool_use",
+    "MCPManager",
+    "get_mcp_manager",
+    "ToolComponentManager",
+    "get_tool_component_manager",
+]

--- a/src/core/managers/tool_manager/manager.py
+++ b/src/core/managers/tool_manager/manager.py
@@ -89,7 +89,7 @@ class ToolComponentManager:
 
     async def filter_tools_for_chat(
         self,
-        usables: list[type["LLMUsable"]] | None = None,
+        usables: list[type["LLMUsable"]],
         *,
         chat_type: "ChatType | str" = "all",
         chatter_name: str = "",
@@ -101,12 +101,12 @@ class ToolComponentManager:
     ) -> list[type["LLMUsable"]]:
         """筛选适用于特定聊天上下文的 Tool 组件类列表。
 
-        Tool 组件仅做部署期静态维度过滤（含筛选前事件钩子），不涉及动态激活
-        （``BaseTool`` 无 ``go_activate``）。传入 ``usables`` 则直接筛给定集合；
-        否则从注册表拉取全部 Tool（获取另由 ``get_all_tools`` 负责）。
+        只负责筛选：Tool 组件仅做部署期静态维度过滤（含筛选前事件钩子），
+        不涉及动态激活（``BaseTool`` 无 ``go_activate``）。拉取全量由
+        ``get_all_tools`` 单独承担，调用方需自行获取后传入。
 
         Args:
-            usables: 待筛选的组件类列表；不传则取全量注册 Tool
+            usables: 待筛选的组件类列表（必填，由调用方传入）
             chat_type: 聊天类型（private / group / all）
             chatter_name: Chatter 名称
             platform: 平台标识
@@ -120,9 +120,6 @@ class ToolComponentManager:
         """
         if isinstance(chat_type, ChatType):
             chat_type = chat_type.value
-
-        if usables is None:
-            usables = list(self.get_all_tools().values())
 
         # 筛选前事件钩子：外部处理器可改写组件集合
         usables = await publish_before_filter_event(

--- a/src/core/managers/tool_manager/manager.py
+++ b/src/core/managers/tool_manager/manager.py
@@ -12,7 +12,6 @@ from typing import TYPE_CHECKING, Any
 
 from src.core.components.registry import get_global_registry
 from src.core.components.types import ChatType, ComponentType, EventType
-from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger
 
 from src.core.managers.utils import (
@@ -24,9 +23,7 @@ from src.core.managers.utils import (
 
 if TYPE_CHECKING:
     from src.core.components.base.chatter import BaseChatter
-    from src.core.components.base.plugin import BasePlugin
     from src.core.components.base.tool import BaseTool
-    from src.core.models.message import Message
     from src.core.models.stream import ChatStream, StreamContext
     from src.kernel.llm import LLMUsable
 
@@ -41,7 +38,7 @@ class ToolComponentManager:
 
     Examples:
         >>> manager = ToolComponentManager()
-        >>> tools = await manager.get_tools_for_chat(
+        >>> tools = await manager.filter_tools_for_chat(
         ...     usables=[CalculatorTool, TranslatorTool],
         ...     chat_type="private",
         ...     chatter_name="my_chatter",
@@ -88,9 +85,9 @@ class ToolComponentManager:
         registry = get_global_registry()
         return registry.get(signature)
 
-    # ── 筛选与激活 ──
+    # ── 筛选 ──
 
-    async def get_tools_for_chat(
+    async def filter_tools_for_chat(
         self,
         usables: list[type["LLMUsable"]] | None = None,
         *,
@@ -102,10 +99,11 @@ class ToolComponentManager:
         stream_context: "StreamContext | None" = None,
         chatter: "BaseChatter | None" = None,
     ) -> list[type["LLMUsable"]]:
-        """获取适用于指定聊天上下文的 Tool 组件类列表。
+        """筛选适用于特定聊天上下文的 Tool 组件类列表。
 
-        若传入 ``usables`` 则直接对给定集合筛选（默认筛选不传 stream_id、
-        不获取流，仅按静态维度）；否则从注册表拉取全部 Tool。
+        Tool 组件仅做部署期静态维度过滤（含筛选前事件钩子），不涉及动态激活
+        （``BaseTool`` 无 ``go_activate``）。传入 ``usables`` 则直接筛给定集合；
+        否则从注册表拉取全部 Tool（获取另由 ``get_all_tools`` 负责）。
 
         Args:
             usables: 待筛选的组件类列表；不传则取全量注册 Tool
@@ -115,6 +113,7 @@ class ToolComponentManager:
             stream_id: 聊天流 ID（空表示不按流筛选）
             chat_stream: 候选聊天流实例（提供后由其派生完整上下文）
             stream_context: 聊天流上下文（提供后按内容类型过滤）
+            chatter: 当前驱动执行的 Chatter 实例
 
         Returns:
             list[type[LLMUsable]]: 筛选后的 Tool 组件类列表
@@ -150,82 +149,17 @@ class ToolComponentManager:
         if stream_context is not None:
             removals.extend(filter_by_associated_types(filtered, stream_context))
 
-        removal_names = {name for name, _ in removals}
-        available = [
-            cls for cls in filtered if (cls.get_signature() or cls.__name__) not in removal_names  # type: ignore[attr-defined]
-        ]
-
+        # 恢复筛选结果日志
+        logger.debug(
+            f"为聊天上下文筛选 Tool: chat_type={chat_type}, "
+            f"chatter={chatter_name}, platform={platform}, "
+            f"结果: {len(filtered)}/{len(usables)}"
+        )
         if removals:
             summary = " | ".join(f"{n}({r})" for n, r in removals)
             logger.debug(f"移除 Tool 组件: {summary}")
 
-        return available
-
-    async def activate_tools_for_chat(
-        self,
-        tools: list[type["LLMUsable"]],
-        *,
-        chat_stream: "ChatStream",
-        plugin: "BasePlugin | None" = None,
-        message: "Message | None" = None,
-    ) -> list[type["LLMUsable"]]:
-        """对 Tool 组件类执行动态激活判定（go_activate）。
-
-        Args:
-            tools: 待判定的 Tool 组件类列表
-            chat_stream: 当前聊天流实例
-            plugin: 所属插件实例（缺省时按组件签名解析）
-            message: 触发消息（用于绑定运行时上下文）
-
-        Returns:
-            list[type[LLMUsable]]: 激活通过的组件类列表
-        """
-        tasks = []
-        signatures = []
-        kept = []
-
-        for tool_cls in tools:
-            signature = tool_cls.get_signature() or tool_cls.__name__  # type: ignore[attr-defined]
-            # 优先按组件签名解析所属插件；无法解析时回退到传入的 plugin
-            tool_plugin = self._resolve_tool_plugin(signature)
-            if tool_plugin is None:
-                tool_plugin = plugin
-            if tool_plugin is None:
-                logger.warning(f"未找到 Tool 所属插件实例: {signature}，跳过激活判定")
-                continue
-            try:
-                instance = tool_cls(plugin=tool_plugin)  # type: ignore[call-arg]
-                instance._bind_runtime_context(  # type: ignore[attr-defined]
-                    stream_id=chat_stream.stream_id,
-                    message=message,
-                )
-                go_activate = getattr(instance, "go_activate", None)
-                if not callable(go_activate):
-                    kept.append(tool_cls)
-                    continue
-                tasks.append(go_activate())
-                signatures.append(signature)
-            except Exception as e:
-                logger.error(f"创建 Tool 实例 {signature} 失败: {e}")
-                continue
-
-        if tasks:
-            results = await get_task_manager().gather(*tasks, return_exceptions=True)
-            for signature, result in zip(signatures, results, strict=False):
-                if isinstance(result, Exception) or not result:
-                    continue
-                tool_cls = next(
-                    (
-                        c
-                        for c in tools
-                        if (c.get_signature() or c.__name__) == signature  # type: ignore[attr-defined]
-                    ),
-                    None,
-                )
-                if tool_cls is not None:
-                    kept.append(tool_cls)
-
-        return kept
+        return filtered
 
     # ── Schema ──
 
@@ -259,28 +193,7 @@ class ToolComponentManager:
         else:
             self._schema_cache.clear()
 
-    # ── 内部 ──
-
-    def _resolve_tool_plugin(self, signature: str) -> "BasePlugin | None":
-        """根据组件签名解析其所属插件实例。
-
-        Args:
-            signature: Tool 组件签名
-
-        Returns:
-            BasePlugin | None: 解析到的插件实例；无法解析时返回 None
-        """
-        try:
-            from src.core.managers import get_plugin_manager
-            from src.core.components.types import parse_signature
-
-            plugin_name = parse_signature(signature)["plugin_name"]
-            return get_plugin_manager().get_plugin(plugin_name)
-        except Exception:
-            return None
-
-
-# 全局工具组件管理器实例
+    # 全局工具组件管理器实例
 _global_tool_component_manager: ToolComponentManager | None = None
 
 

--- a/src/core/managers/tool_manager/manager.py
+++ b/src/core/managers/tool_manager/manager.py
@@ -1,0 +1,299 @@
+"""工具组件管理器。
+
+本模块提供 ToolComponentManager，负责 Tool 组件类的查询、作用域筛选、
+动态激活判定、筛选前事件发布与 schema 查询，是 tool_api 的底层实现。
+与 ToolUse（负责单次工具执行）分工：本管理器负责「选出该给 LLM 哪些工具」，
+ToolUse 负责「执行选中的工具」。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.core.components.registry import get_global_registry
+from src.core.components.types import ChatType, ComponentType, EventType
+from src.kernel.concurrency import get_task_manager
+from src.kernel.logger import get_logger
+
+from src.core.managers.utils import (
+    build_usable_static_context,
+    filter_by_associated_types,
+    publish_before_filter_event,
+    static_filter_usables,
+)
+
+if TYPE_CHECKING:
+    from src.core.components.base.chatter import BaseChatter
+    from src.core.components.base.plugin import BasePlugin
+    from src.core.components.base.tool import BaseTool
+    from src.core.models.message import Message
+    from src.core.models.stream import ChatStream, StreamContext
+    from src.kernel.llm import LLMUsable
+
+logger = get_logger("tool_manager")
+
+
+class ToolComponentManager:
+    """工具组件管理器。
+
+    管理 Tool 组件类的注册查询、作用域筛选、动态激活判定与 schema 查询。
+    筛选前发布 ``BEFORE_TOOL_FILTER`` 事件，允许外部事件处理器改写组件类集合。
+
+    Examples:
+        >>> manager = ToolComponentManager()
+        >>> tools = await manager.get_tools_for_chat(
+        ...     usables=[CalculatorTool, TranslatorTool],
+        ...     chat_type="private",
+        ...     chatter_name="my_chatter",
+        ...     stream_id="",
+        ... )
+    """
+
+    def __init__(self) -> None:
+        """初始化工具组件管理器。"""
+        self._schema_cache: dict[str, dict[str, Any]] = {}
+
+    # ── 查询 ──
+
+    def get_all_tools(self) -> dict[str, type["BaseTool"]]:
+        """获取所有已注册的 Tool 组件类。
+
+        Returns:
+            dict[str, type[BaseTool]]: 签名到 Tool 类的映射
+        """
+        registry = get_global_registry()
+        return registry.get_by_type(ComponentType.TOOL)
+
+    def get_tools_for_plugin(self, plugin_name: str) -> dict[str, type["BaseTool"]]:
+        """获取指定插件的所有 Tool 组件类。
+
+        Args:
+            plugin_name: 插件名称
+
+        Returns:
+            dict[str, type[BaseTool]]: 签名到 Tool 类的映射
+        """
+        registry = get_global_registry()
+        return registry.get_by_plugin_and_type(plugin_name, ComponentType.TOOL)
+
+    def get_tool_class(self, signature: str) -> type["BaseTool"] | None:
+        """通过签名获取 Tool 类。
+
+        Args:
+            signature: Tool 组件签名
+
+        Returns:
+            type[BaseTool] | None: Tool 类，未找到则返回 None
+        """
+        registry = get_global_registry()
+        return registry.get(signature)
+
+    # ── 筛选与激活 ──
+
+    async def get_tools_for_chat(
+        self,
+        usables: list[type["LLMUsable"]] | None = None,
+        *,
+        chat_type: "ChatType | str" = "all",
+        chatter_name: str = "",
+        platform: str = "",
+        stream_id: str = "",
+        chat_stream: "ChatStream | None" = None,
+        stream_context: "StreamContext | None" = None,
+        chatter: "BaseChatter | None" = None,
+    ) -> list[type["LLMUsable"]]:
+        """获取适用于指定聊天上下文的 Tool 组件类列表。
+
+        若传入 ``usables`` 则直接对给定集合筛选（默认筛选不传 stream_id、
+        不获取流，仅按静态维度）；否则从注册表拉取全部 Tool。
+
+        Args:
+            usables: 待筛选的组件类列表；不传则取全量注册 Tool
+            chat_type: 聊天类型（private / group / all）
+            chatter_name: Chatter 名称
+            platform: 平台标识
+            stream_id: 聊天流 ID（空表示不按流筛选）
+            chat_stream: 候选聊天流实例（提供后由其派生完整上下文）
+            stream_context: 聊天流上下文（提供后按内容类型过滤）
+
+        Returns:
+            list[type[LLMUsable]]: 筛选后的 Tool 组件类列表
+        """
+        if isinstance(chat_type, ChatType):
+            chat_type = chat_type.value
+
+        if usables is None:
+            usables = list(self.get_all_tools().values())
+
+        # 筛选前事件钩子：外部处理器可改写组件集合
+        usables = await publish_before_filter_event(
+            EventType.BEFORE_TOOL_FILTER,
+            component_kind="tool",
+            usables=usables,
+            stream_id=stream_id or (getattr(chat_stream, "stream_id", "") or ""),
+            chatter_name=chatter_name,
+            stream_context=stream_context,
+        )
+
+        ctx = build_usable_static_context(
+            usables=usables,
+            chat_type=chat_type,
+            chatter_name=chatter_name,
+            platform=platform,
+            stream_id=stream_id,
+            chat_stream=chat_stream,
+            chatter=chatter,
+        )
+
+        filtered, removals = static_filter_usables(usables, ctx)
+
+        if stream_context is not None:
+            removals.extend(filter_by_associated_types(filtered, stream_context))
+
+        removal_names = {name for name, _ in removals}
+        available = [
+            cls for cls in filtered if (cls.get_signature() or cls.__name__) not in removal_names  # type: ignore[attr-defined]
+        ]
+
+        if removals:
+            summary = " | ".join(f"{n}({r})" for n, r in removals)
+            logger.debug(f"移除 Tool 组件: {summary}")
+
+        return available
+
+    async def activate_tools_for_chat(
+        self,
+        tools: list[type["LLMUsable"]],
+        *,
+        chat_stream: "ChatStream",
+        plugin: "BasePlugin | None" = None,
+        message: "Message | None" = None,
+    ) -> list[type["LLMUsable"]]:
+        """对 Tool 组件类执行动态激活判定（go_activate）。
+
+        Args:
+            tools: 待判定的 Tool 组件类列表
+            chat_stream: 当前聊天流实例
+            plugin: 所属插件实例（缺省时按组件签名解析）
+            message: 触发消息（用于绑定运行时上下文）
+
+        Returns:
+            list[type[LLMUsable]]: 激活通过的组件类列表
+        """
+        tasks = []
+        signatures = []
+        kept = []
+
+        for tool_cls in tools:
+            signature = tool_cls.get_signature() or tool_cls.__name__  # type: ignore[attr-defined]
+            # 优先按组件签名解析所属插件；无法解析时回退到传入的 plugin
+            tool_plugin = self._resolve_tool_plugin(signature)
+            if tool_plugin is None:
+                tool_plugin = plugin
+            if tool_plugin is None:
+                logger.warning(f"未找到 Tool 所属插件实例: {signature}，跳过激活判定")
+                continue
+            try:
+                instance = tool_cls(plugin=tool_plugin)  # type: ignore[call-arg]
+                instance._bind_runtime_context(  # type: ignore[attr-defined]
+                    stream_id=chat_stream.stream_id,
+                    message=message,
+                )
+                go_activate = getattr(instance, "go_activate", None)
+                if not callable(go_activate):
+                    kept.append(tool_cls)
+                    continue
+                tasks.append(go_activate())
+                signatures.append(signature)
+            except Exception as e:
+                logger.error(f"创建 Tool 实例 {signature} 失败: {e}")
+                continue
+
+        if tasks:
+            results = await get_task_manager().gather(*tasks, return_exceptions=True)
+            for signature, result in zip(signatures, results, strict=False):
+                if isinstance(result, Exception) or not result:
+                    continue
+                tool_cls = next(
+                    (
+                        c
+                        for c in tools
+                        if (c.get_signature() or c.__name__) == signature  # type: ignore[attr-defined]
+                    ),
+                    None,
+                )
+                if tool_cls is not None:
+                    kept.append(tool_cls)
+
+        return kept
+
+    # ── Schema ──
+
+    def get_tool_schema(self, signature: str) -> dict[str, Any] | None:
+        """获取 Tool 的 Tool Schema。
+
+        Args:
+            signature: Tool 组件签名
+
+        Returns:
+            dict[str, Any] | None: Tool Schema，未找到则返回 None
+        """
+        if signature in self._schema_cache:
+            return self._schema_cache[signature]
+
+        tool_cls = self.get_tool_class(signature)
+        if not tool_cls:
+            return None
+        schema = tool_cls.to_schema()
+        self._schema_cache[signature] = schema
+        return schema
+
+    def clear_schema_cache(self, signature: str | None = None) -> None:
+        """清除 schema 缓存。
+
+        Args:
+            signature: 要清除的 Tool 签名；None 表示清除全部
+        """
+        if signature:
+            self._schema_cache.pop(signature, None)
+        else:
+            self._schema_cache.clear()
+
+    # ── 内部 ──
+
+    def _resolve_tool_plugin(self, signature: str) -> "BasePlugin | None":
+        """根据组件签名解析其所属插件实例。
+
+        Args:
+            signature: Tool 组件签名
+
+        Returns:
+            BasePlugin | None: 解析到的插件实例；无法解析时返回 None
+        """
+        try:
+            from src.core.managers import get_plugin_manager
+            from src.core.components.types import parse_signature
+
+            plugin_name = parse_signature(signature)["plugin_name"]
+            return get_plugin_manager().get_plugin(plugin_name)
+        except Exception:
+            return None
+
+
+# 全局工具组件管理器实例
+_global_tool_component_manager: ToolComponentManager | None = None
+
+
+def get_tool_component_manager() -> ToolComponentManager:
+    """获取全局工具组件管理器实例。
+
+    Returns:
+        ToolComponentManager: 全局工具组件管理器单例
+    """
+    global _global_tool_component_manager
+    if _global_tool_component_manager is None:
+        _global_tool_component_manager = ToolComponentManager()
+    return _global_tool_component_manager
+
+
+__all__ = ["ToolComponentManager", "get_tool_component_manager"]

--- a/src/core/managers/utils/__init__.py
+++ b/src/core/managers/utils/__init__.py
@@ -1,0 +1,19 @@
+"""组件管理器共用工具。
+
+提供各组件管理器（Action / Tool / Agent）复用的静态作用域筛选、
+筛选前事件发布与组件类归一化等辅助逻辑。
+"""
+
+from .usable_utils import (
+    build_usable_static_context,
+    filter_by_associated_types,
+    publish_before_filter_event,
+    static_filter_usables,
+)
+
+__all__ = [
+    "build_usable_static_context",
+    "filter_by_associated_types",
+    "publish_before_filter_event",
+    "static_filter_usables",
+]

--- a/src/core/managers/utils/usable_utils.py
+++ b/src/core/managers/utils/usable_utils.py
@@ -1,0 +1,204 @@
+"""组件管理器复用筛选逻辑。
+
+本模块提供 Action / Tool / Agent 管理器共用的三块逻辑：
+
+1. ``build_usable_static_context``：从不传 stream_id 的纯静态参数与可选的
+   运行时上下文，构造 ``UsableFilterContext`` 快照。
+2. ``static_filter_usables``：对组件类序列执行 ``evaluate_usable_filter``
+   静态维度过滤，返回 (存活列表, 移除记录)。
+3. ``filter_by_associated_types``：按聊天流上下文支持的内容类型过滤组件。
+4. ``publish_before_filter_event``：在每个管理器筛选前发布事件，允许外部
+   事件处理器通过修改 ``usables`` 参数来增删组件类。
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from src.kernel.event import get_event_bus
+from src.core.components.types import EventType
+from src.core.components.usable_filter import (
+    UsableFilterContext,
+    build_filter_context_from_stream,
+    evaluate_usable_filter,
+)
+
+if TYPE_CHECKING:
+    from src.core.components.base.chatter import BaseChatter
+    from src.core.models.stream import ChatStream, StreamContext
+    from src.kernel.llm import LLMUsable
+
+
+def _normalize_chat_type_value(chat_type: Any) -> str:
+    """将 chat_type 输入规范为小写字符串。
+
+    Args:
+        chat_type: 原始聊天类型值（枚举 / 字符串 / 其他）
+
+    Returns:
+        str: 规范化后的小写字符串；无法识别时回退为 all
+    """
+    if isinstance(chat_type, str):
+        val = chat_type.strip().lower()
+        return val if val else "all"
+    value_attr = getattr(chat_type, "value", None)
+    if isinstance(value_attr, str) and value_attr.strip():
+        return value_attr.strip().lower()
+    return "all"
+
+
+def build_usable_static_context(
+    *,
+    usables: list[type["LLMUsable"]] | None = None,
+    chat_type: Any = "all",
+    chatter_name: str = "",
+    platform: str = "",
+    stream_id: str = "",
+    chat_stream: "ChatStream | None" = None,
+    chatter: "BaseChatter | None" = None,
+) -> "UsableFilterContext":
+    """构造组件筛选所需的 UsableFilterContext。
+
+    遵循「默认筛选不传 stream_id、不获取」的约定：未提供 ``stream_id`` 时，
+    静态维度（chat_type / chatter / platform）参与过滤，流级与实体级维度留空。
+
+    Args:
+        usables: 待筛选组件类列表（当前仅用于计数日志，可省略）
+        chat_type: 聊天类型（ChatType 枚举或字符串，private / group / all）
+        chatter_name: Chatter 名称
+        platform: 平台标识
+        stream_id: 聊天流 ID；空表示不传入流级上下文
+        chat_stream: 候选聊天流实例；提供后可由其派生完整上下文
+        chatter: 当前驱动执行的 Chatter 实例；提供后可由其派生 Chatter 身份
+
+    Returns:
+        UsableFilterContext: 构造完成的过滤上下文快照
+    """
+    if chat_stream is not None and chatter is not None:
+        return build_filter_context_from_stream(chat_stream, chatter)
+
+    return UsableFilterContext(
+        stream_id=stream_id,
+        chat_type=_normalize_chat_type_value(chat_type),
+        platform=platform,
+        chatter_name=chatter_name,
+    )
+
+
+def static_filter_usables(
+    usables: list[type["LLMUsable"]],
+    ctx: "UsableFilterContext",
+) -> tuple[list[type["LLMUsable"]], list[tuple[str, str]]]:
+    """对组件类序列执行静态维度过滤。
+
+    Args:
+        usables: 待过滤的组件类列表
+        ctx: 过滤上下文快照
+
+    Returns:
+        tuple[list[type[LLMUsable]], list[tuple[str, str]]]:
+        存活组件类列表与 (签名, 原因) 移除记录列表
+    """
+    removals: list[tuple[str, str]] = []
+    kept: list[type["LLMUsable"]] = []
+
+    for usable_cls in usables:
+        signature = usable_cls.get_signature() or usable_cls.__name__  # type: ignore[attr-defined]
+        is_eligible, reject_reason = evaluate_usable_filter(usable_cls, ctx)
+        if not is_eligible:
+            removals.append((signature, reject_reason or "静态作用域不匹配"))
+            continue
+        kept.append(usable_cls)
+
+    return kept, removals
+
+
+def filter_by_associated_types(
+    usables: list[type["LLMUsable"]],
+    chat_context: "StreamContext | None",
+) -> list[tuple[str, str]]:
+    """按聊天流上下文支持的内容类型过滤组件。
+
+    Args:
+        usables: 组件类列表
+        chat_context: 聊天流上下文（须支持 ``check_types``）；为空时直接通过
+
+    Returns:
+        list[tuple[str, str]]: 需移除的 (签名, 原因) 记录列表
+    """
+    if chat_context is None:
+        return []
+
+    removals: list[tuple[str, str]] = []
+    for usable_cls in usables:
+        # 仅当组件显式声明了内容类型要求时才进行过滤
+        required_types = getattr(usable_cls, "associated_types", None)
+        if not required_types:
+            continue
+        if not chat_context.check_types(required_types):
+            signature = usable_cls.get_signature() or usable_cls.__name__  # type: ignore[attr-defined]
+            removals.append(
+                (
+                    signature,
+                    f"适配器不支持内容类型（需要: {', '.join(required_types)}）",
+                )
+            )
+    return removals
+
+
+async def publish_before_filter_event(
+    event_type: "EventType",
+    *,
+    component_kind: str,
+    usables: list[type["LLMUsable"]],
+    stream_id: str = "",
+    chatter_name: str = "",
+    stream_context: "StreamContext | None" = None,
+) -> list[type["LLMUsable"]]:
+    """在组件筛选前发布事件，允许外部处理器改写组件类集合。
+
+    事件参数携带 ``stream_id``、``chatter_name``、``component_kind`` 与
+    ``usables``（组件类列表）。外部处理器可返回修改后的 ``usables`` 以增删组件。
+
+    Args:
+        event_type: 要发布的事件类型（BEFORE_*_FILTER 族）
+        component_kind: 组件类别名（action / tool / agent）
+        usables: 待筛选的组件类列表
+        stream_id: 聊天流 ID（可为空）
+        chatter_name: Chatter 名称（可为空）
+        stream_context: 聊天流上下文（可为空）
+
+    Returns:
+        list[type[LLMUsable]]: 事件处理器改写后的组件类列表
+    """
+    event_bus = get_event_bus()
+    if not event_bus.get_subscribers(event_type):
+        return usables
+
+    try:
+        _, modified = await event_bus.publish(
+            event_type,
+            {
+                "component_kind": component_kind,
+                "usables": list(usables),
+                "stream_id": stream_id,
+                "chatter_name": chatter_name,
+                "stream_context": stream_context,
+            },
+        )
+        new_usables = modified.get("usables")
+        if isinstance(new_usables, list):
+            return [cls for cls in new_usables if cls is not None]
+    except Exception:
+        # 事件处理器异常不中断筛选流程，静默降级
+        pass
+
+    return usables
+
+
+__all__ = [
+    "build_usable_static_context",
+    "filter_by_associated_types",
+    "publish_before_filter_event",
+    "static_filter_usables",
+]

--- a/src/kernel/llm/request.py
+++ b/src/kernel/llm/request.py
@@ -50,6 +50,11 @@ class LLMRequest:
         elif not isinstance(self.meta_data, dict):
             self.meta_data = dict(self.meta_data)
 
+    @property
+    def stream_id(self) -> str:
+        """从 meta_data 中获取 stream_id。"""
+        return str(self.meta_data.get("stream_id", "") or "")
+
     def add_payload(self, payload: LLMPayload, position=None) -> Self:
         """按当前 context manager 规则追加或插入 payload。"""
         if self.context_manager is not None:

--- a/test/app/plugin_system/api/test_agent_api.py
+++ b/test/app/plugin_system/api/test_agent_api.py
@@ -117,7 +117,10 @@ async def test_filter_agents_for_chat_filters_by_chat_type(
         agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
     )
 
-    result = await agent_api.filter_agents_for_chat(chat_type=ChatType.PRIVATE)
+    usables = list(agent_api.get_all_agents().values())
+    result = await agent_api.filter_agents_for_chat(  # type: ignore[arg-type]
+        usables, chat_type=ChatType.PRIVATE
+    )
 
     assert len(result) == 1
     assert result[0] is PrivateAgent
@@ -158,7 +161,10 @@ async def test_filter_agents_for_chat_filters_by_chatter_allow(
         agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
     )
 
-    result = await agent_api.filter_agents_for_chat(chatter_name="my_chatter")
+    usables = list(agent_api.get_all_agents().values())
+    result = await agent_api.filter_agents_for_chat(  # type: ignore[arg-type]
+        usables, chatter_name="my_chatter"
+    )
 
     assert len(result) == 1
     assert result[0] is AllowedAgent
@@ -199,7 +205,10 @@ async def test_filter_agents_for_chat_filters_by_platform(
         agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
     )
 
-    result = await agent_api.filter_agents_for_chat(platform="test_platform")
+    usables = list(agent_api.get_all_agents().values())
+    result = await agent_api.filter_agents_for_chat(  # type: ignore[arg-type]
+        usables, platform="test_platform"
+    )
 
     assert len(result) == 1
     assert result[0] is PlatformAgent

--- a/test/app/plugin_system/api/test_agent_api.py
+++ b/test/app/plugin_system/api/test_agent_api.py
@@ -11,6 +11,7 @@ from src.app.plugin_system.api import agent_api
 from src.app.plugin_system.types import ChatType
 from src.core.components.base.agent import BaseAgent
 from src.core.components.base.tool import BaseTool
+from src.core.managers import agent_manager as agent_manager_mod
 
 
 class MockPrivateTool(BaseTool):
@@ -51,7 +52,9 @@ def test_get_all_agents_returns_dict(monkeypatch: pytest.MonkeyPatch) -> None:
         def get_by_type(self, component_type):
             return {"demo:agent:demo": MockAgent}
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     result = agent_api.get_all_agents()
 
@@ -72,14 +75,17 @@ def test_get_agents_for_plugin_delegates(monkeypatch: pytest.MonkeyPatch) -> Non
         def get_by_plugin_and_type(self, plugin_name: str, component_type):
             return {f"{plugin_name}:agent:demo": MockAgent}
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     result = agent_api.get_agents_for_plugin("demo_plugin")
 
     assert "demo_plugin:agent:demo" in result
 
 
-def test_get_agents_for_chat_filters_by_chat_type(
+@pytest.mark.asyncio
+async def test_get_agents_for_chat_filters_by_chat_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """get_agents_for_chat 应根据 chat_type 过滤。"""
@@ -107,15 +113,18 @@ def test_get_agents_for_chat_filters_by_chat_type(
                 "plugin:agent:private": PrivateAgent,
             }
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
-    result = agent_api.get_agents_for_chat(chat_type=ChatType.PRIVATE)
+    result = await agent_api.get_agents_for_chat(chat_type=ChatType.PRIVATE)
 
     assert len(result) == 1
     assert result[0] is PrivateAgent
 
 
-def test_get_agents_for_chat_filters_by_chatter_allow(
+@pytest.mark.asyncio
+async def test_get_agents_for_chat_filters_by_chatter_allow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """get_agents_for_chat 应根据 chatter_allow 过滤。"""
@@ -145,15 +154,18 @@ def test_get_agents_for_chat_filters_by_chatter_allow(
                 "plugin:agent:not_allowed": NotAllowedAgent,
             }
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
-    result = agent_api.get_agents_for_chat(chatter_name="my_chatter")
+    result = await agent_api.get_agents_for_chat(chatter_name="my_chatter")
 
     assert len(result) == 1
     assert result[0] is AllowedAgent
 
 
-def test_get_agents_for_chat_filters_by_platform(
+@pytest.mark.asyncio
+async def test_get_agents_for_chat_filters_by_platform(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """get_agents_for_chat 应根据 platform 过滤。"""
@@ -183,9 +195,11 @@ def test_get_agents_for_chat_filters_by_platform(
                 "plugin:agent:other": OtherAgent,
             }
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
-    result = agent_api.get_agents_for_chat(platform="test_platform")
+    result = await agent_api.get_agents_for_chat(platform="test_platform")
 
     assert len(result) == 1
     assert result[0] is PlatformAgent
@@ -206,7 +220,9 @@ def test_get_agent_class_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
                 return MockAgent
             return None
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     result = agent_api.get_agent_class("demo:agent:demo")
 
@@ -228,7 +244,9 @@ def test_get_agent_schema_returns_schema(monkeypatch: pytest.MonkeyPatch) -> Non
                 return MockAgent
             return None
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     result = agent_api.get_agent_schema("demo:agent:demo")
 
@@ -237,7 +255,10 @@ def test_get_agent_schema_returns_schema(monkeypatch: pytest.MonkeyPatch) -> Non
     assert result["function"]["name"] == "agent-mock_agent"
 
 
-def test_get_agent_schemas_returns_list(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.asyncio
+async def test_get_agent_schemas_returns_list(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """get_agent_schemas 应返回 schema 列表。"""
 
     class _FakeRegistry:
@@ -246,9 +267,11 @@ def test_get_agent_schemas_returns_list(monkeypatch: pytest.MonkeyPatch) -> None
                 "plugin:agent:mock": MockAgent,
             }
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
-    result = agent_api.get_agent_schemas(chat_type=ChatType.PRIVATE)
+    result = await agent_api.get_agent_schemas(chat_type=ChatType.PRIVATE)
 
     assert isinstance(result, list)
     assert len(result) == 1
@@ -287,18 +310,16 @@ async def test_execute_agent_raises_if_not_found() -> None:
         def get(self, signature: str):
             return None
 
-    import src.app.plugin_system.api.agent_api as module
-
-    original_func = module.get_global_registry
+    original_func = agent_manager_mod.get_global_registry
 
     try:
-        module.get_global_registry = lambda: _FakeRegistry()
+        agent_manager_mod.get_global_registry = lambda: _FakeRegistry()
 
         with pytest.raises(ValueError, match="Agent 类未找到"):
             await agent_api.execute_agent("demo:agent:demo", mock_plugin, "stream_123")
 
     finally:
-        module.get_global_registry = original_func
+        agent_manager_mod.get_global_registry = original_func
 
 
 @pytest.mark.asyncio
@@ -321,7 +342,9 @@ async def test_execute_agent_calls_execute(monkeypatch: pytest.MonkeyPatch) -> N
         def get(self, signature: str):
             return TestAgent
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     success, result = await agent_api.execute_agent(
         "demo:agent:test",
@@ -353,7 +376,9 @@ async def test_execute_agent_keeps_declared_reason(
         def get(self, signature: str):
             return ReasonAgent
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     success, result = await agent_api.execute_agent(
         "demo:agent:reason",
@@ -380,7 +405,9 @@ def test_get_agent_usables_returns_list(monkeypatch: pytest.MonkeyPatch) -> None
         def get(self, signature: str):
             return MockAgent
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     result = agent_api.get_agent_usables("demo:agent:demo")
 
@@ -404,7 +431,9 @@ def test_get_agent_usable_schemas_returns_list(
         def get(self, signature: str):
             return MockAgent
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     result = agent_api.get_agent_usable_schemas("demo:agent:demo")
 
@@ -475,7 +504,9 @@ async def test_execute_agent_usable_calls_execute_local_usable(
         def get(self, signature: str):
             return TestAgent
 
-    monkeypatch.setattr(agent_api, "get_global_registry", lambda: _FakeRegistry())
+    monkeypatch.setattr(
+        agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
+    )
 
     success, result = await agent_api.execute_agent_usable(
         "demo:agent:test",

--- a/test/app/plugin_system/api/test_agent_api.py
+++ b/test/app/plugin_system/api/test_agent_api.py
@@ -85,10 +85,10 @@ def test_get_agents_for_plugin_delegates(monkeypatch: pytest.MonkeyPatch) -> Non
 
 
 @pytest.mark.asyncio
-async def test_get_agents_for_chat_filters_by_chat_type(
+async def test_filter_agents_for_chat_filters_by_chat_type(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """get_agents_for_chat 应根据 chat_type 过滤。"""
+    """filter_agents_for_chat 应根据 chat_type 过滤。"""
 
     class GroupAgent(BaseAgent):
         agent_name = "group_agent"
@@ -117,17 +117,17 @@ async def test_get_agents_for_chat_filters_by_chat_type(
         agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
     )
 
-    result = await agent_api.get_agents_for_chat(chat_type=ChatType.PRIVATE)
+    result = await agent_api.filter_agents_for_chat(chat_type=ChatType.PRIVATE)
 
     assert len(result) == 1
     assert result[0] is PrivateAgent
 
 
 @pytest.mark.asyncio
-async def test_get_agents_for_chat_filters_by_chatter_allow(
+async def test_filter_agents_for_chat_filters_by_chatter_allow(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """get_agents_for_chat 应根据 chatter_allow 过滤。"""
+    """filter_agents_for_chat 应根据 chatter_allow 过滤。"""
 
     class AllowedAgent(BaseAgent):
         agent_name = "allowed_agent"
@@ -158,17 +158,17 @@ async def test_get_agents_for_chat_filters_by_chatter_allow(
         agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
     )
 
-    result = await agent_api.get_agents_for_chat(chatter_name="my_chatter")
+    result = await agent_api.filter_agents_for_chat(chatter_name="my_chatter")
 
     assert len(result) == 1
     assert result[0] is AllowedAgent
 
 
 @pytest.mark.asyncio
-async def test_get_agents_for_chat_filters_by_platform(
+async def test_filter_agents_for_chat_filters_by_platform(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """get_agents_for_chat 应根据 platform 过滤。"""
+    """filter_agents_for_chat 应根据 platform 过滤。"""
 
     class PlatformAgent(BaseAgent):
         agent_name = "platform_agent"
@@ -199,7 +199,7 @@ async def test_get_agents_for_chat_filters_by_platform(
         agent_manager_mod, "get_global_registry", lambda: _FakeRegistry()
     )
 
-    result = await agent_api.get_agents_for_chat(platform="test_platform")
+    result = await agent_api.filter_agents_for_chat(platform="test_platform")
 
     assert len(result) == 1
     assert result[0] is PlatformAgent

--- a/test/core/components/test_chatter_modify_usables.py
+++ b/test/core/components/test_chatter_modify_usables.py
@@ -1,0 +1,100 @@
+"""测试 BaseChatter.modify_llm_usables 两阶段过滤流程。"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.core.components.base.action import BaseAction
+from src.core.components.base.chatter import BaseChatter
+from src.core.components.base.tool import BaseTool
+from src.core.components.types import ChatType
+
+
+class StaticBlockedTool(BaseTool):
+    """静态作用域不匹配的工具。"""
+
+    name = "static_blocked_tool"
+    chat_type = ChatType.GROUP  # 私聊流下应在 Phase 1 直接排除
+
+
+class ActivateSuccessAction(BaseAction):
+    """Phase 1 通过且 go_activate 返回 True 的动作。"""
+
+    name = "activate_success_action"
+    chat_type = ChatType.PRIVATE
+
+    async def go_activate(self) -> bool:
+        return True
+
+    async def execute(self) -> tuple[bool, str]:
+        return True, "ok"
+
+
+class ActivateFailAction(BaseAction):
+    """Phase 1 通过但 go_activate 返回 False 的动作。"""
+
+    name = "activate_fail_action"
+    chat_type = ChatType.PRIVATE
+
+    async def go_activate(self) -> bool:
+        return False
+
+    async def execute(self) -> tuple[bool, str]:
+        return True, "fail"
+
+
+class ActivateExceptionAction(BaseAction):
+    """Phase 1 通过但 go_activate 抛出异常的动作。"""
+
+    name = "activate_exception_action"
+    chat_type = ChatType.PRIVATE
+
+    async def go_activate(self) -> bool:
+        raise RuntimeError("模拟激活异常")
+
+    async def execute(self) -> tuple[bool, str]:
+        return True, "err"
+
+
+class ConcreteChatter(BaseChatter):
+    """用于测试的具体 Chatter 子类。"""
+
+    name = "test_chatter"
+
+    async def execute(self) -> Any:
+        yield None
+
+
+@pytest.mark.asyncio
+async def test_modify_llm_usables_two_phase_pipeline() -> None:
+    """验证两阶段过滤流水线：Phase 1 排除不调用 go_activate，Phase 2 准确筛选。"""
+    mock_plugin = MagicMock()
+    chatter = ConcreteChatter(stream_id="test_stream_1", plugin=mock_plugin)
+
+    # 构造 Mock ChatStream
+    mock_stream = MagicMock()
+    mock_stream.stream_id = "test_stream_1"
+    mock_stream.chat_type = "private"
+    mock_stream.platform = "qq"
+    mock_stream.context.current_message = None
+    mock_stream.context.unread_messages = []
+
+    mock_sm = MagicMock()
+    mock_sm.get_or_create_stream = AsyncMock(return_value=mock_stream)
+
+    usables = [
+        StaticBlockedTool,
+        ActivateSuccessAction,
+        ActivateFailAction,
+        ActivateExceptionAction,
+    ]
+
+    with patch("src.core.managers.get_stream_manager", return_value=mock_sm):
+        available = await chatter.modify_llm_usables(usables)
+
+    # 只有 ActivateSuccessAction 应该存活
+    assert len(available) == 1
+    assert available[0] is ActivateSuccessAction

--- a/test/core/components/test_plugin_loader_api_version.py
+++ b/test/core/components/test_plugin_loader_api_version.py
@@ -46,8 +46,8 @@ def _patch_api_version(monkeypatch: pytest.MonkeyPatch, api_name: str, version: 
 # =============================================================================
 
 
-def test_plugin_api_versions_contains_all_20_modules() -> None:
-    """PLUGIN_API_VERSIONS 应包含全部 20 个 *_api 模块，且初始版本均为 1.0.0。"""
+def test_plugin_api_versions_contains_all_modules() -> None:
+    """PLUGIN_API_VERSIONS 应包含全部 *_api 模块，且版本为合法语义化版本号。"""
     expected = {
         "action_api",
         "adapter_api",
@@ -62,6 +62,7 @@ def test_plugin_api_versions_contains_all_20_modules() -> None:
         "media_api",
         "message_api",
         "permission_api",
+        "person_api",
         "plugin_api",
         "prompt_api",
         "router_api",
@@ -69,11 +70,13 @@ def test_plugin_api_versions_contains_all_20_modules() -> None:
         "service_api",
         "storage_api",
         "stream_api",
+        "tool_api",
     }
     assert set(PLUGIN_API_VERSIONS) == expected
-    assert len(PLUGIN_API_VERSIONS) == 20
     for name, ver in PLUGIN_API_VERSIONS.items():
-        assert ver == "1.0.0", f"{name} 初始版本应为 1.0.0，实际为 {ver}"
+        parts = ver.split(".")
+        assert len(parts) == 3, f"{name} 版本应为三段式语义化版本，实际为 {ver}"
+        assert all(p.isdigit() for p in parts), f"{name} 版本含非数字段: {ver}"
 
 
 # =============================================================================

--- a/test/core/components/test_usable_filter.py
+++ b/test/core/components/test_usable_filter.py
@@ -56,22 +56,6 @@ class DummyToolWithStreamScope:
     stream_deny = ["stream_blocked"]
 
 
-class DummyToolWithGroupScope:
-    """指定群组作用域的工具类。"""
-
-    name = "dummy_group_scope"
-    group_allow = [123456, "888888"]
-    group_deny = [999999]
-
-
-class DummyToolWithUserScope:
-    """指定用户作用域的工具类。"""
-
-    name = "dummy_user_scope"
-    user_allow = [10001, "20002"]
-    user_deny = [30003]
-
-
 class DummyActionWithFormats:
     """指定内容格式作用域的动作类。"""
 
@@ -213,61 +197,27 @@ def test_evaluate_usable_filter_stream() -> None:
     assert "聊天流不匹配" in str(reason3)
 
 
-def test_evaluate_usable_filter_group() -> None:
-    """群组 ID 黑白名单在群聊与非群聊上下文中的行为。"""
-    # 非群聊上下文不校验群组规则
-    ctx_private = UsableFilterContext(
-        stream_id="s1", chat_type="private", platform="qq", group_id="999999"
-    )
-    is_ok0, _ = evaluate_usable_filter(DummyToolWithGroupScope, ctx_private)
-    assert is_ok0 is True
+def test_evaluate_usable_filter_does_not_evaluate_entity_lists() -> None:
+    """Group / User 实体名单不应由引擎评估（运行时交给事件钩子/go_activate）。"""
 
-    ctx_group_deny = UsableFilterContext(
-        stream_id="s1", chat_type="group", platform="qq", group_id="999999"
-    )
-    is_ok1, reason1 = evaluate_usable_filter(
-        DummyToolWithGroupScope, ctx_group_deny
-    )
-    assert is_ok1 is False
-    assert "群组在黑名单中" in str(reason1)
+    class PlainGroupTool:
+        name = "plain_group_tool"
 
-    ctx_group_allow = UsableFilterContext(
-        stream_id="s1", chat_type="group", platform="qq", group_id="123456"
+    # 任意群上下文都不做名单过滤
+    ctx_group = UsableFilterContext(
+        stream_id="s1", chat_type="group", platform="qq", group_id="any_group"
     )
-    is_ok2, _ = evaluate_usable_filter(DummyToolWithGroupScope, ctx_group_allow)
+    is_ok, reason = evaluate_usable_filter(PlainGroupTool, ctx_group)
+    assert is_ok is True
+    assert reason is None
+
+    # 任意用户上下文都不做名单过滤
+    ctx_user = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="qq", user_id="any_user"
+    )
+    is_ok2, reason2 = evaluate_usable_filter(PlainGroupTool, ctx_user)
     assert is_ok2 is True
-
-    ctx_group_unauth = UsableFilterContext(
-        stream_id="s1", chat_type="group", platform="qq", group_id="777777"
-    )
-    is_ok3, reason3 = evaluate_usable_filter(
-        DummyToolWithGroupScope, ctx_group_unauth
-    )
-    assert is_ok3 is False
-    assert "群组不匹配" in str(reason3)
-
-
-def test_evaluate_usable_filter_user() -> None:
-    """用户 ID 黑白名单校验。"""
-    ctx_deny = UsableFilterContext(
-        stream_id="s1", chat_type="private", platform="qq", user_id="30003"
-    )
-    is_ok1, reason1 = evaluate_usable_filter(DummyToolWithUserScope, ctx_deny)
-    assert is_ok1 is False
-    assert "用户在黑名单中" in str(reason1)
-
-    ctx_allow = UsableFilterContext(
-        stream_id="s1", chat_type="private", platform="qq", user_id="10001"
-    )
-    is_ok2, _ = evaluate_usable_filter(DummyToolWithUserScope, ctx_allow)
-    assert is_ok2 is True
-
-    ctx_unauth = UsableFilterContext(
-        stream_id="s1", chat_type="private", platform="qq", user_id="40004"
-    )
-    is_ok3, reason3 = evaluate_usable_filter(DummyToolWithUserScope, ctx_unauth)
-    assert is_ok3 is False
-    assert "用户不匹配" in str(reason3)
+    assert reason2 is None
 
 
 def test_evaluate_usable_filter_content_types() -> None:
@@ -351,10 +301,6 @@ class DummyToolSingleValues:
     platform_deny = "discord"
     stream_allow = "s1"
     stream_deny = "s_blocked"
-    group_allow = 123456
-    group_deny = 999999
-    user_allow = 10001
-    user_deny = 30003
     chat_type = "group"
 
 

--- a/test/core/components/test_usable_filter.py
+++ b/test/core/components/test_usable_filter.py
@@ -1,0 +1,440 @@
+"""测试 LLMUsable 过滤引擎与作用域评估功能。"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from src.core.components.types import ChatType
+from src.core.components.usable_filter import (
+    UsableFilterContext,
+    build_filter_context_from_stream,
+    evaluate_usable_filter,
+)
+
+
+class DummyToolDefault:
+    """默认配置工具类。"""
+
+    name = "dummy_default"
+
+
+class DummyToolWithChatterScope:
+    """指定 Chatter 作用域的工具类。"""
+
+    name = "dummy_chatter_scope"
+    chatter_allow = ["main_chatter", "test_plugin:chatter:custom"]
+    chatter_deny = ["blocked_chatter"]
+
+
+class DummyToolWithChatTypeScope:
+    """指定 ChatType 作用域的工具类。"""
+
+    name = "dummy_chat_type_scope"
+    chat_type = [ChatType.GROUP]
+
+
+class DummyToolWithPlatformScope:
+    """指定 Platform 作用域的工具类。"""
+
+    name = "dummy_platform_scope"
+    platform_allow = ["qq"]
+    platform_deny = ["discord"]
+
+
+class DummyToolWithLegacyPlatform:
+    """指定 associated_platforms 平台白名单的工具类。"""
+
+    name = "dummy_legacy_platform"
+    associated_platforms = ["telegram"]
+
+
+class DummyToolWithStreamScope:
+    """指定 Stream ID 作用域的工具类。"""
+
+    name = "dummy_stream_scope"
+    stream_allow = ["stream_123"]
+    stream_deny = ["stream_blocked"]
+
+
+class DummyToolWithGroupScope:
+    """指定群组作用域的工具类。"""
+
+    name = "dummy_group_scope"
+    group_allow = [123456, "888888"]
+    group_deny = [999999]
+
+
+class DummyToolWithUserScope:
+    """指定用户作用域的工具类。"""
+
+    name = "dummy_user_scope"
+    user_allow = [10001, "20002"]
+    user_deny = [30003]
+
+
+class DummyActionWithFormats:
+    """指定内容格式作用域的动作类。"""
+
+    name = "dummy_formats"
+    associated_types = ["text", "image"]
+
+
+def test_evaluate_usable_filter_default_allow() -> None:
+    """全默认配置组件在任意上下文中均应通过过滤。"""
+    ctx = UsableFilterContext(
+        stream_id="stream_abc",
+        chat_type="private",
+        platform="qq",
+        user_id="10001",
+    )
+    is_ok, reason = evaluate_usable_filter(DummyToolDefault, ctx)
+    assert is_ok is True
+    assert reason is None
+
+
+def test_evaluate_usable_filter_chatter_deny() -> None:
+    """命中 chatter_deny 黑名单时应拒绝。"""
+    ctx = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        chatter_name="blocked_chatter",
+    )
+    is_ok, reason = evaluate_usable_filter(DummyToolWithChatterScope, ctx)
+    assert is_ok is False
+    assert "chatter 在黑名单中" in str(reason)
+
+
+def test_evaluate_usable_filter_chatter_allow_match_name_or_sig() -> None:
+    """命中 chatter_allow 白名单（按 name 或 signature）时应放行。"""
+    ctx1 = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        chatter_name="main_chatter",
+    )
+    is_ok1, _ = evaluate_usable_filter(DummyToolWithChatterScope, ctx1)
+    assert is_ok1 is True
+
+    ctx2 = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        chatter_name="other_name",
+        chatter_signature="test_plugin:chatter:custom",
+    )
+    is_ok2, _ = evaluate_usable_filter(DummyToolWithChatterScope, ctx2)
+    assert is_ok2 is True
+
+    ctx3 = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        chatter_name="unauthorized_chatter",
+        chatter_signature="unauthorized:sig",
+    )
+    is_ok3, reason3 = evaluate_usable_filter(DummyToolWithChatterScope, ctx3)
+    assert is_ok3 is False
+    assert "chatter 不匹配" in str(reason3)
+
+
+def test_evaluate_usable_filter_chat_type() -> None:
+    """聊天类型不匹配时应拒绝。"""
+    ctx_private = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+    )
+    is_ok1, reason1 = evaluate_usable_filter(
+        DummyToolWithChatTypeScope, ctx_private
+    )
+    assert is_ok1 is False
+    assert "聊天类型不匹配" in str(reason1)
+
+    ctx_group = UsableFilterContext(
+        stream_id="s1",
+        chat_type="group",
+        platform="qq",
+    )
+    is_ok2, _ = evaluate_usable_filter(DummyToolWithChatTypeScope, ctx_group)
+    assert is_ok2 is True
+
+
+def test_evaluate_usable_filter_platform() -> None:
+    """平台黑白名单及 associated_platforms 属性测试。"""
+    ctx_discord = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="discord"
+    )
+    is_ok1, reason1 = evaluate_usable_filter(
+        DummyToolWithPlatformScope, ctx_discord
+    )
+    assert is_ok1 is False
+    assert "平台在黑名单中" in str(reason1)
+
+    ctx_telegram = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="telegram"
+    )
+    is_ok2, reason2 = evaluate_usable_filter(
+        DummyToolWithPlatformScope, ctx_telegram
+    )
+    assert is_ok2 is False
+    assert "平台不匹配" in str(reason2)
+
+    is_ok3, _ = evaluate_usable_filter(
+        DummyToolWithLegacyPlatform, ctx_telegram
+    )
+    assert is_ok3 is True
+
+
+def test_evaluate_usable_filter_stream() -> None:
+    """Stream ID 黑白名单校验。"""
+    ctx_blocked = UsableFilterContext(
+        stream_id="stream_blocked", chat_type="private", platform="qq"
+    )
+    is_ok1, reason1 = evaluate_usable_filter(
+        DummyToolWithStreamScope, ctx_blocked
+    )
+    assert is_ok1 is False
+    assert "聊天流在黑名单中" in str(reason1)
+
+    ctx_allowed = UsableFilterContext(
+        stream_id="stream_123", chat_type="private", platform="qq"
+    )
+    is_ok2, _ = evaluate_usable_filter(DummyToolWithStreamScope, ctx_allowed)
+    assert is_ok2 is True
+
+    ctx_other = UsableFilterContext(
+        stream_id="stream_999", chat_type="private", platform="qq"
+    )
+    is_ok3, reason3 = evaluate_usable_filter(
+        DummyToolWithStreamScope, ctx_other
+    )
+    assert is_ok3 is False
+    assert "聊天流不匹配" in str(reason3)
+
+
+def test_evaluate_usable_filter_group() -> None:
+    """群组 ID 黑白名单在群聊与非群聊上下文中的行为。"""
+    # 非群聊上下文不校验群组规则
+    ctx_private = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="qq", group_id="999999"
+    )
+    is_ok0, _ = evaluate_usable_filter(DummyToolWithGroupScope, ctx_private)
+    assert is_ok0 is True
+
+    ctx_group_deny = UsableFilterContext(
+        stream_id="s1", chat_type="group", platform="qq", group_id="999999"
+    )
+    is_ok1, reason1 = evaluate_usable_filter(
+        DummyToolWithGroupScope, ctx_group_deny
+    )
+    assert is_ok1 is False
+    assert "群组在黑名单中" in str(reason1)
+
+    ctx_group_allow = UsableFilterContext(
+        stream_id="s1", chat_type="group", platform="qq", group_id="123456"
+    )
+    is_ok2, _ = evaluate_usable_filter(DummyToolWithGroupScope, ctx_group_allow)
+    assert is_ok2 is True
+
+    ctx_group_unauth = UsableFilterContext(
+        stream_id="s1", chat_type="group", platform="qq", group_id="777777"
+    )
+    is_ok3, reason3 = evaluate_usable_filter(
+        DummyToolWithGroupScope, ctx_group_unauth
+    )
+    assert is_ok3 is False
+    assert "群组不匹配" in str(reason3)
+
+
+def test_evaluate_usable_filter_user() -> None:
+    """用户 ID 黑白名单校验。"""
+    ctx_deny = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="qq", user_id="30003"
+    )
+    is_ok1, reason1 = evaluate_usable_filter(DummyToolWithUserScope, ctx_deny)
+    assert is_ok1 is False
+    assert "用户在黑名单中" in str(reason1)
+
+    ctx_allow = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="qq", user_id="10001"
+    )
+    is_ok2, _ = evaluate_usable_filter(DummyToolWithUserScope, ctx_allow)
+    assert is_ok2 is True
+
+    ctx_unauth = UsableFilterContext(
+        stream_id="s1", chat_type="private", platform="qq", user_id="40004"
+    )
+    is_ok3, reason3 = evaluate_usable_filter(DummyToolWithUserScope, ctx_unauth)
+    assert is_ok3 is False
+    assert "用户不匹配" in str(reason3)
+
+
+def test_evaluate_usable_filter_content_types() -> None:
+    """内容段格式支持校验。"""
+    ctx_supported = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        accept_formats=["text", "image", "emoji"],
+    )
+    is_ok1, _ = evaluate_usable_filter(DummyActionWithFormats, ctx_supported)
+    assert is_ok1 is True
+
+    ctx_unsupported = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        accept_formats=["text"],  # 缺少 image
+    )
+    is_ok2, reason2 = evaluate_usable_filter(
+        DummyActionWithFormats, ctx_unsupported
+    )
+    assert is_ok2 is False
+    assert "适配器不支持内容格式" in str(reason2)
+
+
+def test_build_filter_context_from_stream() -> None:
+    """从 ChatStream 和 Chatter 实例提取上下文快照。"""
+    mock_stream = MagicMock()
+    mock_stream.stream_id = "stream_demo_1"
+    mock_stream.chat_type = "group"
+    mock_stream.platform = "qq"
+
+    mock_msg = MagicMock()
+    mock_msg.sender_id = "12345"
+    mock_msg.extra = {
+        "group_id": "888888",
+        "format_info": {"accept_format": ["text", "image"]},
+    }
+
+    mock_stream.context.current_message = mock_msg
+    mock_stream.context.unread_messages = []
+
+    mock_chatter = MagicMock()
+    mock_chatter.name = "demo_chatter"
+    mock_chatter.get_signature.return_value = "plugin:chatter:demo"
+
+    ctx = build_filter_context_from_stream(mock_stream, mock_chatter)
+    assert ctx.stream_id == "stream_demo_1"
+    assert ctx.chat_type == "group"
+    assert ctx.platform == "qq"
+    assert ctx.group_id == "888888"
+    assert ctx.user_id == "12345"
+    assert ctx.chatter_name == "demo_chatter"
+    assert ctx.chatter_signature == "plugin:chatter:demo"
+    assert ctx.accept_formats == ["text", "image"]
+
+
+def test_normalize_str_list_none() -> None:
+    """None 输入应安全返回空列表。"""
+    from src.core.components.usable_filter import _normalize_str_list
+
+    assert _normalize_str_list(None) == []
+
+
+def test_resolve_allowed_chat_types_all() -> None:
+    """包含 ChatType.ALL 或 'all' 的列表声明应返回空集合。"""
+    from src.core.components.usable_filter import _resolve_allowed_chat_types
+
+    assert _resolve_allowed_chat_types([ChatType.ALL]) == set()
+    assert _resolve_allowed_chat_types(["all"]) == set()
+
+
+class DummyToolSingleValues:
+    """属性为非列表标量值的组件。"""
+
+    name = "dummy_single_values"
+    chatter_allow = "main_chatter"
+    chatter_deny = "blocked_chatter"
+    platform_allow = "qq"
+    platform_deny = "discord"
+    stream_allow = "s1"
+    stream_deny = "s_blocked"
+    group_allow = 123456
+    group_deny = 999999
+    user_allow = 10001
+    user_deny = 30003
+    chat_type = "group"
+
+
+class DummyToolInvalidCollection:
+    """属性为非列表/标量无效类型的组件。"""
+
+    name = "dummy_invalid"
+    chatter_allow = {"invalid": True}  # type: ignore
+
+
+class DummyToolValidateAssociatedTypesRaises:
+    """validate_associated_types 抛出异常的组件。"""
+
+    name = "dummy_raises"
+    associated_types = ["text"]
+
+    @classmethod
+    def validate_associated_types(cls) -> list[str]:
+        raise ValueError("模拟校验异常")
+
+
+def test_evaluate_usable_filter_scalar_attributes() -> None:
+    """测试单个标量属性（如单个字符串/数字）的自动规范化解析。"""
+    ctx = UsableFilterContext(
+        stream_id="s1",
+        chat_type="group",
+        platform="qq",
+        group_id="123456",
+        user_id="10001",
+        chatter_name="main_chatter",
+    )
+    is_ok, _ = evaluate_usable_filter(DummyToolSingleValues, ctx)
+    assert is_ok is True
+
+
+def test_evaluate_usable_filter_invalid_attribute_type() -> None:
+    """非合法集合类型属性应安全退化为空列表。"""
+    ctx = UsableFilterContext(stream_id="s1", chat_type="private", platform="qq")
+    is_ok, _ = evaluate_usable_filter(DummyToolInvalidCollection, ctx)
+    assert is_ok is True
+
+
+def test_evaluate_usable_filter_validate_types_exception_fallback() -> None:
+    """validate_associated_types 抛出异常时回退到 associated_types 属性。"""
+    ctx = UsableFilterContext(
+        stream_id="s1",
+        chat_type="private",
+        platform="qq",
+        accept_formats=["text"],
+    )
+    is_ok, _ = evaluate_usable_filter(
+        DummyToolValidateAssociatedTypesRaises, ctx
+    )
+    assert is_ok is True
+
+
+def test_build_filter_context_from_unread_messages_and_stream_group_id() -> None:
+    """current_message 为空时回退到 unread_messages，且 group_id 从 stream 属性提取。"""
+    mock_stream = MagicMock()
+    mock_stream.stream_id = "stream_unread"
+    mock_stream.chat_type = "group"
+    mock_stream.platform = "qq"
+    mock_stream.group_id = "55555"
+
+    mock_unread_msg = MagicMock()
+    mock_unread_msg.sender_id = "sender_unread"
+    mock_unread_msg.group_id = None
+    mock_unread_msg.extra = {
+        "format_info": {"accept_format": "text"},
+    }
+
+    mock_stream.context.current_message = None
+    mock_stream.context.unread_messages = [mock_unread_msg]
+
+    mock_chatter = MagicMock()
+    mock_chatter.name = "demo"
+    mock_chatter.get_signature.return_value = None
+
+    ctx = build_filter_context_from_stream(mock_stream, mock_chatter)
+    assert ctx.stream_id == "stream_unread"
+    assert ctx.user_id == "sender_unread"
+    assert ctx.group_id == "55555"
+    assert ctx.accept_formats == ["text"]

--- a/test/core/managers/test_action_manager.py
+++ b/test/core/managers/test_action_manager.py
@@ -141,11 +141,11 @@ class TestActionManagerGetActionsForPlugin:
             assert result == {}
 
 
-class TestActionManagerGetActionsForChat:
+class TestActionManagerFilterActionsForChat:
     """测试根据聊天上下文过滤 Action 功能。"""
     
     @pytest.mark.asyncio
-    async def test_get_actions_for_chat_all_type(self) -> None:
+    async def test_filter_actions_for_chat_all_type(self) -> None:
         """测试获取 ALL 类型的 Action。"""
         manager = ActionManager()
         
@@ -159,7 +159,7 @@ class TestActionManagerGetActionsForChat:
             mock_registry.get_by_type.return_value = actions
             mock_get_registry.return_value = mock_registry
             
-            result = await manager.get_actions_for_chat(
+            result = await manager.filter_actions_for_chat(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
@@ -169,7 +169,7 @@ class TestActionManagerGetActionsForChat:
             assert len(result) > 0
     
     @pytest.mark.asyncio
-    async def test_get_actions_for_chat_specific_type(self) -> None:
+    async def test_filter_actions_for_chat_specific_type(self) -> None:
         """测试获取特定聊天类型的 Action。"""
         manager = ActionManager()
         
@@ -183,13 +183,13 @@ class TestActionManagerGetActionsForChat:
             mock_registry.get_by_type.return_value = actions
             mock_get_registry.return_value = mock_registry
             
-            result_group = await manager.get_actions_for_chat(
+            result_group = await manager.filter_actions_for_chat(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
             )
             
-            result_private = await manager.get_actions_for_chat(
+            result_private = await manager.filter_actions_for_chat(
                 chat_type=ChatType.PRIVATE,
                 chatter_name="",
                 platform=""
@@ -200,7 +200,7 @@ class TestActionManagerGetActionsForChat:
             assert len(result_private) == 0
     
     @pytest.mark.asyncio
-    async def test_get_actions_for_chat_empty(self) -> None:
+    async def test_filter_actions_for_chat_empty(self) -> None:
         """测试无匹配 Action 时返回空列表。"""
         manager = ActionManager()
         
@@ -209,7 +209,7 @@ class TestActionManagerGetActionsForChat:
             mock_registry.get_by_type.return_value = {}
             mock_get_registry.return_value = mock_registry
             
-            result = await manager.get_actions_for_chat(
+            result = await manager.filter_actions_for_chat(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
@@ -297,7 +297,7 @@ class TestActionManagerGetActionSchemas:
         manager = ActionManager()
         
         
-        with patch.object(manager, 'get_actions_for_chat', return_value=[TestAction, TestAction]), patch.object(
+        with patch.object(manager, 'filter_actions_for_chat', return_value=[TestAction, TestAction]), patch.object(
             manager, 'get_action_schema'
         ) as mock_get_schema:
             mock_get_schema.side_effect = [
@@ -318,7 +318,7 @@ class TestActionManagerGetActionSchemas:
         """测试无 Action 时返回空列表。"""
         manager = ActionManager()
         
-        with patch.object(manager, 'get_actions_for_chat') as mock_get_actions:
+        with patch.object(manager, 'filter_actions_for_chat') as mock_get_actions:
             mock_get_actions.return_value = []
             
             result = await manager.get_action_schemas(

--- a/test/core/managers/test_action_manager.py
+++ b/test/core/managers/test_action_manager.py
@@ -144,7 +144,8 @@ class TestActionManagerGetActionsForPlugin:
 class TestActionManagerGetActionsForChat:
     """测试根据聊天上下文过滤 Action 功能。"""
     
-    def test_get_actions_for_chat_all_type(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_actions_for_chat_all_type(self) -> None:
         """测试获取 ALL 类型的 Action。"""
         manager = ActionManager()
         
@@ -158,7 +159,7 @@ class TestActionManagerGetActionsForChat:
             mock_registry.get_by_type.return_value = actions
             mock_get_registry.return_value = mock_registry
             
-            result = manager.get_actions_for_chat(
+            result = await manager.get_actions_for_chat(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
@@ -167,7 +168,8 @@ class TestActionManagerGetActionsForChat:
             # ALL 类型应该匹配所有聊天类型
             assert len(result) > 0
     
-    def test_get_actions_for_chat_specific_type(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_actions_for_chat_specific_type(self) -> None:
         """测试获取特定聊天类型的 Action。"""
         manager = ActionManager()
         
@@ -181,13 +183,13 @@ class TestActionManagerGetActionsForChat:
             mock_registry.get_by_type.return_value = actions
             mock_get_registry.return_value = mock_registry
             
-            result_group = manager.get_actions_for_chat(
+            result_group = await manager.get_actions_for_chat(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
             )
             
-            result_private = manager.get_actions_for_chat(
+            result_private = await manager.get_actions_for_chat(
                 chat_type=ChatType.PRIVATE,
                 chatter_name="",
                 platform=""
@@ -197,7 +199,8 @@ class TestActionManagerGetActionsForChat:
             assert len(result_group) > 0
             assert len(result_private) == 0
     
-    def test_get_actions_for_chat_empty(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_actions_for_chat_empty(self) -> None:
         """测试无匹配 Action 时返回空列表。"""
         manager = ActionManager()
         
@@ -206,7 +209,7 @@ class TestActionManagerGetActionsForChat:
             mock_registry.get_by_type.return_value = {}
             mock_get_registry.return_value = mock_registry
             
-            result = manager.get_actions_for_chat(
+            result = await manager.get_actions_for_chat(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
@@ -288,7 +291,8 @@ class TestActionManagerGetActionSchema:
 class TestActionManagerGetActionSchemas:
     """测试批量获取 Action schemas 功能。"""
     
-    def test_get_action_schemas_multiple(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_action_schemas_multiple(self) -> None:
         """测试获取多个 Action 的 schemas。"""
         manager = ActionManager()
         
@@ -301,7 +305,7 @@ class TestActionManagerGetActionSchemas:
                 {"name": "schema2"},
             ]
             
-            result = manager.get_action_schemas(
+            result = await manager.get_action_schemas(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""
@@ -309,14 +313,15 @@ class TestActionManagerGetActionSchemas:
             
             assert len(result) == 2
     
-    def test_get_action_schemas_empty(self) -> None:
+    @pytest.mark.asyncio
+    async def test_get_action_schemas_empty(self) -> None:
         """测试无 Action 时返回空列表。"""
         manager = ActionManager()
         
         with patch.object(manager, 'get_actions_for_chat') as mock_get_actions:
             mock_get_actions.return_value = []
             
-            result = manager.get_action_schemas(
+            result = await manager.get_action_schemas(
                 chat_type=ChatType.GROUP,
                 chatter_name="",
                 platform=""

--- a/test/core/managers/test_action_manager.py
+++ b/test/core/managers/test_action_manager.py
@@ -150,23 +150,16 @@ class TestActionManagerFilterActionsForChat:
         manager = ActionManager()
         
         TestAction.supported_chat_types = [ChatType.ALL]
-        actions = {
-            "test_plugin:action:test": TestAction,
-        }
         
-        with patch('src.core.managers.action_manager.get_global_registry') as mock_get_registry:
-            mock_registry = MagicMock()
-            mock_registry.get_by_type.return_value = actions
-            mock_get_registry.return_value = mock_registry
-            
-            result = await manager.filter_actions_for_chat(
-                chat_type=ChatType.GROUP,
-                chatter_name="",
-                platform=""
-            )
-            
-            # ALL 类型应该匹配所有聊天类型
-            assert len(result) > 0
+        result = await manager.filter_actions_for_chat(
+            [TestAction],
+            chat_type=ChatType.GROUP,
+            chatter_name="",
+            platform="",
+        )
+        
+        # ALL 类型应该匹配所有聊天类型
+        assert len(result) > 0
     
     @pytest.mark.asyncio
     async def test_filter_actions_for_chat_specific_type(self) -> None:
@@ -174,48 +167,38 @@ class TestActionManagerFilterActionsForChat:
         manager = ActionManager()
         
         TestAction.supported_chat_types = [ChatType.GROUP]
-        actions = {
-            "test_plugin:action:test": TestAction,
-        }
         
-        with patch('src.core.managers.action_manager.get_global_registry') as mock_get_registry:
-            mock_registry = MagicMock()
-            mock_registry.get_by_type.return_value = actions
-            mock_get_registry.return_value = mock_registry
-            
-            result_group = await manager.filter_actions_for_chat(
-                chat_type=ChatType.GROUP,
-                chatter_name="",
-                platform=""
-            )
-            
-            result_private = await manager.filter_actions_for_chat(
-                chat_type=ChatType.PRIVATE,
-                chatter_name="",
-                platform=""
-            )
-            
-            # 应该只匹配 GROUP 类型
-            assert len(result_group) > 0
-            assert len(result_private) == 0
+        result_group = await manager.filter_actions_for_chat(
+            [TestAction],
+            chat_type=ChatType.GROUP,
+            chatter_name="",
+            platform="",
+        )
+        
+        result_private = await manager.filter_actions_for_chat(
+            [TestAction],
+            chat_type=ChatType.PRIVATE,
+            chatter_name="",
+            platform="",
+        )
+        
+        # 应该只匹配 GROUP 类型
+        assert len(result_group) > 0
+        assert len(result_private) == 0
     
     @pytest.mark.asyncio
     async def test_filter_actions_for_chat_empty(self) -> None:
-        """测试无匹配 Action 时返回空列表。"""
+        """测试空列表直接返回空列表。"""
         manager = ActionManager()
         
-        with patch('src.core.managers.action_manager.get_global_registry') as mock_get_registry:
-            mock_registry = MagicMock()
-            mock_registry.get_by_type.return_value = {}
-            mock_get_registry.return_value = mock_registry
-            
-            result = await manager.filter_actions_for_chat(
-                chat_type=ChatType.GROUP,
-                chatter_name="",
-                platform=""
-            )
-            
-            assert result == []
+        result = await manager.filter_actions_for_chat(
+            [],
+            chat_type=ChatType.GROUP,
+            chatter_name="",
+            platform="",
+        )
+        
+        assert result == []
 
 
 class TestActionManagerGetActionClass:

--- a/test/core/managers/test_action_manager.py
+++ b/test/core/managers/test_action_manager.py
@@ -293,7 +293,9 @@ class TestActionManagerGetActionSchemas:
         manager = ActionManager()
         
         
-        with patch.object(manager, 'get_action_schema') as mock_get_schema:
+        with patch.object(manager, 'get_actions_for_chat', return_value=[TestAction, TestAction]), patch.object(
+            manager, 'get_action_schema'
+        ) as mock_get_schema:
             mock_get_schema.side_effect = [
                 {"name": "schema1"},
                 {"name": "schema2"},

--- a/test/core/test_components_base_chatter.py
+++ b/test/core/test_components_base_chatter.py
@@ -270,11 +270,17 @@ class TestBaseChatter:
         mock_stream.context = MagicMock()
         mock_stream.context.current_message = None
 
+        def _resolve_plugin(name: str) -> MagicMock | None:
+            """按插件名返回对应 plugin mock。"""
+            if name == "plugin_b":
+                return owner_plugin
+            return MagicMock(plugin_name=name)
+
         with patch("src.core.components.base.chatter.get_stream_manager") as mock_sm, patch(
-            "src.core.components.base.chatter.get_plugin_manager"
+            "src.core.managers.get_plugin_manager"
         ) as mock_pm:
             mock_sm.return_value.get_or_create_stream = AsyncMock(return_value=mock_stream)
-            mock_pm.return_value.get_plugin.return_value = owner_plugin
+            mock_pm.return_value.get_plugin.side_effect = _resolve_plugin
 
             result = await chatter.modify_llm_usables([CrossPluginTool])
 
@@ -314,8 +320,15 @@ class TestBaseChatter:
         mock_stream.stream_id = "stream_123"
         mock_stream.context = MagicMock()
 
-        with patch("src.core.components.base.chatter.get_stream_manager") as mock_sm:
+        def _resolve_plugin(name: str) -> MagicMock:
+            """按插件名返回对应 plugin mock。"""
+            return MagicMock(plugin_name=name)
+
+        with patch("src.core.components.base.chatter.get_stream_manager") as mock_sm, patch(
+            "src.core.managers.get_plugin_manager"
+        ) as mock_pm:
             mock_sm.return_value.get_or_create_stream = AsyncMock(return_value=mock_stream)
+            mock_pm.return_value.get_plugin.side_effect = _resolve_plugin
 
             result = await chatter.modify_llm_usables([AllowedTool, RejectedTool, OpenTool])
 

--- a/test/plugins/snowluma_extension/__init__.py
+++ b/test/plugins/snowluma_extension/__init__.py
@@ -1,0 +1,1 @@
+"""snowluma_extension 插件测试包。"""

--- a/test/plugins/snowluma_extension/test_usable_filter_live.py
+++ b/test/plugins/snowluma_extension/test_usable_filter_live.py
@@ -1,0 +1,167 @@
+"""验证新管理器架构对 snowluma_extension 真实工具类的筛选链路。
+
+链路：
+    ToolComponentManager.filter_tools_for_chat（静态筛选 + BEFORE_TOOL_FILTER 事件钩子）
+    -> GetGroupJoinRequestsTool（仅静态维度过滤，不做 go_activate 激活）
+
+实体名单（如群白名单）过滤由 BEFORE_TOOL_FILTER 事件处理器承担。
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from src.core.components.types import ChatType, EventType
+from src.kernel.event import EventDecision, get_event_bus
+from src.core.managers.tool_manager.manager import get_tool_component_manager
+from src.core.models.stream import ChatStream
+
+from plugins.snowluma_extension.config import SnowLumaExtensionConfig
+from plugins.snowluma_extension.src.tools import GetGroupJoinRequestsTool
+
+ALLOWED_GROUP = "160791652"
+DENIED_GROUP = "169850076"
+
+
+def _make_plugin(config: SnowLumaExtensionConfig) -> MagicMock:
+    """构造带真实配置的 mock 插件实例。"""
+    plugin = MagicMock()
+    plugin.config = config
+    plugin.plugin_name = "snowluma_extension"
+    return plugin
+
+
+def _make_message(group_id: str) -> MagicMock:
+    """构造携带群号的消息对象。"""
+    msg = MagicMock()
+    msg.stream_id = f"qq_group_{group_id}"
+    msg.extra = {"group_id": group_id}
+    msg.processed_plain_text = "查询加群请求"
+    msg.content = "查询加群请求"
+    return msg
+
+
+def _group_allowlist_handler(group_list: list[str | int]):
+    """构造按群名单改写 usables 的 BEFORE_TOOL_FILTER 事件处理器。"""
+    allowed = {str(g) for g in group_list}
+
+    async def _handler(
+        event_name: str, params: dict
+    ) -> tuple[EventDecision, dict]:
+        stream_id = str(params.get("stream_id") or "")
+        group_id = stream_id.replace("qq_group_", "")
+        if group_id not in allowed:
+            params["usables"] = []
+        return EventDecision.SUCCESS, params
+
+    return _handler
+
+
+@pytest.fixture
+def manager() -> object:
+    """返回全局 ToolComponentManager 实例。"""
+    return get_tool_component_manager()
+
+
+@pytest.fixture
+def whitelist_config() -> SnowLumaExtensionConfig:
+    """构造仅白名单允许指定群的配置。"""
+    config = SnowLumaExtensionConfig()
+    config.plugin.enabled = True
+    config.join_request.enable = True
+    config.join_request.group_list_type = "white"
+    config.join_request.group_list = [int(ALLOWED_GROUP)]
+    return config
+
+
+@pytest.mark.asyncio
+async def test_whitelisted_group_tool_survives_static_filter(
+    manager: object,
+    whitelist_config: SnowLumaExtensionConfig,
+) -> None:
+    """白名单群：工具应通过静态筛选与事件钩子存活。"""
+    msg = _make_message(ALLOWED_GROUP)
+    chat_stream = ChatStream(
+        stream_id=msg.stream_id,
+        platform="qq",
+        chat_type=ChatType.GROUP.value,
+    )
+
+    handler = _group_allowlist_handler(whitelist_config.join_request.group_list)
+    get_event_bus().subscribe(EventType.BEFORE_TOOL_FILTER, handler)
+    try:
+        usables = await manager.filter_tools_for_chat(  # type: ignore[attr-defined]
+            [GetGroupJoinRequestsTool],
+            chat_type="group",
+            platform="qq",
+            stream_id=msg.stream_id,
+            chat_stream=chat_stream,
+            stream_context=chat_stream.context,
+        )
+    finally:
+        get_event_bus().unsubscribe(EventType.BEFORE_TOOL_FILTER, handler)
+
+    assert GetGroupJoinRequestsTool in usables
+
+
+@pytest.mark.asyncio
+async def test_denied_group_tool_removed_by_before_filter_event(
+    manager: object,
+    whitelist_config: SnowLumaExtensionConfig,
+) -> None:
+    """非白名单群：工具经 BEFORE_TOOL_FILTER 事件剔除。"""
+    msg = _make_message(DENIED_GROUP)
+    chat_stream = ChatStream(
+        stream_id=msg.stream_id,
+        platform="qq",
+        chat_type=ChatType.GROUP.value,
+    )
+
+    handler = _group_allowlist_handler(whitelist_config.join_request.group_list)
+    get_event_bus().subscribe(EventType.BEFORE_TOOL_FILTER, handler)
+    try:
+        usables = await manager.filter_tools_for_chat(  # type: ignore[attr-defined]
+            [GetGroupJoinRequestsTool],
+            chat_type="group",
+            platform="qq",
+            stream_id=msg.stream_id,
+            chat_stream=chat_stream,
+            stream_context=chat_stream.context,
+        )
+    finally:
+        get_event_bus().unsubscribe(EventType.BEFORE_TOOL_FILTER, handler)
+
+    assert GetGroupJoinRequestsTool not in usables
+
+
+@pytest.mark.asyncio
+async def test_before_tool_filter_event_can_rewrite_usables(
+    manager: object,
+) -> None:
+    """BEFORE_TOOL_FILTER 事件处理器可改写组件集合。"""
+    bus = get_event_bus()
+    event_fired = False
+
+    async def blocker(
+        event_name: str, params: dict
+    ) -> tuple[EventDecision, dict]:
+        nonlocal event_fired
+        event_fired = True
+        params["usables"] = []
+        return EventDecision.SUCCESS, params
+
+    bus.subscribe(EventType.BEFORE_TOOL_FILTER, blocker)
+    try:
+        filtered = await manager.filter_tools_for_chat(  # type: ignore[attr-defined]
+            [GetGroupJoinRequestsTool],
+            chat_type="group",
+            platform="qq",
+            stream_id=f"qq_group_{ALLOWED_GROUP}",
+        )
+    finally:
+        bus.unsubscribe(EventType.BEFORE_TOOL_FILTER, blocker)
+
+    assert event_fired is True
+    assert GetGroupJoinRequestsTool not in filtered


### PR DESCRIPTION
# feat: 新增 LLMUsable 核心组件细粒度作用域与两阶段过滤体系

## 摘要 (Summary)

本 PR 为 Neo-MoFox 核心框架引入了通用的 **LLMUsable（Action / Tool / Agent）细粒度作用域与两阶段过滤引擎（UsableFilterEngine）**。
补齐了框架层面在实体级（群组 ID、会话流 ID、用户 ID）作用域声明缺失、黑名单（Deny-first）排除机制缺失，以及静态未命中组件被无谓实例化异步调度导致的性能与 Token 损耗等架构缺口。

---

## 变更背景与动机 (Motivation)

1. **会话流与实体粒度缺口**：
   原有框架仅具备粗粒度的 `ChatType`（私聊/群聊/全部），组件无法通过声明式方式限定特定的群组 ID、特定的聊天流 ID 或特定的调用用户 ID。
2. **反向排除（Deny-first）与安全控制缺失**：
   缺乏黑名单机制，无法声明“在除某群之外的全域生效”或“在特定 Chatter 中禁用”等常见反向过滤策略。
3. **两阶段流水线消除冗余开销**：
   重构 `BaseChatter.modify_llm_usables()`，在 Phase 1 毫秒级直接静态排除不符合作用域的组件，仅对存活组件在 Phase 2 进行对象创建与 `go_activate()` 异步并发调度，大幅降低系统调度开销并减少暴露给大模型的 Tool Schema Token 与误调用概率。

---

## 核心架构设计 (Architecture & Technical Design)

### 1. 七大维度作用域规范 (Scope Dimensions)
在 `BaseAction`、`BaseTool`、`BaseAgent` 基类中统一定义以下规范属性：
- **Chatter 作用域**：`chatter_allow: list[str] = []` / `chatter_deny: list[str] = []`
- **ChatType 作用域**：`chat_type: ChatType | list[ChatType] = ChatType.ALL`
- **Platform 平台作用域**：`platform_allow: list[str] = []` / `platform_deny: list[str] = []`（兼容 `associated_platforms`）
- **Stream 聊天流作用域**：`stream_allow: list[str] = []` / `stream_deny: list[str] = []`
- **Group 群组实体作用域**：`group_allow: list[str | int] = []` / `group_deny: list[str | int] = []`（仅群聊生效）
- **User 用户实体作用域**：`user_allow: list[str | int] = []` / `user_deny: list[str | int] = []`
- **Content Formats 消息段格式**：`associated_types: list[str] = []`

### 2. 两阶段过滤流水线 (Two-Phase Pipeline)
```text
组件候选集 -> Phase 1: Fast-Path 静态元数据评估 (UsableFilterEngine，纯内存计算，零实例化)
          -> Phase 2: Slow-Path 动态激活判定 (仅对存活组件实例化并异步执行 go_activate)
          -> 最终注入 LLM Tool Registry
```

### 3. 上下文快照模型 (`UsableFilterContext`)
采用不可变、无副作用的 `@dataclass(frozen=True, slots=True)`，从 `ChatStream` / `Chatter` 提取会话状态，供过滤引擎与管理层（`ActionManager`、`agent_api` 等）统一复用。

---

## 文件修改清单 (Changed Files)

| 文件路径 | 变更类型 | 说明 |
|---|---|---|
| `src/core/components/usable_filter.py` | 新增 | 核心作用域评估引擎与 `UsableFilterContext` 数据结构 |
| `src/core/components/__init__.py` | 修改 | 导出过滤引擎核心对象并规范 `__all__` |
| `src/core/components/base/action.py` | 修改 | 扩充 7 大维度作用域类属性定义与类型注解 |
| `src/core/components/base/tool.py` | 修改 | 扩充 7 大维度作用域类属性定义与类型注解 |
| `src/core/components/base/agent.py` | 修改 | 扩充 7 大维度作用域类属性定义与类型注解 |
| `src/core/components/base/chatter.py` | 修改 | 重构 `modify_llm_usables()` 接入两阶段过滤流水线 |
| `src/core/managers/action_manager.py` | 修改 | `get_actions_for_chat()` 统一接入 `UsableFilterEngine` |
| `src/app/plugin_system/api/agent_api.py` | 修改 | `get_agents_for_chat()` 统一接入 `UsableFilterEngine` |
| `src/kernel/llm/request.py` | 修改 | `LLMRequest` 新增 `stream_id` 属性访问器 |
| `test/core/components/test_usable_filter.py` | 新增 | 核心过滤引擎 100% 覆盖率单元测试 (16 个测试用例) |
| `test/core/components/test_chatter_modify_usables.py` | 新增 | Chatter 两阶段流水线集成测试 |
| `test/core/managers/test_action_manager.py` | 修改 | 完善 Mock 隔离边界 |
| `examples/src/core/components/usable_filter_example.py` | 新增 | 通用作用域声明与过滤引擎使用示例 |

---

## 验证与测试 (Verification & Testing)

1. **单测覆盖率验证**：
   `test/core/components/test_usable_filter.py` 达到 **100% 行覆盖率**。
2. **集成与回归验证**：
   相关组件与 API 测试套件（`test_usable_filter.py`、`test_chatter_modify_usables.py`、`test_components_base_chatter.py`、`test_action_manager.py`、`test_agent_api.py`）**98 passed 0 failed**。
3. **代码风格与静态检查**：
   `uv run ruff check` 全部通过（All checks passed）。
4. **示例脚本运行**：
   `uv run python examples/src/core/components/usable_filter_example.py` 成功执行并验证通用作用域过滤场景。

## Summary by Sourcery

Introduce fine-grained LLMUsable scoping and a shared two-stage filtering pipeline across Action, Tool, and Agent components.

New Features:
- Add reusable fine-grained scope declarations for Action, Tool, and Agent components, including allow/deny rules for chatters, platforms, streams, groups, and users.
- Add a shared filtering context and static evaluation engine with deny-first behavior and content-format checks.
- Add Tool component management APIs and Agent manager abstractions for querying, filtering, activation, schemas, and execution.
- Add pre-filter lifecycle events that allow external handlers to modify candidate component sets.

Enhancements:
- Refactor Chatter and component managers to use a two-stage pipeline that performs static filtering before dynamic activation.
- Centralize Action, Tool, and Agent filtering and activation behavior behind manager and plugin-system APIs.
- Expose stream identifiers through LLM requests and improve schema cache management and API delegation.

Documentation:
- Add examples demonstrating component scopes and update Action and Agent API examples for asynchronous filtering and schema queries.

Tests:
- Add comprehensive unit, integration, and live-plugin coverage for scope evaluation, two-stage activation, event-based filtering, and manager APIs.

Chores:
- Update plugin API version registration and exports for the new Tool API and manager components.