### PR TITLE
feat(emoji_sender): 新增 picker 模式，支持 LLM 亲自挑选表情包

### DIFF
--- a/plugins/emoji_sender/README.md
+++ b/plugins/emoji_sender/README.md
@@ -11,3 +11,32 @@
 - 检索阶段支持通过 `config/plugins/emoji_sender/config.toml` 中的 `vector.temperature` 控制采样强度，避免代表性表情反复被固定选中
 
 说明：情感 tag 预设为插件内置常量，不进入配置。用户手动删除 `data/emoji_sender/memes/` 中不想要的表情后，会在下一次入库任务开始时自动清理数据库对应条目。
+
+## 发送模式（1.1.0 起）
+
+通过 `config/plugins/emoji_sender/config.toml` 的 `plugin.interaction_mode` 切换，修改后需重载插件：
+
+### direct（默认）——一步直达
+
+注册 Action `send_emoji_meme`：AI 给出"目标描述 + 情感 tag"，插件按向量距离与温度采样自动挑选一张直接发送。
+
+- 适合：简单场景，省一轮 LLM 调用
+- LLM 组件：`send_emoji_meme`
+
+### picker——查询挑选（AI 亲自挑选）
+
+注册 Tool `search_emoji_memes` + Action `send_emoji_meme_by_id`，两段式流程：
+
+1. AI 调用 `search_emoji_memes(描述, [情感tag], page)` 查看候选列表（每项含 id、标签、描述、距离，距离越小越贴切，同一表情多标签已去重）
+2. AI 从中挑选最契合的一张，调用 `send_emoji_meme_by_id(id)` 发送；不满意可换描述重查或翻页
+
+- 适合：希望 AI 对发什么表情有更高控制力、表达更精准的场景
+- 每页数量由 `picker.page_size` 控制（默认 6）
+
+### 使用历史去重（两种模式共通）
+
+`[dedup]` 配置节：
+
+- `enabled`：默认开启。每个聊天流记住最近 `window`（默认 6）张已发送的表情包，检索候选时自动过滤，避免短时间重复发同一张
+- 候选全被过滤时自动回退全量，不会因此无表情可发
+- 历史保存在内存中，重启后清空

--- a/plugins/emoji_sender/action.py
+++ b/plugins/emoji_sender/action.py
@@ -1,8 +1,8 @@
 """emoji_sender Action：发送表情包。
 
-该 Action 面向 LLM Tool Calling：
-- 输入：目标表情包描述文本 + 情感 tag（可多个）
-- 行为：按 tag 过滤候选后向量检索 topN，选择距离满足阈值的最佳表情包发送
+提供两个 Action：
+- SendEmojiMemeAction（direct 模式）：输入目标描述 + 情感 tag，一步完成检索与发送
+- SendEmojiMemeByIdAction（picker 模式）：按 search_emoji_memes 返回的 id 精确发送指定表情包
 """
 
 from __future__ import annotations
@@ -72,5 +72,51 @@ class SendEmojiMemeAction(BaseAction):
             return
 
         # 失败：尽量带上原因
+        yield False, reason
+        return
+
+
+class SendEmojiMemeByIdAction(BaseAction):
+    """按 id 精确发送表情包动作。"""
+
+    name: str = "send_emoji_meme_by_id"
+    description: str = (
+        "按 id 发送一张表情包库中的指定表情包。"
+        "id 必须来自 search_emoji_memes 返回的候选列表；"
+        "此动作可以单独使用也可以和发送文字一起使用，更符合日常聊天习惯。"
+    )
+    primary_action: bool = False
+    associated_types = ["emoji"]
+
+    async def execute(
+        self,
+        meme_id: Annotated[str, "要发送的表情包 id（来自 search_emoji_memes 返回的候选列表）"],
+    ) -> AsyncGenerator[tuple[bool, str] | None, None]:
+        """执行按 id 发送表情包动作。"""
+        service = get_service("emoji_sender:service:emoji_sender")
+        if service is None:
+            yield False, "emoji_sender service 未加载"
+            return
+
+        service = cast(EmojiSenderService, service)
+
+        yield None
+        ok, result, reason = await service.send_by_id(
+            short_id=meme_id,
+            stream_id=self.chat_stream.stream_id,
+            platform=self.chat_stream.platform,
+        )
+
+        if ok:
+            if not result:
+                yield True, "已发送表情包"
+                return
+
+            tag = str(result.get("tag") or "").strip()
+            desc = str(result.get("description") or "").strip()
+            detail = f"已发送表情包\n- 标签: {tag}\n- 描述: {desc}" if desc else f"已发送表情包\n- 标签: {tag}"
+            yield True, detail
+            return
+
         yield False, reason
         return

--- a/plugins/emoji_sender/config.py
+++ b/plugins/emoji_sender/config.py
@@ -10,7 +10,6 @@ from typing import ClassVar
 
 from src.core.components.base.config import BaseConfig, Field, SectionBase, config_section
 
-
 class EmojiSenderConfig(BaseConfig):
     """emoji_sender 插件配置。"""
 
@@ -38,6 +37,15 @@ class EmojiSenderConfig(BaseConfig):
         inject_system_prompt: bool = Field(
             default=True,
             description="是否将表情包使用提示同步到 default_chatter 的 actor system reminder",
+        )
+
+        interaction_mode: str = Field(
+            default="direct",
+            description=(
+                "表情包发送模式：direct=一步直达（插件自动挑选后直接发送）；"
+                "picker=两段式（先查询候选列表，由 AI 亲自挑选后按 id 发送）。"
+                "修改后需重载插件生效。"
+            ),
         )
 
     @config_section("prompt")
@@ -93,6 +101,29 @@ class EmojiSenderConfig(BaseConfig):
             description="检索结果采样温度（<=0 时固定选择最相似项，越大越随机）",
         )
 
