### PR TITLE
更新docker容器编排文件喵，弃用nc改用sl喵

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,61 @@
 services:
+  # ===== SnowLuma - QQ 协议桥接框架 =====
+  snowluma:
+    image: motricseven7/snowluma:latest
+    container_name: snowluma
+    restart: unless-stopped
+    shm_size: 1gb
+    cap_add:
+      - SYS_PTRACE
+    security_opt:
+      - seccomp=unconfined
+    environment:
+      VNC_PASSWD: vncpasswd
+      SNOWLUMA_UID: "1000"
+      SNOWLUMA_GID: "1000"
+      SNOWLUMA_WEBUI_HOST: "0.0.0.0"
+      SNOWLUMA_WEBUI_PORT: "5099"
+      SNOWLUMA_LOG_LEVEL: info
+      SNOWLUMA_SCREEN: "1920x1080x24"
+      SNOWLUMA_HOOK_AUTOLOAD: "1"
+      SNOWLUMA_QQ_FLAGS: >-
+        --disable-gpu --disable-software-rasterizer --disable-gpu-compositing
+    ports:
+      - "5900:5900" # VNC
+      - "6081:6081" # noVNC
+      - "5099:5099" # SnowLuma WebUI
+      - "3000:3000" # OneBot HTTP
+      - "3001:3001" # OneBot WebSocket
+    volumes:
+      - snowluma-data:/app/data
+      - snowluma-config:/app/.config
+      - snowluma-local:/app/.local/share
+
+  # ===== Neo-MoFox - AI 聊天机器人框架 (dev 分支) =====
   mofox:
-    # 默认拉取 main 分支的构建镜像
-    # 如果需要 dev 分支，请修改为 ikun11451/neo-mofox-dev:latest
     image: ikun11451/neo-mofox-dev:latest
-    # build: .
     container_name: mofox-bot
     restart: unless-stopped
     volumes:
-      # 将配置、数据和日志文件夹物理映射到宿主机
       - ./config:/app/config
       - ./data:/app/data
       - ./logs:/app/logs
-      # 建议也将插件目录映射，方便动态开发
       - ./plugins:/app/plugins
-      # 映射协议文件，方便更新后无需重建镜像
       - ./eula.md:/app/eula.md
       - ./PRIVACY.md:/app/PRIVACY.md
       - ./LICENSE:/app/LICENSE
     environment:
-      # 设置容器时区为上海
-      - TZ=Asia/Shanghai
-      # 非交互部署时，设置该环境变量可自动确认启动协议
-      - MOFOX_ACCEPT_STARTUP_AGREEMENTS=1
+      TZ: Asia/Shanghai
+      MOFOX_ACCEPT_STARTUP_AGREEMENTS: "1"
     ports:
-      - "8000:8000"
-    # 启用交互模式，支持 Rich 等库的终端控制台输出
+      - "8000:8000" # MoFox WebUI
     stdin_open: true
     tty: true
 
-  napcat:
-    image: mlikiowa/napcat-docker:latest
-    container_name: mofox-napcat
-    restart: unless-stopped
-    environment:
-      - NAPCAT_UID=0
-      - NAPCAT_GID=0
-      - TZ=Asia/Shanghai
-    ports:
-      - "6099:6099"
-    volumes:
-      - ./config/napcat:/app/napcat/config
-      - ./data/qq:/app/.config/QQ
-    mac_address: 02:42:ac:11:00:00
-
-networks:
-  default:
-    name: mofox-network
+volumes:
+  snowluma-data:
+    name: snowluma-data
+  snowluma-config:
+    name: snowluma-config
+  snowluma-local:
+    name: snowluma-local


### PR DESCRIPTION
更新docker容器编排文件喵，弃用nc改用sl喵

## Summary by Sourcery

Adopt SnowLuma for QQ integration and update the Docker Compose deployment alongside the MoFox development service.

New Features:
- Add a SnowLuma QQ protocol bridge service with VNC, noVNC, WebUI, OneBot HTTP, and WebSocket access.
- Provide persistent named volumes for SnowLuma data, configuration, and local state.

Enhancements:
- Replace the standalone NapCat container with SnowLuma as the QQ integration service.
- Update the MoFox service configuration for the dev image and simplify its environment and port definitions.

Build:
- Update the Docker Compose service topology and persistent volume definitions.