### PR TITLE
fix: get_or_create_stream 增加无锁读快速路径，消除高压并发下的锁排队

### DIFF
--- a/src/core/managers/stream_manager.py
+++ b/src/core/managers/stream_manager.py
@@ -303,10 +303,20 @@ class StreamManager:
                 group_id=group_id,
             )
 
+        # 读快速路径：流已存在时直接返回，不抢流级锁。
+        # 高压下大量协程（每条消息）并发获取同一已存在流，若一律串行抢锁会
+        # 使读路径在锁上排队（曾导致 inject_usables 被挤到 30 秒超时）。
+        # 仅当未命中缓存时才进入写路径，锁内二次检查防止并发重复创建。
+        existed = self._streams.get(stream_id)
+        if existed is not None:
+            await self._ensure_stream_bot_identity(existed)
+            logger.debug(f"获取已存在的流实例: {stream_id}")
+            return existed
+
         # 并发保护：同一个 stream_id 的创建/加载必须串行化
         lock = self._get_stream_lock(stream_id)
         async with lock:
-            # 检查，避免等待锁期间已被其他协程创建
+            # 二次检查，避免等待锁期间已被其他协程创建
             existed = self._streams.get(stream_id)
             if existed is not None:
                 await self._ensure_stream_bot_identity(existed)

--- a/test/core/managers/test_stream_manager_get_or_create.py
+++ b/test/core/managers/test_stream_manager_get_or_create.py
@@ -488,3 +488,66 @@ def test_serialize_content_for_db_keeps_non_binary_media_data() -> None:
 
     assert "file-001" in serialized
     assert "99999" in serialized
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_stream_fast_path_ignores_locked_write_path() -> None:
+    """已存在流应走无锁快速路径：即使写路径锁被长期占用也不阻塞读。"""
+    from src.core.managers.stream_manager import StreamManager
+
+    manager = StreamManager()
+    stream_id = "stream-fast-path-001"
+    cached_stream = SimpleNamespace(
+        stream_id=stream_id,
+        platform="qq",
+        bot_id="bot-1",
+        bot_nickname="Bot",
+        context=SimpleNamespace(),
+    )
+    manager._streams[stream_id] = cached_stream  # type: ignore[assignment]
+    manager._streams_crud.get_by = AsyncMock(return_value=None)
+    manager._create_new_stream = AsyncMock()  # type: ignore[method-assign]
+
+    # 预先占用写路径锁（模拟高压下正在进行的创建/加载）
+    lock = manager._get_stream_lock(stream_id)
+    await lock.acquire()
+    try:
+        # 快速路径不应等待锁，直接返回缓存实例
+        result = await asyncio.wait_for(
+            manager.get_or_create_stream(stream_id=stream_id, platform="qq"),
+            timeout=1.0,
+        )
+    finally:
+        lock.release()
+
+    assert result is cached_stream
+    assert manager._streams_crud.get_by.await_count == 0
+    assert manager._create_new_stream.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_or_create_stream_concurrent_create_still_once(monkeypatch) -> None:
+    """流不存在时并发创建：double-check 仍应保证只创建一次。"""
+    from src.core.managers.stream_manager import StreamManager
+
+    manager = StreamManager()
+    stream_id = "stream-double-check-001"
+    fake_stream = SimpleNamespace(
+        stream_id=stream_id,
+        platform="qq",
+        bot_id="",
+        bot_nickname="",
+        context=SimpleNamespace(),
+    )
+    manager._streams_crud.get_by = AsyncMock(return_value=None)
+    manager._create_new_stream = AsyncMock(return_value=fake_stream)  # type: ignore[method-assign]
+
+    first, second = await asyncio.gather(
+        manager.get_or_create_stream(stream_id=stream_id, platform="qq"),
+        manager.get_or_create_stream(stream_id=stream_id, platform="qq"),
+    )
+
+    assert first is fake_stream
+    assert second is fake_stream
+    assert manager._create_new_stream.await_count == 1
+    assert manager._streams_crud.get_by.await_count == 1


### PR DESCRIPTION
# PR: get_or_create_stream 增加无锁读快速路径

## 改动内容

`StreamManager.get_or_create_stream` 在获取流级锁之前增加无锁读快速路径：

- 缓存中已有该 `stream_id` 的流实例时，直接回填 Bot 身份信息后返回，不再抢流级锁
- 未命中缓存的写路径保持原逻辑：流级锁串行化 + 锁内二次检查（double-check），防止并发重复建流

同时新增两个回归测试：

- `test_get_or_create_stream_fast_path_ignores_locked_write_path`：写路径锁被长期占用时，读快速路径不应阻塞（1 秒超时内返回缓存实例）
- `test_get_or_create_stream_concurrent_create_still_once`：流不存在时并发获取，double-check 仍保证只创建一次

## 原因

高压场景下每条消息都会调用 `get_or_create_stream` 获取同一已存在的流。原实现一律抢流级锁，导致大量协程的读路径在锁上排队，间接使 `inject_usables` 等后续步骤被挤到 30 秒超时。已存在流的读取本质上是纯内存字典查询 + 只读回填，无需与写路径（建流/加载）互斥，因此增加无锁快速路径。

## 影响范围

- 仅影响 `src/core/managers/stream_manager.py` 的 `get_or_create_stream`
- 行为语义不变：同一 `stream_id` 仍返回全局唯一实例；新流创建仍经锁串行化
- 其余调用方（消息收发、上下文加载）无感知

## 验证

- `pytest test/core/managers/test_stream_manager_get_or_create.py`：16 passed
- `ruff check src/core/managers/stream_manager.py test/core/managers/test_stream_manager_get_or_create.py`：All checks passed

## Summary by Sourcery

Add a lock-free fast path for existing streams while preserving synchronized creation for cache misses.

Bug Fixes:
- Avoid lock contention for reads of already-cached streams under high concurrency, preventing downstream processing delays and timeouts.

Enhancements:
- Retain serialized stream creation with an in-lock double-check to ensure concurrent requests create each stream only once.

Tests:
- Add regression coverage for the lock-independent cached-stream path and concurrent single-creation behavior.