+    @config_section("picker")
+    class PickerSection(SectionBase):
+        """两段式挑选模式（interaction_mode="picker"）相关配置。"""
+
+        page_size: int = Field(
+            default=6,
+            description="候选列表每页数量",
+        )
+
+    @config_section("dedup")
+    class DedupSection(SectionBase):
+        """使用历史去重配置。"""
+
+        enabled: bool = Field(
+            default=True,
+            description="是否过滤每个聊天流最近已发送过的表情包（无可用候选时自动回退全量）",
+        )
+
+        window: int = Field(
+            default=6,
+            description="每个聊天流记住的最近已发送表情包数量（即最近 N 张内的不会重复发送）",
+        )
+
     @config_section("storage")
     class StorageSection(SectionBase):
         """文件存储相关配置。"""
@@ -112,4 +143,6 @@ class EmojiSenderConfig(BaseConfig):
     prompt: PromptSection = Field(default_factory=PromptSection)
     ingest: IngestSection = Field(default_factory=IngestSection)
     vector: VectorSection = Field(default_factory=VectorSection)
+    picker: PickerSection = Field(default_factory=PickerSection)
+    dedup: DedupSection = Field(default_factory=DedupSection)
     storage: StorageSection = Field(default_factory=StorageSection)

--- a/plugins/emoji_sender/manifest.json
+++ b/plugins/emoji_sender/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "emoji_sender",
   "display_name": "表情包发送器",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Emoji Sender — 从 media cache 随机挑选表情包，VLM 决策是否收藏并标注入库；按情感 tag + 向量检索发送表情包。",
   "author": "MoFox Team",
   "dependencies": {
@@ -18,6 +18,18 @@
     {
       "component_type": "action",
       "component_name": "send_emoji_meme",
+      "dependencies": [],
+      "enabled": true
+    },
+    {
+      "component_type": "tool",
+      "component_name": "search_emoji_memes",
+      "dependencies": [],
+      "enabled": true
+    },
+    {
+      "component_type": "action",
+      "component_name": "send_emoji_meme_by_id",
       "dependencies": [],
       "enabled": true
     }

--- a/plugins/emoji_sender/plugin.py
+++ b/plugins/emoji_sender/plugin.py
@@ -2,6 +2,10 @@
 
 加载后会注册一个 scheduler 周期任务：定时执行一次入库（对齐→抽取→VLM 决策→收藏入库）。
 注意：scheduler 在 Bot.run() 阶段才 start()，因此这里使用 task_manager 后台协程等待 scheduler 就绪后再注册。
+
+发送模式由 config.plugin.interaction_mode 决定：
+- "direct"：注册 SendEmojiMemeAction（一步直达，插件自动挑选后直接发送）
+- "picker"：注册 SearchEmojiMemesTool + SendEmojiMemeByIdAction（先查询候选，AI 亲自挑选后按 id 发送）
 """
 
 from __future__ import annotations
@@ -13,12 +17,16 @@ from src.core.components import BasePlugin, register_plugin
 from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger
 
-from .action import SendEmojiMemeAction
+from .action import SendEmojiMemeAction, SendEmojiMemeByIdAction
 from .config import EmojiSenderConfig
 from .service import EmojiSenderService
+from .tool import SearchEmojiMemesTool
 
 
 logger = get_logger("emoji_sender")
+
+MODE_DIRECT = "direct"
+MODE_PICKER = "picker"
 
 _TARGET_REMINDER_BUCKET = "actor"
 _TARGET_REMINDER_NAME = "关于表情包的使用"
@@ -31,6 +39,31 @@ _EMOJI_USAGE_REMINDER = (
     "简单发个表情包是个很常见的做法。因此，虽然使用表情包看起来很简单，但是也值得你认真思考，请你在接下来的对话中时刻牢记这个能力，"
     "把表情包用活、用的恰到好处。"
 )
+_EMOJI_USAGE_REMINDER_PICKER = (
+    "表情包的使用在你的日常互动中扮演着非常重要的角色。它直接影响到你向他人所展示出的形象。"
+    "如果你经常只发文字，不发表情包，则通常被认为是严肃、专业的象征，而经常使用表情包则更可能被认为是可爱、活力的象征，"
+    "所以请你认真对待表情包的使用。\n"
+    "同时，表情包使用的时机也是一门学问。当别人和你谈正事等严肃的场合时，随意使用表情包可能被认为嘻嘻哈哈惹人厌的家伙，"
+    "而在日常聊天中使用更多表情包的而不是认真的回复则可能更贴合轻松诙谐的气氛；当你懒得专门打字回应，或者只是冒个泡刷个存在感时，"
+    "简单发个表情包是个很常见的做法。\n"
+    "你发送表情包的方式是两步：先调用 search_emoji_memes 按目标描述（可附带情感标签）检索表情包库，"
+    "查看返回的候选列表（列表中每项含 id、标签、描述与距离，距离越小与你想要的越贴切），"
+    "从中挑选最契合当前语境与你的形象的一张，再用它的 id 调用 send_emoji_meme_by_id 发送；"
+    "如果对候选不满意，可以换更具体的描述重新查询，或翻页查看更多候选。"
+    "请把表情包用活、用的恰到好处。"
+)
+
+
+def _get_interaction_mode(plugin: Any) -> str:
+    """读取当前发送模式，非法值按 direct 处理并告警。"""
+    config = plugin.config
+    if not isinstance(config, EmojiSenderConfig):
+        return MODE_DIRECT
+    mode = str(config.plugin.interaction_mode).strip().lower()
+    if mode not in (MODE_DIRECT, MODE_PICKER):
+        logger.warning(f"未知 interaction_mode: {mode!r}，按 direct 处理")
+        return MODE_DIRECT
+    return mode
 
 
 def build_emoji_sender_actor_reminder(plugin: Any) -> str:
@@ -39,6 +72,8 @@ def build_emoji_sender_actor_reminder(plugin: Any) -> str:
     config = getattr(plugin, "config", None)
     if isinstance(config, EmojiSenderConfig) and not config.plugin.inject_system_prompt:
         return ""
+    if _get_interaction_mode(plugin) == MODE_PICKER:
+        return _EMOJI_USAGE_REMINDER_PICKER
     return _EMOJI_USAGE_REMINDER
 
 
@@ -78,10 +113,12 @@ class EmojiSenderPlugin(BasePlugin):
         self._register_task_id: str | None = None
 
     def get_components(self) -> list[type]:
-        """返回本插件提供的组件类。"""
+        """返回本插件提供的组件类（按 interaction_mode 分模式注册）。"""
         config = self.config
         if isinstance(config, EmojiSenderConfig) and not config.plugin.enabled:
             return []
+        if _get_interaction_mode(self) == MODE_PICKER:
+            return [EmojiSenderService, SearchEmojiMemesTool, SendEmojiMemeByIdAction]
         return [EmojiSenderService, SendEmojiMemeAction]
 
     async def on_plugin_loaded(self) -> None:
@@ -91,14 +128,23 @@ class EmojiSenderPlugin(BasePlugin):
             return
         sync_emoji_sender_actor_reminder(self)
 
-        # 将自定义场景说明追加到 action 的描述，使 Chatter 侧感知使用时机
+        # 将自定义场景说明追加到当前模式对应 LLM 组件的描述，使 Chatter 侧感知使用时机
         if isinstance(self.config, EmojiSenderConfig):
             custom = self.config.prompt.custom_instructions.strip()
             if custom:
-                SendEmojiMemeAction.description = (
-                    SendEmojiMemeAction.description.rstrip() + "\n\n自定义指令：\n" + custom
-                )
-                logger.debug("已将自定义场景说明追加到 send_emoji_meme 描述")
+                if _get_interaction_mode(self) == MODE_PICKER:
+                    SearchEmojiMemesTool.description = (
+                        SearchEmojiMemesTool.description.rstrip() + "\n\n自定义指令：\n" + custom
+                    )
+                    SendEmojiMemeByIdAction.description = (
+                        SendEmojiMemeByIdAction.description.rstrip() + "\n\n自定义指令：\n" + custom
+                    )
+                    logger.debug("已将自定义场景说明追加到 picker 模式组件描述")
+                else:
+                    SendEmojiMemeAction.description = (
+                        SendEmojiMemeAction.description.rstrip() + "\n\n自定义指令：\n" + custom
+                    )
+                    logger.debug("已将自定义场景说明追加到 send_emoji_meme 描述")
 
         tm = get_task_manager()
         task = tm.create_task(

--- a/plugins/emoji_sender/service.py
+++ b/plugins/emoji_sender/service.py
@@ -20,6 +20,7 @@ import math
 import random
 import shutil
 import time
+from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -90,11 +91,42 @@ class EmojiSenderService(BaseService):
     对外提供：
     - search_best：按 tag + 向量检索，返回满足阈值并经温度采样的表情包
     - send_best：发送检索到的表情包
+    - search_candidates：按 tag + 向量检索，返回去重分页后的候选列表（picker 模式）
+    - send_by_id：按 meme id 前缀精确发送指定表情包（picker 模式）
     - ingest_once：执行一次入库任务（对齐→抽取→VLM 决策→写入）
     """
 
     name: str = "emoji_sender"
     description: str = "表情包收藏、检索与发送服务"
+
+    _SHORT_ID_LENGTH = 12
+
+    def __init__(self, plugin: Any) -> None:
+        """初始化服务并创建使用历史容器。"""
+        super().__init__(plugin)
+        self._usage_history: dict[str, deque[str]] = {}
+
+    def _dedup_enabled(self) -> bool:
+        """使用历史去重是否开启。"""
+        return bool(self._cfg().dedup.enabled)
+
+    def _recently_used(self, stream_id: str) -> set[str]:
+        """获取指定聊天流最近已发送的表情包 id 集合。"""
+        history = self._usage_history.get(stream_id)
+        if not history:
+            return set()
+        return set(history)
+
+    def _record_usage(self, stream_id: str, meme_id: str) -> None:
+        """记录一次成功的表情包发送（仅当去重开启时记录）。"""
+        if not self._dedup_enabled() or not stream_id or not meme_id:
+            return
+        window = max(1, int(self._cfg().dedup.window))
+        history = self._usage_history.get(stream_id)
+        if history is None:
+            history = deque(maxlen=window)
+            self._usage_history[stream_id] = history
+        history.append(meme_id)
 
     def _selection_temperature(self) -> float:
         """获取检索候选采样温度。"""
@@ -742,10 +774,80 @@ class EmojiSenderService(BaseService):
             except Exception as e:
                 logger.warning(f"写入向量库失败: {e}")
 
+    async def _embed_query(self, query: str, request_name: str) -> list[float] | None:
+        """生成查询文本的 embedding，失败返回 None。"""
+        try:
+            embedding_model_set = get_model_set_by_task("embedding")
+        except Exception:
+            return None
+
+        try:
+            emb_req = create_embedding_request(
+                model_set=embedding_model_set,
+                request_name=request_name,
+                inputs=[query],
+            )
+            emb_resp = await emb_req.send()
+            return list(emb_resp.embeddings[0])
+        except Exception as e:
+            logger.warning(f"生成查询 embedding 失败: {e}")
+            return None
+
+    async def _query_candidates(
+        self,
+        description_query: str,
+        emotion_tags: list[str] | None,
+        n_results: int,
+    ) -> list[MemeCandidate]:
+        """按描述与 tag 过滤执行向量检索，解析并返回候选列表。"""
+        query = str(description_query or "").strip()
+        if not query:
+            raise ValueError("description_query 不能为空")
+
+        tags: list[str] = []
+        if emotion_tags:
+            tags = [str(t).strip() for t in emotion_tags if str(t).strip() in EMOTION_TAG_PRESET]
+
+        query_embedding = await self._embed_query(query, "emoji_sender_search")
+        if query_embedding is None:
+            return []
+
+        vdb = self._vector_db()
+        collection = self._collection_name()
+        await vdb.get_or_create_collection(collection)
+
+        where: dict[str, Any] | None = None
+        if tags:
+            where = {"tag": tags}
+
+        results = await vdb.query(
+            collection_name=collection,
+            query_embeddings=[query_embedding],
+            n_results=n_results,
+            where=where,
+        )
+
+        ids_list: list[list[str]] = list(results.get("ids") or [])
+        distances_list: list[list[float]] = list(results.get("distances") or [])
+        metadatas_list: list[list[dict[str, Any]]] = list(results.get("metadatas") or [])
+
+        if not ids_list or not ids_list[0]:
+            return []
+
+        candidates: list[MemeCandidate] = []
+        for i, _ in enumerate(ids_list[0]):
+            distance = float(distances_list[0][i]) if distances_list and distances_list[0] and i < len(distances_list[0]) else 999.0
+            meta = metadatas_list[0][i] if metadatas_list and metadatas_list[0] and i < len(metadatas_list[0]) else {}
+            cand = self._build_candidate(distance=distance, metadata=meta)
+            if cand is not None:
+                candidates.append(cand)
+        return candidates
+
     async def search_best(
         self,
         description_query: str,
         emotion_tags: list[str] | None = None,
+        stream_id: str = "",
     ) -> dict[str, Any] | None:
         """按 tag 过滤后执行向量检索，返回温度采样后的候选。"""
         query = str(description_query or "").strip()
@@ -756,62 +858,27 @@ class EmojiSenderService(BaseService):
         if emotion_tags:
             tags = [str(t).strip() for t in emotion_tags if str(t).strip() in EMOTION_TAG_PRESET]
 
-        try:
-            embedding_model_set = get_model_set_by_task("embedding")
-        except Exception:
-            return None
-
-        try:
-            emb_req = create_embedding_request(
-                model_set=embedding_model_set,
-                request_name="emoji_sender_search",
-                inputs=[query],
-            )
-            emb_resp = await emb_req.send()
-            query_embedding = emb_resp.embeddings[0]
-        except Exception as e:
-            logger.warning(f"生成查询 embedding 失败: {e}")
-            return None
-
-        vdb = self._vector_db()
-        collection = self._collection_name()
-        await vdb.get_or_create_collection(collection)
-
-        where: dict[str, Any] | None = None
-        if tags:
-            where = {"tag": tags}
-
         top_n = int(self._cfg().vector.top_n)
         max_distance = float(self._cfg().vector.max_distance)
 
-        results = await vdb.query(
-            collection_name=collection,
-            query_embeddings=[list(query_embedding)],
-            n_results=top_n,
-            where=where,
-        )
-
-        ids_list: list[list[str]] = list(results.get("ids") or [])
-        distances_list: list[list[float]] = list(results.get("distances") or [])
-        metadatas_list: list[list[dict[str, Any]]] = list(results.get("metadatas") or [])
-
-        if not ids_list or not ids_list[0]:
+        all_candidates = await self._query_candidates(query, tags, top_n)
+        if not all_candidates:
             return None
 
-        all_candidates: list[MemeCandidate] = []
+        # 使用历史过滤：阈值内候选全被过滤时回退全量，保持原有 fallback 行为
+        recent: set[str] = set()
+        if self._dedup_enabled() and stream_id:
+            recent = self._recently_used(stream_id)
+            if recent:
+                filtered = [c for c in all_candidates if c.meme_id not in recent]
+                if filtered:
+                    all_candidates = filtered
+
         best_any: MemeCandidate | None = None
         candidates_under_threshold: list[MemeCandidate] = []
-        for i, _ in enumerate(ids_list[0]):
-            distance = float(distances_list[0][i]) if distances_list and distances_list[0] and i < len(distances_list[0]) else 999.0
-            meta = metadatas_list[0][i] if metadatas_list and metadatas_list[0] and i < len(metadatas_list[0]) else {}
-            cand = self._build_candidate(distance=distance, metadata=meta)
-            if cand is None:
-                continue
-
-            all_candidates.append(cand)
+        for cand in all_candidates:
             if best_any is None or cand.distance < best_any.distance:
                 best_any = cand
-
             if cand.distance <= max_distance:
                 candidates_under_threshold.append(cand)
 
@@ -840,6 +907,156 @@ class EmojiSenderService(BaseService):
             "fallback_used": fallback_used,
         }
 
