### PR TITLE
fix(kernel): 增强 Logger.print_panel 对非法 rich markup 的容错

### DIFF
--- a/src/kernel/logger/logger.py
+++ b/src/kernel/logger/logger.py
@@ -452,8 +452,13 @@ class Logger:
             if border_style is None:
                 border_style = self.color
 
+            try:
+                renderable = Text.from_markup(message) if "[" in message else message
+            except Exception:
+                renderable = Text(message)
+
             panel = Panel(
-                message,
+                renderable,
                 title=title or self.display,
                 border_style=border_style,
             )

--- a/test/kernel/test_logger.py
+++ b/test/kernel/test_logger.py
@@ -133,6 +133,9 @@ class TestLogger:
         # 测试面板输出不会抛出异常
         logger.print_panel("Panel content", title="Test Panel")
         logger.print_panel("Another panel")
+        # 测试包含非法 markup 标签时回退不抛出异常
+        logger.print_panel("Panel with [unclosed tag", title="Markup Test")
+        logger.print_panel("Panel with valid [bold]markup[/bold]")
 
     def test_print_rich(self) -> None:
         """测试直接使用 rich 打印"""


### PR DESCRIPTION
## 概述
增强 `Logger.print_panel` 对包含非法或未闭合 rich markup 标签字符串的容错能力，避免打印异常文本时抛出 `MarkupError` 导致进程中断。

## 改动内容
1. **`src/kernel/logger/logger.py`**：
   - 在 `Logger.print_panel` 中，当消息包含 `[` 字符时尝试优先通过 `Text.from_markup` 解析；
   - 若解析失败或发生异常，平滑回退为纯文本 `Text(message)`。
   - 保持与 `Logger._log` 中 markup 解析容错行为一致。
2. **`test/kernel/test_logger.py`**：
   - 补充 `print_panel` 针对合法 markup 与非法未闭合 markup 字符串（如 `[unclosed tag`）的测试用例。

## 验证
- 运行 `uv run pytest test/kernel/test_logger.py` 全部 61 项测试通过。
- 运行 `uv run ruff check src/kernel/logger/logger.py test/kernel/test_logger.py` 检查通过。

## Summary by Sourcery

Make panel logging resilient to malformed Rich markup without interrupting the process.

Bug Fixes:
- Prevent `Logger.print_panel` from raising errors when messages contain invalid or unclosed Rich markup.

Enhancements:
- Preserve valid Rich markup rendering while safely falling back to plain text for unparseable messages.

Tests:
- Add coverage for valid and invalid markup passed to `print_panel`.