+    async def search_candidates(
+        self,
+        description_query: str,
+        emotion_tags: list[str] | None = None,
+        page: int = 1,
+        stream_id: str = "",
+    ) -> dict[str, Any] | None:
+        """按 tag 过滤后向量检索，返回去重、历史过滤、分页后的候选列表。
+
+        Returns:
+            {candidates: [{meme_id, short_id, tag, description, distance}], page, total}
+            无有效候选时返回 None。
+        """
+        tags: list[str] = []
+        if emotion_tags:
+            tags = [str(t).strip() for t in emotion_tags if str(t).strip() in EMOTION_TAG_PRESET]
+
+        page_size = max(1, int(self._cfg().picker.page_size))
+        page = max(1, int(page))
+
+        # 拉取足够多的候选：页深 × 页大小 × 元余量，上限 60
+        fetch_n = min(60, max(page * page_size * 3, page_size * 3))
+        candidates = await self._query_candidates(description_query, tags, fetch_n)
+        if not candidates:
+            return None
+
+        # 同一 meme 多 tag 多记录：按 meme_id 去重，保留最小距离
+        best_by_meme: dict[str, MemeCandidate] = {}
+        for cand in candidates:
+            existing = best_by_meme.get(cand.meme_id)
+            if existing is None or cand.distance < existing.distance:
+                best_by_meme[cand.meme_id] = cand
+        deduped = sorted(best_by_meme.values(), key=lambda c: c.distance)
+
+        # 使用历史过滤：全被过滤时回退全量，避免无结果可发
+        if self._dedup_enabled() and stream_id:
+            recent = self._recently_used(stream_id)
+            if recent:
+                filtered = [c for c in deduped if c.meme_id not in recent]
+                if filtered:
+                    deduped = filtered
+
+        total = len(deduped)
+        start = (page - 1) * page_size
+        page_items = deduped[start : start + page_size]
+        if not page_items:
+            return None
+
+        return {
+            "candidates": [
+                {
+                    "meme_id": cand.meme_id,
+                    "short_id": cand.meme_id[: self._SHORT_ID_LENGTH],
+                    "tag": cand.tag,
+                    "description": cand.description,
+                    "distance": cand.distance,
+                }
+                for cand in page_items
+            ],
+            "page": page,
+            "total": total,
+        }
+
+    async def send_by_id(
+        self,
+        *,
+        short_id: str,
+        stream_id: str,
+        platform: str | None,
+    ) -> tuple[bool, dict[str, Any] | None, str]:
+        """按 meme id 前缀精确发送指定表情包。
+
+        Returns:
+            (ok, result, reason)，result 含 meme_id/tag/path/description，失败时为 None。
+        """
+        prefix = str(short_id or "").strip().lower()
+        if not prefix:
+            return False, None, "meme_id 不能为空"
+
+        vdb = self._vector_db()
+        collection = self._collection_name()
+        await vdb.get_or_create_collection(collection)
+
+        matched: dict[str, Any] | None = None
+        offset = 0
+        limit = 512
+        while True:
+            data = await vdb.get(
+                collection_name=collection,
+                limit=limit,
+                offset=offset,
+                include=["metadatas"],
+            )
+            ids: list[str] = list(data.get("ids") or [])
+            metadatas: list[dict[str, Any]] = list(data.get("metadatas") or [])
+            if not ids:
+                break
+
+            for i, record_id in enumerate(ids):
+                meme_id = record_id.split(":", 1)[0]
+                if meme_id.startswith(prefix):
+                    meta = metadatas[i] if i < len(metadatas) else {}
+                    matched = meta
+                    break
+            if matched is not None:
+                break
+            offset += len(ids)
+
+        if matched is None:
+            return False, None, f"未找到 id={prefix} 对应的表情包，请重新调用 search_emoji_memes 获取有效候选"
+
+        path_value = str(matched.get("path") or "").strip()
+        description = str(matched.get("description") or "").strip()
+        tag = str(matched.get("tag") or "").strip()
+        meme_id = str(matched.get("meme_id") or "").strip()
+        if not path_value or not meme_id:
+            return False, None, "表情包记录元数据不完整"
+
+        path = Path(path_value)
+        if not path.exists():
+            return False, None, "表情包文件已被删除"
+
+        try:
+            payload = await asyncio.to_thread(self._read_file_bytes, path)
+        except Exception as e:
+            logger.warning(f"读取表情包失败: {path} - {e}")
+            return False, None, "读取表情包文件失败"
+
+        image_base64 = await asyncio.to_thread(base64_encode_bytes, payload)
+        processed_plain_text = f"[表情包:{tag}:{description}]" if description else f"[表情包:{tag}]"
+
+        ok = await send_emoji(
+            emoji_data=image_base64,
+            stream_id=stream_id,
+            platform=platform,
+            processed_plain_text=processed_plain_text,
+        )
+
+        result = {
+            "meme_id": meme_id,
+            "tag": tag,
+            "path": path_value,
+            "description": description,
+            "fallback_used": False,
+        }
+        if ok:
+            self._record_usage(stream_id, meme_id)
+            return True, result, "发送成功"
+        return False, result, "发送失败"
+
     async def send_best_detailed(
         self,
         *,
@@ -859,6 +1076,7 @@ class EmojiSenderService(BaseService):
         result = await self.search_best(
             description_query=description_query,
             emotion_tags=emotion_tags,
+            stream_id=stream_id,
         )
         if not result:
             return False, None, "没有找到满足条件的表情包"
@@ -887,6 +1105,7 @@ class EmojiSenderService(BaseService):
         )
 
         if ok:
+            self._record_usage(stream_id, str(result.get("meme_id") or ""))
             return True, result, "发送成功"
         return False, result, "发送失败"
 

--- a/plugins/emoji_sender/tool.py
+++ b/plugins/emoji_sender/tool.py
@@ -1,0 +1,89 @@
+"""emoji_sender Tool：检索表情包候选列表。
+
+该 Tool 面向 LLM Tool Calling（picker 模式）：
+- 输入：目标表情包描述文本 + 情感 tag（可多个）+ 页码
+- 行为：按 tag 过滤候选后向量检索，按 meme 去重、过滤最近已发送，分页返回
+- Tool 结果会触发 FOLLOW_UP 轮，AI 可从候选列表挑选 id 后调用 send_emoji_meme_by_id 发送
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, cast
+
+from src.app.plugin_system.api.service_api import get_service
+from src.app.plugin_system.base import BaseTool
+
+from .service import EMOTION_TAG_PRESET, EmojiSenderService
+
+_EMOTION_TAG_VALUES = "、".join(EMOTION_TAG_PRESET)
+_EMOTION_TAG_DESC = (
+    f"情感标签（可多个，可为空）。可选值：{_EMOTION_TAG_VALUES}。"
+    "若为空则不按 tag 过滤，直接全库向量检索。"
+)
+
+
+class SearchEmojiMemesTool(BaseTool):
+    """检索表情包候选列表。"""
+
+    tool_description = "按目标描述与情感标签检索表情包库，返回候选列表供挑选"
+    tool_name = "search_emoji_memes"
+
+    name: str = "search_emoji_memes"
+    description: str = (
+        "根据目标描述与情感标签检索表情包库，返回候选列表（每项含 id、标签、描述与距离，距离越小与你想要的越贴切）。"
+        "当你想发表情包时，先用本工具查看有哪些候选，挑选最契合当前语境的一张，"
+        "再用它的 id 调用 send_emoji_meme_by_id 发送。对候选不满意时可换更具体的描述重新查询，或翻页查看更多。"
+    )
+
+    async def execute(
+        self,
+        description: Annotated[str, "目标表情包的描述文本，用于向量匹配（例如：‘生气地翻白眼’）"],
+        emotion_tags: Annotated[
+            list[str] | None,
+            _EMOTION_TAG_DESC,
+        ] = None,
+        page: Annotated[int, "页码（从 1 开始），候选不足或想看更多时翻页"] = 1,
+    ) -> tuple[bool, str]:
+        """检索候选表情包列表。
+
+        Returns:
+            (是否成功, 候选列表文本)
+        """
+        service = get_service("emoji_sender:service:emoji_sender")
+        if service is None:
+            return False, "emoji_sender service 未加载"
+
+        service = cast(EmojiSenderService, service)
+        stream_id = self.get_current_stream_id() or ""
+
+        result = await service.search_candidates(
+            description_query=description,
+            emotion_tags=emotion_tags,
+            page=page,
+            stream_id=stream_id,
+        )
+
+        if not result:
+            return (
+                True,
+                "没有找到符合条件的表情包。可尝试：换更具体的描述、去掉情感标签过滤、或翻回前一页。",
+            )
+
+        candidates: list[dict] = list(result.get("candidates") or [])
+        current_page = int(result.get("page") or 1)
+        total = int(result.get("total") or 0)
+
+        lines: list[str] = [f"候选表情包列表（第 {current_page} 页，共 {total} 张可选）："]
+        for item in candidates:
+            short_id = str(item.get("short_id") or "")
+            tag = str(item.get("tag") or "")
+            desc = str(item.get("description") or "")
+            distance = item.get("distance")
+            dist_text = f"{float(distance):.2f}" if isinstance(distance, (int, float)) else "?"
+            lines.append(f"- id={short_id} | 标签: {tag} | 描述: {desc} | 距离: {dist_text}")
+
+        lines.append(
+            "用 send_emoji_meme_by_id(id) 发送选中的表情包；"
+            "候选都不合适时可换更具体的描述重新查询，或传更大 page 翻页。"
+        )
+        return True, "\n".join(lines)

--- a/test/plugins/emoji_sender/test_service.py
+++ b/test/plugins/emoji_sender/test_service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -173,3 +174,265 @@ async def test_ingest_once_skips_alignment_when_storage_is_full(tmp_path: Any) -
         await service.ingest_once()
 
     align_mock.assert_not_awaited()
+
+
+# ── picker 模式：search_candidates / send_by_id ──────────────────────
+
+
+def _make_vdb_query_mock(records: list[tuple[str, float, dict[str, Any]]]) -> MagicMock:
+    """构建向量库 query mock，records 为 (record_id, distance, metadata) 列表。"""
+    mock_vdb = MagicMock()
+    mock_vdb.get_or_create_collection = AsyncMock()
+    mock_vdb.query = AsyncMock(
+        return_value={
+            "ids": [[record_id for record_id, _, _ in records]],
+            "distances": [[distance for _, distance, _ in records]],
+            "metadatas": [[meta for _, _, meta in records]],
+        }
+    )
+    return mock_vdb
+
+
+def _make_embedding_mocks() -> MagicMock:
+    """构建 embedding 请求 mock。"""
+    embedding_request = MagicMock()
+    embedding_request.send = AsyncMock(return_value=SimpleNamespace(embeddings=[[0.1, 0.2, 0.3]]))
+    return embedding_request
+
+
+@pytest.mark.asyncio
+async def test_search_candidates_dedupes_by_meme_and_truncates_short_id() -> None:
+    """同一 meme 多 tag 记录应去重保留最小距离，short_id 取前 12 位。"""
+    service = _make_service()
+    long_id_a = "a" * 64
+    long_id_b = "b" * 64
+    mock_vdb = _make_vdb_query_mock(
+        [
+            (
+                f"{long_id_a}:开心",
+                0.10,
+                {"meme_id": long_id_a, "tag": "开心", "path": "/tmp/a.png", "description": "A 开心"},
+            ),
+            (
+                f"{long_id_a}:兴奋",
+                0.20,
+                {"meme_id": long_id_a, "tag": "兴奋", "path": "/tmp/a.png", "description": "A 兴奋"},
+            ),
+            (
+                f"{long_id_b}:无语",
+                0.30,
+                {"meme_id": long_id_b, "tag": "无语", "path": "/tmp/b.png", "description": "B 无语"},
+            ),
+        ]
+    )
+
+    with (
+        patch("plugins.emoji_sender.service.get_model_set_by_task", return_value=object()),
+        patch("plugins.emoji_sender.service.create_embedding_request", return_value=_make_embedding_mocks()),
+        patch("plugins.emoji_sender.service.get_vector_db_service", return_value=mock_vdb),
+    ):
+        result = await service.search_candidates("开心地笑", ["开心", "兴奋"])
+
+    assert result is not None
+    candidates = result["candidates"]
+    assert [item["meme_id"] for item in candidates] == [long_id_a, long_id_b]
+    # 去重后 a 的记录保留 tag=开心（距离 0.10 < 0.20）
+    assert candidates[0]["tag"] == "开心"
+    assert candidates[0]["short_id"] == long_id_a[:12]
+    assert result["total"] == 2
+
+
+@pytest.mark.asyncio
+async def test_search_candidates_filters_recent_usage_with_fallback() -> None:
+    """使用历史应过滤候选；全被过滤时回退全量。"""
+    service = _make_service()
+    long_id_a = "a" * 64
+    long_id_b = "b" * 64
+    mock_vdb = _make_vdb_query_mock(
+        [
+            (
+                f"{long_id_a}:开心",
+                0.10,
+                {"meme_id": long_id_a, "tag": "开心", "path": "/tmp/a.png", "description": "A"},
+            ),
+            (
+                f"{long_id_b}:开心",
+                0.30,
+                {"meme_id": long_id_b, "tag": "开心", "path": "/tmp/b.png", "description": "B"},
+            ),
+        ]
+    )
+
+    with (
+        patch("plugins.emoji_sender.service.get_model_set_by_task", return_value=object()),
+        patch("plugins.emoji_sender.service.create_embedding_request", return_value=_make_embedding_mocks()),
+        patch("plugins.emoji_sender.service.get_vector_db_service", return_value=mock_vdb),
+    ):
+        # a 已发送过：候选只剩 b
+        service._record_usage("stream1", long_id_a)
+        result = await service.search_candidates("开心地笑", ["开心"], stream_id="stream1")
+        assert result is not None
+        assert [item["meme_id"] for item in result["candidates"]] == [long_id_b]
+
+        # a、b 都发送过：回退全量（a、b 都在候选中）
+        service._record_usage("stream1", long_id_b)
+        result = await service.search_candidates("开心地笑", ["开心"], stream_id="stream1")
+        assert result is not None
+        assert [item["meme_id"] for item in result["candidates"]] == [long_id_a, long_id_b]
+
+
+@pytest.mark.asyncio
+async def test_search_candidates_paginates_without_overlap() -> None:
+    """翻页切片正确且页间无重叠。"""
+    service = _make_service()
+    service._cfg().picker.page_size = 2
+    records = []
+    for i in range(5):
+        meme_id = f"{i:064d}"
+        records.append(
+            (
+                f"{meme_id}:开心",
+                0.10 + i * 0.01,
+                {"meme_id": meme_id, "tag": "开心", "path": f"/tmp/{i}.png", "description": f"第{i}张"},
+            )
+        )
+    mock_vdb = _make_vdb_query_mock(records)
+
+    with (
+        patch("plugins.emoji_sender.service.get_model_set_by_task", return_value=object()),
+        patch("plugins.emoji_sender.service.create_embedding_request", return_value=_make_embedding_mocks()),
+        patch("plugins.emoji_sender.service.get_vector_db_service", return_value=mock_vdb),
+    ):
+        page1 = await service.search_candidates("开心地笑", ["开心"], page=1)
+        page2 = await service.search_candidates("开心地笑", ["开心"], page=2)
+        page3 = await service.search_candidates("开心地笑", ["开心"], page=3)
+        page4 = await service.search_candidates("开心地笑", ["开心"], page=4)
+
+    assert page1 is not None and [c["short_id"] for c in page1["candidates"]] == [f"{0:064d}"[:12], f"{1:064d}"[:12]]
+    assert page2 is not None and [c["short_id"] for c in page2["candidates"]] == [f"{2:064d}"[:12], f"{3:064d}"[:12]]
+    assert page3 is not None and [c["short_id"] for c in page3["candidates"]] == [f"{4:064d}"[:12]]
+    assert page4 is None  # 超出总数
+
+
+@pytest.mark.asyncio
+async def test_send_by_id_prefix_match_and_records_usage(tmp_path: Any) -> None:
+    """send_by_id 应按 id 前缀匹配并发送，成功后记录使用历史。"""
+    service = _make_service()
+    long_id = "c" * 64
+    meme_path = tmp_path / "c.png"
+    meme_path.write_bytes(b"payload")
+
+    mock_vdb = MagicMock()
+    mock_vdb.get_or_create_collection = AsyncMock()
+    mock_vdb.get = AsyncMock(
+        return_value={
+            "ids": [f"{long_id}:开心", f"{'d' * 64}:无语"],
+            "metadatas": [
+                {"meme_id": long_id, "tag": "开心", "path": str(meme_path), "description": "C"},
+                {"meme_id": "d" * 64, "tag": "无语", "path": "/tmp/d.png", "description": "D"},
+            ],
+        }
+    )
+
+    with (
+        patch("plugins.emoji_sender.service.get_vector_db_service", return_value=mock_vdb),
+        patch("plugins.emoji_sender.service.send_emoji", new=AsyncMock(return_value=True)) as send_mock,
+    ):
+        ok, result, reason = await service.send_by_id(
+            short_id=long_id[:12],
+            stream_id="stream1",
+            platform="qq",
+        )
+
+    assert ok is True
+    assert result is not None and result["meme_id"] == long_id
+    assert reason == "发送成功"
+    assert long_id in service._recently_used("stream1")
+    send_mock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_send_by_id_unknown_prefix_returns_failure() -> None:
+    """未知 id 前缀应返回失败并提示重新查询。"""
+    service = _make_service()
+    mock_vdb = MagicMock()
+    mock_vdb.get_or_create_collection = AsyncMock()
+    mock_vdb.get = AsyncMock(return_value={"ids": [], "metadatas": []})
+
+    with patch("plugins.emoji_sender.service.get_vector_db_service", return_value=mock_vdb):
+        ok, result, reason = await service.send_by_id(
+            short_id="ffffffffffff",
+            stream_id="stream1",
+            platform="qq",
+        )
+
+    assert ok is False
+    assert result is None
+    assert "未找到" in reason
+
+
+@pytest.mark.asyncio
+async def test_send_best_detailed_records_usage_history() -> None:
+    """direct 模式发送成功后应记录使用历史，且下次检索过滤该表情。"""
+    service = _make_service(temperature=0.0)
+    long_id = "e" * 64
+    searched = {
+        "meme_id": long_id,
+        "tag": "开心",
+        "path": "/tmp/e.png",
+        "description": "E",
+        "distance": 0.1,
+        "fallback_used": False,
+    }
+
+    with (
+        patch.object(service, "search_best", new=AsyncMock(return_value=searched)),
+        patch("plugins.emoji_sender.service.Path", side_effect=lambda p: MagicMock(exists=lambda: True, read_bytes=lambda: b"payload") if str(p) == "/tmp/e.png" else Path(p)),
+        patch("plugins.emoji_sender.service.send_emoji", new=AsyncMock(return_value=True)),
+    ):
+        ok, result, reason = await service.send_best_detailed(
+            stream_id="stream1",
+            platform="qq",
+            description_query="开心地笑",
+        )
+
+    assert ok is True
+    assert reason == "发送成功"
+    assert long_id in service._recently_used("stream1")
+
+
+# ── 插件模式分支 ──────────────────────────────────────────────
+
+
+def test_get_components_returns_picker_components_in_picker_mode() -> None:
+    """picker 模式应返回 Tool + ById Action，而非 direct 的 Action。"""
+    from plugins.emoji_sender.plugin import EmojiSenderPlugin
+
+    config = EmojiSenderConfig()
+    config.plugin.interaction_mode = "picker"
+    plugin = EmojiSenderPlugin(config)
+
+    components = plugin.get_components()
+
+    names = {component.name for component in components}
+    assert "search_emoji_memes" in names
+    assert "send_emoji_meme_by_id" in names
+    assert "send_emoji_meme" not in names
+
+
+def test_get_components_returns_direct_components_by_default() -> None:
+    """默认（及非法值）应返回 direct 模式组件。"""
+    from plugins.emoji_sender.plugin import EmojiSenderPlugin
+
+    plugin = EmojiSenderPlugin(EmojiSenderConfig())
+    names = {component.name for component in plugin.get_components()}
+    assert "send_emoji_meme" in names
+    assert "search_emoji_memes" not in names
+
+    # 非法值按 direct 处理
+    config = EmojiSenderConfig()
+    config.plugin.interaction_mode = "bogus"
+    plugin = EmojiSenderPlugin(config)
+    names = {component.name for component in plugin.get_components()}
+    assert "send_emoji_meme" in names
+    assert "search_emoji_memes" not in names


### PR DESCRIPTION
# feat(emoji_sender): 新增 picker 模式，支持 LLM 亲自挑选表情包

## 改动内容

emoji_sender 原有发送流程为"一步直达"：LLM 只提供描述 + 情感 tag，插件按向量距离与温度采样自动挑选后直接发送，LLM 从未见过候选、无法亲自挑选，表达颗粒度受限。本次升级为可配置双模式：

### 1. 发送模式（`[plugin] interaction_mode`，默认 `direct`，重载插件生效）

- **direct（默认）**：保留原行为，注册 `send_emoji_meme` Action，一步完成检索与发送
- **picker（新增）**：注册 `search_emoji_memes` Tool + `send_emoji_meme_by_id` Action，两段式流程：
  1. LLM 调用 `search_emoji_memes(描述, [情感tag], page)` 查看候选列表（id/标签/描述/距离，距离越小越贴切）
  2. LLM 亲自挑选最契合的一张，调用 `send_emoji_meme_by_id(id)` 发送；不满意可换描述重查或翻页
  - 依赖框架 Tool 结果触发 FOLLOW_UP 轮的既有机制（与 media_retriever 的"Tool 查列表 + Action 按 id 发送"同构），未改动任何框架代码

### 2. 使用历史去重（`[dedup]` 节，两种模式共通）

- `enabled`（默认开）、`window`（默认 6）：每个聊天流记住最近 N 张已发送表情，检索候选时自动过滤，避免短时间重复发同一张
- 候选全被过滤时自动回退全量，保证不会无表情可发
- 内存态（`stream_id → deque`），重启清空

### 3. 候选翻页（`[picker] page_size`，默认 6）

picker 模式下候选列表分页返回，翻页页间无重叠；同一表情多 tag 记录按 meme 去重（保留最小距离）

## 变更文件

| 文件 | 变更 |
|------|------|
| `plugins/emoji_sender/config.py` | 新增 `interaction_mode`、`[picker]`、`[dedup]` 配置 |
| `plugins/emoji_sender/service.py` | 新增 `search_candidates`/`send_by_id`/使用历史；`search_best` 重构复用公共检索链并接入历史过滤 |
| `plugins/emoji_sender/tool.py` | 新建 `search_emoji_memes` Tool |
| `plugins/emoji_sender/action.py` | 新增 `send_emoji_meme_by_id` Action |
| `plugins/emoji_sender/plugin.py` | 按模式注册组件；reminder 按 picker 模式输出流程引导 |
| `plugins/emoji_sender/manifest.json` | 1.0.0 → 1.1.0，注册新组件 |
| `plugins/emoji_sender/README.md` | 双模式说明 |
| `test/plugins/emoji_sender/test_service.py` | 新增 8 用例（共 14 全通过） |

## 影响范围

- 仅 `plugins/emoji_sender/` 与对应测试，未触碰框架（`src/`）与其他插件
- 默认配置行为完全不变（direct 模式 = 原逻辑 + 可选历史去重）

## 测试

- [x] `pytest test/plugins/emoji_sender/ -v`：14/14 通过（新增 8 个：meme 去重与 short_id 截取、历史过滤与回退、翻页无重叠、前缀匹配发送并记录历史、未知 id 失败提示、direct 模式记录历史、两种模式组件注册、非法 mode 兜底）
- [x] `ruff check plugins/emoji_sender/`：无告警
- [x] picker 模式实机验证：`search_emoji_memes → FOLLOW_UP → send_emoji_meme_by_id + send_text` 调用链正常，LLM 在思考中逐个评估候选后亲自挑选发送

## 关联

- 修复表情发送解码失败问题的 snowluma_adapter 侧改动已在其独立仓库单独发布（v2.2.9），与本 PR 无耦合

## Summary by Sourcery

Enable configurable LLM-guided emoji selection while retaining direct sending and reducing recent meme repetition.

New Features:
- Add a configurable picker mode that lets the LLM search emoji candidates and choose a specific meme to send.
- Add paginated, deduplicated candidate search and ID-based emoji sending components.

Enhancements:
- Add per-chat usage-history filtering with automatic fallback when all candidates were recently used.
- Preserve direct mode as the default while providing mode-specific component registration and usage guidance.

Documentation:
- Document direct and picker interaction modes, pagination, and usage-history deduplication.

Tests:
- Add coverage for candidate deduplication, pagination, usage filtering and fallback, ID-based sending, history recording, and mode registration.

Chores:
- Bump the emoji_sender plugin version to 1.1.0.