### PR TITLE
fix(skill_manager): 加固 get_script 的脚本执行路径

### DIFF
--- a/plugins/skill_manager/README.md
+++ b/plugins/skill_manager/README.md
@@ -2,11 +2,12 @@
 
 SkillManager 是 Neo-MoFox 的技能索引与按需加载插件。
 
-它会在插件加载完成后扫描本地 skill 目录，建立技能清单，并提供 3 个工具给 LLM 按需调用：
+它会在插件加载完成后扫描本地 skill 目录，建立技能清单，并提供工具给 LLM 按需调用：
 
 - get_skill：读取并注入 SKILL.md
 - get_reference：读取 skill 内 markdown 引用文件
-- get_script：执行 skill 内脚本（支持 .py/.ps1/.bat/.cmd/.sh，支持参数，返回脚本输出）
+- get_script：在子进程中执行 skill 内脚本（支持 .py/.ps1/.bat/.cmd/.sh，支持参数，返回脚本输出）
+  —— **默认关闭**，需在配置中显式开启
 
 ## 目录结构
 
@@ -17,7 +18,11 @@ plugins/skill_manager/
 ├── manifest.json
 ├── models.py
 ├── plugin.py
+├── README.md
 ├── tools.py
+├── commands/
+│   ├── __init__.py
+│   └── skill_command.py
 └── handlers/
     ├── __init__.py
     └── skillmanager.py
@@ -77,7 +82,9 @@ plugins/skill_manager/
 
 ### 3) get_script
 
-直接执行 skill 根目录内脚本，支持可选参数透传。
+在独立子进程中执行 skill 根目录内脚本，支持可选参数透传。
+
+> **该工具默认不注册，且开启后仍受权限门约束。** 需要在配置中把 `[security].allow_script_execution` 设为 `true` 才会出现在 LLM 的工具列表里；调用者还必须达到 `[security].script_execution_permission_level`（默认 `owner`）。详见「安全与边界」。
 
 参数：
 
@@ -89,18 +96,20 @@ plugins/skill_manager/
 
 执行行为：
 
-- `.py` 通过 `runpy.run_path(..., run_name="__main__")` 内嵌执行。
-- `.ps1` 通过 `pwsh` 或 `powershell` 执行。
-- `.bat/.cmd` 通过 `cmd.exe /c` 执行。
+- 所有脚本一律以**独立子进程**执行，统一受 15 秒超时保护。
+- `.py` 通过当前解释器（`sys.executable`）执行。
+- `.ps1` 通过 `pwsh` 或 `powershell` 执行，附带 `-NoProfile -NonInteractive`。
+- `.bat/.cmd` 通过 `%COMSPEC%`（即 `cmd.exe`）`/c` 执行。
 - `.sh` 通过 `bash` 或 `sh` 执行。
 - 执行时会透传 `script_args`，并自动将工作目录设置为脚本所在目录。
-- 自动捕获脚本的 `stdout/stderr`（包含 print 与标准流日志输出）并拼接到返回内容。
-- `SystemExit(0)` / `SystemExit(None)` 视为成功（例如 argparse `--help`）。
+- 自动捕获脚本的 `stdout/stderr`（包含 print 与标准流日志输出）并拼接到返回内容；
+  子进程内的 Python 被强制以 UTF-8 输出，避免 Windows 本地代码页导致中文乱码。
+- 退出码 `0` 视为成功（例如 argparse `--help`），非零视为失败并回显输出。
 
 返回：
 
 - 成功：`(True, "脚本已执行: xxx.py\n\n[stdout]/[stderr]...")`
-- 失败：`(False, "执行脚本失败...\n\n[stdout]/[stderr]...")`
+- 失败：`(False, "脚本执行退出码: 1\n\n[stdout]/[stderr]...")`
 
 ## 配置项
 
@@ -113,6 +122,15 @@ plugins/skill_manager/
 - `inject_actor_reminder: bool = true`
 - `inject_sub_actor_reminder: bool = true`
 
+`[security]`：
+
+- `allow_script_execution: bool = false` —— 是否允许通过 `get_script` 执行脚本。
+  关闭时 `get_script` 组件根本不会注册。
+- `script_execution_permission_level: str = "owner"` —— 执行脚本所需的**调用者**最低权限
+  级别，可选 `guest` / `user` / `operator` / `owner`。与 `/skill` 命令用同一套权限体系。
+- `powershell_bypass_execution_policy: bool = false` —— 执行 `.ps1` 时是否附加
+  `-ExecutionPolicy Bypass`。关闭时沿用机器/用户的 PowerShell 执行策略。
+
 示意：
 
 ```toml
@@ -121,7 +139,19 @@ enabled = true
 paths = ["skill"]
 inject_actor_reminder = true
 inject_sub_actor_reminder = true
+
+[security]
+allow_script_execution = false
+script_execution_permission_level = "owner"
+powershell_bypass_execution_policy = false
 ```
+
+### manifest `include` 与实际注册集合
+
+`manifest.json` 的 `include` 列出的是本插件**声明的全部组件面**（5 个），而实际注册集合由配置
+决定：`manager.enabled = false` 时一个都不注册，`security.allow_script_execution = false` 时不
+注册 `get_script`。`include` 只被 `loader.py` 解析成组件级依赖声明，不参与强制校验，因此这种
+「清单是超集」的关系是有意为之，不是漏维护。
 
 ## 常见调用建议
 
@@ -131,12 +161,48 @@ inject_sub_actor_reminder = true
 
 ## 安全与边界
 
-- 所有引用路径都会做目录边界校验，禁止越界访问。
-- `get_reference` 仅允许 `.md`。
-- `get_script` 仅允许 `.py`。
-- 本插件不负责脚本沙箱隔离，脚本执行权限等同当前进程。
+`get_script` 以 bot 进程权限执行代码，而工具调用层**没有权限模型**（`tool_manager/` 下不存在
+任何鉴权代码）：任何聊天用户都可以通过提示注入影响 LLM 选择的工具参数。因此这里的默认姿态是
+「默认关闭、显式开启、开启后仍要看调用者是谁」。
+
+- **脚本执行总开关默认关闭。** `[security].allow_script_execution = false` 时插件不注册
+  `get_script`，LLM 的工具列表里看不到它。
+- **开启后仍有调用者权限门。** 每次调用都会用触发消息的 `platform` + `sender_id` 解析
+  `person_id`，查出权限级别并与 `script_execution_permission_level`（默认 `owner`）比对。
+  这一层是为了避免「开关一开就对所有聊天用户放开」，让它与 `/skill` 命令的 `OWNER` 门对齐。
+  以下情况一律拒绝（fail-closed）：无触发消息、身份字段为空、级别配置写错、权限查询抛错。
+- **所有脚本都在子进程中运行。** `.py` 不再用 `runpy` 在 bot 进程内执行，因此脚本拿不到
+  bot 进程内的对象：已加载的配置实例、内存中的数据库会话、以及 monkeypatch 全局状态
+  （含权限判定函数）的能力都消失了。代价是脚本**不能再 `import src.*`**：需要框架能力的
+  逻辑应写成插件组件，而不是 skill 脚本。
+
+  这是**进程内存隔离，不是沙箱**：子进程仍以与 bot 相同的 OS 身份运行，拥有同样的文件系统
+  与网络权限，可以直接读 `config/`（含 `config/model.toml` 里的模型配置）、`data/`、以及
+  继承到的环境变量。想真正约束这些，需要 OS 层手段（独立低权限账号、容器、AppArmor 等），
+  本插件不提供。
+- **`.bat/.cmd` 参数走字符白名单。** Windows 上 `subprocess.list2cmdline` 不转义 cmd.exe
+  元字符，参数里的 `&` 会逃逸成独立命令。因此这类脚本的参数只接受
+  `字母、数字与 . _ : / \ @ = -`，出现空白或 `& | < > ^ ( ) " % !` 一律拒绝执行。
+  需要传含空格的值时请拆成多个列表元素，或改用 `.ps1` / `.py`。
+- **所有类型的参数都不接受控制字符**（含换行、回车、NUL）。
+- **不再默认绕过 PowerShell 执行策略。** 执行策略是 Windows 上阻止未签名脚本运行的纵深
+  防御，默认不再附加 `-ExecutionPolicy Bypass`；在受限策略的机器上运行未签名 skill 脚本
+  需要运维显式打开 `[security].powershell_bypass_execution_policy`。
+- **所有引用路径都会做目录边界校验**，禁止越界访问；`get_reference` 仅允许 `.md`，
+  `get_script` 仅允许 `.py/.ps1/.bat/.cmd/.sh`。
+- **脚本执行有 15 秒超时**，超时后进程会被 kill，并尽量回收已产生的输出。
+
+### 已知的、有意接受的残留风险
+
+- **调用者可以触达脚本声明的完整参数面。** `.ps1` 走 `-File`，参数作为字面字符串交给脚本的
+  `param()` 绑定器（不会被重新解析成 PowerShell 代码），但以 `-` 开头的参数确实会绑定到
+  命名参数上。`.py` 的 argparse、`.sh` 的 getopts 同理。这是「给脚本传参」这个功能的固有
+  语义，砍掉才能消除；实际约束靠的是上面的调用者权限门与下面的可信前提。
+- **脚本文件本身属于可信输入。** 本插件没有任何写盘、下载、解压逻辑，skill 目录内容完全由
+  运维决定，脚本路径也因此不做元字符校验。请把「往 skill 目录放一个脚本」当作
+  「授予该脚本 bot 进程权限」来对待。
 
 ## 版本
 
-- Plugin: `1.0.0`
+- Plugin: `1.1.0`
 - Manifest: `plugins/skill_manager/manifest.json`

--- a/plugins/skill_manager/README.md
+++ b/plugins/skill_manager/README.md
@@ -98,10 +98,13 @@ plugins/skill_manager/
 
 - 所有脚本一律以**独立子进程**执行，统一受 15 秒超时保护。
 - `.py` 通过当前解释器（`sys.executable`）执行。
-- `.ps1` 通过 `pwsh` 或 `powershell` 执行，附带 `-NoProfile -NonInteractive`。
+- `.ps1` 通过 `pwsh` 或 `powershell` 执行；`-NoProfile` / `-NonInteractive` /
+  `-ExecutionPolicy Bypass` 三个开关全部由配置决定，见「配置项」。
 - `.bat/.cmd` 通过 `%COMSPEC%`（即 `cmd.exe`）`/c` 执行。
 - `.sh` 通过 `bash` 或 `sh` 执行。
 - 执行时会透传 `script_args`，并自动将工作目录设置为脚本所在目录。
+- 子进程的 `stdin` 接到 `DEVNULL`，脚本读取输入会立即得到 EOF；bot 主循环本身是交互式
+  控制台命令循环，若让脚本继承 `stdin` 会和控制台抢同一个 fd。
 - 自动捕获脚本的 `stdout/stderr`（包含 print 与标准流日志输出）并拼接到返回内容；
   子进程内的 Python 被强制以 UTF-8 输出，避免 Windows 本地代码页导致中文乱码。
 - 退出码 `0` 视为成功（例如 argparse `--help`），非零视为失败并回显输出。
@@ -130,6 +133,14 @@ plugins/skill_manager/
   级别，可选 `guest` / `user` / `operator` / `owner`。与 `/skill` 命令用同一套权限体系。
 - `powershell_bypass_execution_policy: bool = false` —— 执行 `.ps1` 时是否附加
   `-ExecutionPolicy Bypass`。关闭时沿用机器/用户的 PowerShell 执行策略。
+- `powershell_no_profile: bool = true` —— 执行 `.ps1` 时是否附加 `-NoProfile`。默认跳过
+  用户 profile 脚本（与 skill 无关的额外代码）；若运维依赖 profile 里预置的模块或函数，
+  可以关掉。
+- `powershell_non_interactive: bool = true` —— 执行 `.ps1` 时是否附加 `-NonInteractive`。
+  默认让脚本请求交互输入时直接失败，而不是挂到执行超时；关掉后脚本仍读不到 bot 的控制台
+  输入，因为子进程 `stdin` 接的是 `DEVNULL`。
+
+后三个开关的默认值取的是更安全的一档，但都可由运维改写 —— 代码不替部署方定夺。
 
 示意：
 
@@ -144,6 +155,8 @@ inject_sub_actor_reminder = true
 allow_script_execution = false
 script_execution_permission_level = "owner"
 powershell_bypass_execution_policy = false
+powershell_no_profile = true
+powershell_non_interactive = true
 ```
 
 ### manifest `include` 与实际注册集合
@@ -171,6 +184,16 @@ powershell_bypass_execution_policy = false
   `person_id`，查出权限级别并与 `script_execution_permission_level`（默认 `owner`）比对。
   这一层是为了避免「开关一开就对所有聊天用户放开」，让它与 `/skill` 命令的 `OWNER` 门对齐。
   以下情况一律拒绝（fail-closed）：无触发消息、身份字段为空、级别配置写错、权限查询抛错。
+
+  判定逻辑住在 `SkillGetScriptTool._authorize`（`tools.py`），插件类只负责按总开关决定要不要
+  注册这个组件。配置读取统一走 `config.resolve_security_section()`，配置缺失时回退到全默认
+  实例 —— 该段默认值全取最严一档，所以回退等价于 fail-closed。
+
+  关于「身份字段为空」这条：`Message` 是无校验的普通类，`platform` 与 `sender_id` 都默认空串；
+  各 chatter 在流里没有现成消息时会构造合成触发消息，且都没填 `sender_id`（见
+  `neo_default_chatter/components/event_handlers/defaults/pick_trigger_message.py`、
+  `default_chatter/session.py`、`default_chatter/sub_agent_collaboration.py`）。定时唤醒与
+  sub_agent 协作走的正是这些分支，所以这个判断是有实际触发路径的，不是防御性冗余。
 - **所有脚本都在子进程中运行。** `.py` 不再用 `runpy` 在 bot 进程内执行，因此脚本拿不到
   bot 进程内的对象：已加载的配置实例、内存中的数据库会话、以及 monkeypatch 全局状态
   （含权限判定函数）的能力都消失了。代价是脚本**不能再 `import src.*`**：需要框架能力的

--- a/plugins/skill_manager/README.md
+++ b/plugins/skill_manager/README.md
@@ -98,8 +98,8 @@ plugins/skill_manager/
 
 - 所有脚本一律以**独立子进程**执行，统一受 15 秒超时保护。
 - `.py` 通过当前解释器（`sys.executable`）执行。
-- `.ps1` 通过 `pwsh` 或 `powershell` 执行；`-NoProfile` / `-NonInteractive` /
-  `-ExecutionPolicy Bypass` 三个开关全部由配置决定，见「配置项」。
+- `.ps1` 通过 `pwsh` 或 `powershell` 执行，固定附带 `-NoProfile -NonInteractive`；
+  `-ExecutionPolicy Bypass` 由配置决定，默认不附加。
 - `.bat/.cmd` 通过 `%COMSPEC%`（即 `cmd.exe`）`/c` 执行。
 - `.sh` 通过 `bash` 或 `sh` 执行。
 - 执行时会透传 `script_args`，并自动将工作目录设置为脚本所在目录。
@@ -133,14 +133,6 @@ plugins/skill_manager/
   级别，可选 `guest` / `user` / `operator` / `owner`。与 `/skill` 命令用同一套权限体系。
 - `powershell_bypass_execution_policy: bool = false` —— 执行 `.ps1` 时是否附加
   `-ExecutionPolicy Bypass`。关闭时沿用机器/用户的 PowerShell 执行策略。
-- `powershell_no_profile: bool = true` —— 执行 `.ps1` 时是否附加 `-NoProfile`。默认跳过
-  用户 profile 脚本（与 skill 无关的额外代码）；若运维依赖 profile 里预置的模块或函数，
-  可以关掉。
-- `powershell_non_interactive: bool = true` —— 执行 `.ps1` 时是否附加 `-NonInteractive`。
-  默认让脚本请求交互输入时直接失败，而不是挂到执行超时；关掉后脚本仍读不到 bot 的控制台
-  输入，因为子进程 `stdin` 接的是 `DEVNULL`。
-
-后三个开关的默认值取的是更安全的一档，但都可由运维改写 —— 代码不替部署方定夺。
 
 示意：
 
@@ -155,8 +147,6 @@ inject_sub_actor_reminder = true
 allow_script_execution = false
 script_execution_permission_level = "owner"
 powershell_bypass_execution_policy = false
-powershell_no_profile = true
-powershell_non_interactive = true
 ```
 
 ### manifest `include` 与实际注册集合
@@ -189,11 +179,17 @@ powershell_non_interactive = true
   注册这个组件。配置读取统一走 `config.resolve_security_section()`，配置缺失时回退到全默认
   实例 —— 该段默认值全取最严一档，所以回退等价于 fail-closed。
 
-  关于「身份字段为空」这条：`Message` 是无校验的普通类，`platform` 与 `sender_id` 都默认空串；
-  各 chatter 在流里没有现成消息时会构造合成触发消息，且都没填 `sender_id`（见
-  `neo_default_chatter/components/event_handlers/defaults/pick_trigger_message.py`、
-  `default_chatter/session.py`、`default_chatter/sub_agent_collaboration.py`）。定时唤醒与
-  sub_agent 协作走的正是这些分支，所以这个判断是有实际触发路径的，不是防御性冗余。
+  关于「身份字段为空」这条，有两类真实来源，不是防御性冗余：
+
+  1. `trigger_message` 本身为 None —— `BaseTool.trigger_message` 默认 None。Agent usable
+     路径经 `create_llm_usable_execution` 会调 `_bind_runtime_context`，但传入的 message
+     允许为 None（`execute_local_usable` 的 message 默认 None，`agent_api.execute_agent_usable`
+     根本没有 message 参数）；`ToolUse.execute_tool` 则压根不绑定运行时上下文。
+  2. 消息存在但字段为空 —— `Message` 无字段校验，`platform`/`sender_id` 都默认空串；各
+     chatter 在流里没有现成消息时会构造合成触发消息，且都没填 `sender_id`（见
+     `neo_default_chatter/components/event_handlers/defaults/pick_trigger_message.py`、
+     `default_chatter/session.py`、`default_chatter/sub_agent_collaboration.py`）。定时唤醒
+     与 sub_agent 协作走的正是这些分支。
 - **所有脚本都在子进程中运行。** `.py` 不再用 `runpy` 在 bot 进程内执行，因此脚本拿不到
   bot 进程内的对象：已加载的配置实例、内存中的数据库会话、以及 monkeypatch 全局状态
   （含权限判定函数）的能力都消失了。代价是脚本**不能再 `import src.*`**：需要框架能力的

--- a/plugins/skill_manager/config.py
+++ b/plugins/skill_manager/config.py
@@ -36,3 +36,38 @@ class SkillManagerConfig(BaseConfig):
         )
 
     manager: ManagerSection = Field(default_factory=ManagerSection)
+
+    @config_section("security", title="脚本执行安全", tag="security")
+    class SecuritySection(SectionBase):
+        """脚本执行相关的安全开关。
+
+        这些开关一律默认取最严的一档：``get_script`` 以 bot 进程权限执行脚本，而工具
+        调用层不存在权限模型，任何聊天用户都能通过提示注入影响 LLM 的工具调用参数。
+        """
+
+        allow_script_execution: bool = Field(
+            default=False,
+            description=(
+                "是否允许通过 get_script 执行 skill 脚本；关闭时该工具不会注册。"
+                "开启后 LLM 可控制脚本的全部命令行参数（等价于可触达脚本声明的完整"
+                "参数面），请仅在信任 skill 目录内脚本的前提下开启（高风险，默认关闭）"
+            ),
+        )
+        script_execution_permission_level: str = Field(
+            default="owner",
+            description=(
+                "执行 skill 脚本所需的调用者最低权限级别；"
+                "默认 owner，与 /skill 管理命令的权限门对齐"
+            ),
+            input_type="select",
+            choices=["guest", "user", "operator", "owner"],
+        )
+        powershell_bypass_execution_policy: bool = Field(
+            default=False,
+            description=(
+                "执行 .ps1 脚本时是否附加 -ExecutionPolicy Bypass；"
+                "开启会绕过 PowerShell 执行策略与脚本签名校验（高风险，默认关闭）"
+            ),
+        )
+
+    security: SecuritySection = Field(default_factory=SecuritySection)

--- a/plugins/skill_manager/config.py
+++ b/plugins/skill_manager/config.py
@@ -69,5 +69,38 @@ class SkillManagerConfig(BaseConfig):
                 "开启会绕过 PowerShell 执行策略与脚本签名校验（高风险，默认关闭）"
             ),
         )
+        powershell_no_profile: bool = Field(
+            default=True,
+            description=(
+                "执行 .ps1 脚本时是否附加 -NoProfile；"
+                "开启表示跳过用户 profile 脚本（与 skill 无关的额外代码），"
+                "关闭则沿用运维为该账户配置的 profile"
+            ),
+        )
+        powershell_non_interactive: bool = Field(
+            default=True,
+            description=(
+                "执行 .ps1 脚本时是否附加 -NonInteractive；"
+                "开启表示脚本请求交互输入时直接失败，关闭则让脚本挂到执行超时"
+            ),
+        )
 
     security: SecuritySection = Field(default_factory=SecuritySection)
+
+
+def resolve_security_section(config: object) -> SkillManagerConfig.SecuritySection:
+    """取出生效的 ``[security]`` 配置段。
+
+    配置未加载或类型不符时回退到一个全默认实例。该段所有默认值都取最严的一档，
+    因此回退等价于 fail-closed，不会因为配置缺失而放开脚本执行。
+
+    Args:
+        config: 待解析的配置对象，通常是 ``BasePlugin.config``。
+
+    Returns:
+        SkillManagerConfig.SecuritySection: 生效的安全配置段。
+    """
+
+    if isinstance(config, SkillManagerConfig):
+        return config.security
+    return SkillManagerConfig.SecuritySection()

--- a/plugins/skill_manager/config.py
+++ b/plugins/skill_manager/config.py
@@ -69,21 +69,6 @@ class SkillManagerConfig(BaseConfig):
                 "开启会绕过 PowerShell 执行策略与脚本签名校验（高风险，默认关闭）"
             ),
         )
-        powershell_no_profile: bool = Field(
-            default=True,
-            description=(
-                "执行 .ps1 脚本时是否附加 -NoProfile；"
-                "开启表示跳过用户 profile 脚本（与 skill 无关的额外代码），"
-                "关闭则沿用运维为该账户配置的 profile"
-            ),
-        )
-        powershell_non_interactive: bool = Field(
-            default=True,
-            description=(
-                "执行 .ps1 脚本时是否附加 -NonInteractive；"
-                "开启表示脚本请求交互输入时直接失败，关闭则让脚本挂到执行超时"
-            ),
-        )
 
     security: SecuritySection = Field(default_factory=SecuritySection)
 

--- a/plugins/skill_manager/manifest.json
+++ b/plugins/skill_manager/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "skill_manager",
   "display_name": "Skill 管理器",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Skill 管理器：索引本地 skill 目录并按需注入 SKILL.md/引用文档/脚本能力",
   "author": "MoFox Team",
   "dependencies": {
@@ -38,6 +38,7 @@
     "entry_point": "plugin.py",
     "min_core_version": "1.2.0-rc.2",
     "api_version": {
-        "send_api": "1.0.0"
+        "send_api": "1.0.0",
+        "permission_api": "1.0.0"
     }
 }

--- a/plugins/skill_manager/plugin.py
+++ b/plugins/skill_manager/plugin.py
@@ -4,6 +4,11 @@ import os
 import re
 from pathlib import Path
 
+from src.app.plugin_system.api.permission_api import (
+    generate_person_id,
+    get_user_permission_level,
+)
+from src.app.plugin_system.types import Message, PermissionLevel
 from src.core.components import BasePlugin, register_plugin
 from src.core.prompt import SystemReminderInsertType
 from src.kernel.logger import get_logger
@@ -16,6 +21,14 @@ from .tools import SkillGetReferenceTool, SkillGetScriptTool, SkillGetTool
 
 logger = get_logger("skill_manager")
 _FRONT_MATTER_FIELD_RE = re.compile(r"^(name|description)\s*:\s*(.+)$", re.IGNORECASE)
+
+SCRIPT_EXECUTION_DISABLED_MESSAGE = (
+    "skill 脚本执行已被禁用；如确需开启，"
+    "请在 skill_manager 配置中把 [security].allow_script_execution 设为 true"
+)
+SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE = "无法确认调用者身份，已拒绝执行 skill 脚本"
+SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE = "脚本执行权限级别配置无效，已拒绝执行 skill 脚本"
+SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE = "权限校验失败，已拒绝执行 skill 脚本"
 
 
 def _is_path_inside(base_dir: Path, target_path: Path) -> bool:
@@ -90,13 +103,116 @@ class SkillManagerPlugin(BasePlugin):
         ):
             logger.info("skill_manager 已在配置中禁用")
             return []
-        return [
+
+        components: list[type] = [
             SkillManagerLoadHandler,
             SkillManagerCommand,
             SkillGetTool,
             SkillGetReferenceTool,
-            SkillGetScriptTool,
         ]
+        if self.allow_script_execution:
+            components.append(SkillGetScriptTool)
+        else:
+            logger.info(
+                "skill_manager 未开启脚本执行，get_script 工具不会注册；"
+                "如需开启请将 [security].allow_script_execution 设为 true"
+            )
+        return components
+
+    @property
+    def _security(self) -> SkillManagerConfig.SecuritySection:
+        """返回生效的 ``[security]`` 配置段。
+
+        配置缺失时回退到一个全默认实例：该段所有默认值都取最严的一档，因此回退等价于
+        fail-closed，不会因为配置没加载而放开脚本执行。
+
+        Returns:
+            SkillManagerConfig.SecuritySection: 生效的安全配置段。
+        """
+
+        if isinstance(self.config, SkillManagerConfig):
+            return self.config.security
+        return SkillManagerConfig.SecuritySection()
+
+    @property
+    def allow_script_execution(self) -> bool:
+        """是否允许通过 get_script 执行 skill 脚本。"""
+
+        return self._security.allow_script_execution
+
+    @property
+    def powershell_bypass_execution_policy(self) -> bool:
+        """执行 .ps1 脚本时是否附加 ``-ExecutionPolicy Bypass``。"""
+
+        return self._security.powershell_bypass_execution_policy
+
+    @property
+    def script_execution_permission_level(self) -> PermissionLevel:
+        """执行 skill 脚本所需的调用者最低权限级别。
+
+        Returns:
+            PermissionLevel: 配置中声明的最低权限级别。
+
+        Raises:
+            ValueError: 配置中的级别字符串不是合法的权限级别名。
+        """
+
+        return PermissionLevel.from_string(
+            self._security.script_execution_permission_level
+        )
+
+    async def authorize_script_execution(
+        self,
+        message: Message | None,
+    ) -> tuple[bool, str | None]:
+        """判定一次 get_script 调用是否获得授权。
+
+        工具调用层本身没有权限模型（``src/core/managers/tool_manager/`` 内不存在任何
+        鉴权代码），因此这里按 ``/skill`` 管理命令的同一套权限体系补上调用者级别的门：
+        总开关只决定「这台部署是否提供脚本执行」，具体「谁可以执行」由权限级别决定，
+        避免开关一开就对所有聊天用户放开。
+
+        任何无法完成判定的情况（无触发消息、身份字段为空、级别配置非法、权限查询失败）
+        都按拒绝处理。
+
+        Args:
+            message: 触发本次工具调用的消息；为 None 表示无法归因到具体用户。
+
+        Returns:
+            tuple[bool, str | None]: (是否放行, 拒绝原因)；放行时第二项为 None。
+        """
+
+        if not self.allow_script_execution:
+            return False, SCRIPT_EXECUTION_DISABLED_MESSAGE
+
+        platform = str(getattr(message, "platform", "") or "").strip()
+        sender_id = str(getattr(message, "sender_id", "") or "").strip()
+        if not platform or not sender_id:
+            logger.warning("skill 脚本执行请求无法归因到具体用户，已拒绝")
+            return False, SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE
+
+        try:
+            required_level = self.script_execution_permission_level
+        except ValueError as error:
+            logger.error(f"skill_manager 脚本执行权限级别配置非法，已拒绝: {error}")
+            return False, SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE
+
+        try:
+            person_id = generate_person_id(platform, sender_id)
+            actual_level = await get_user_permission_level(person_id)
+        except Exception as error:
+            logger.error(f"查询 skill 脚本执行权限失败，已拒绝: {error}")
+            return False, SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE
+
+        if actual_level < required_level:
+            logger.warning(
+                f"权限拒绝: 执行 skill 脚本需要 {required_level.to_string()}，"
+                f"调用者为 {actual_level.to_string()}"
+            )
+            return False, (
+                f"权限不足：执行 skill 脚本需要 {required_level.to_string()} 级别权限"
+            )
+        return True, None
 
     async def on_plugin_unloaded(self) -> None:
         """插件卸载时清理 system reminder。"""

--- a/plugins/skill_manager/plugin.py
+++ b/plugins/skill_manager/plugin.py
@@ -4,31 +4,18 @@ import os
 import re
 from pathlib import Path
 
-from src.app.plugin_system.api.permission_api import (
-    generate_person_id,
-    get_user_permission_level,
-)
-from src.app.plugin_system.types import Message, PermissionLevel
 from src.core.components import BasePlugin, register_plugin
 from src.core.prompt import SystemReminderInsertType
 from src.kernel.logger import get_logger
 
 from .commands import SkillManagerCommand
-from .config import SkillManagerConfig
+from .config import SkillManagerConfig, resolve_security_section
 from .handlers import SkillManagerLoadHandler
 from .models import SkillEntry
 from .tools import SkillGetReferenceTool, SkillGetScriptTool, SkillGetTool
 
 logger = get_logger("skill_manager")
 _FRONT_MATTER_FIELD_RE = re.compile(r"^(name|description)\s*:\s*(.+)$", re.IGNORECASE)
-
-SCRIPT_EXECUTION_DISABLED_MESSAGE = (
-    "skill 脚本执行已被禁用；如确需开启，"
-    "请在 skill_manager 配置中把 [security].allow_script_execution 设为 true"
-)
-SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE = "无法确认调用者身份，已拒绝执行 skill 脚本"
-SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE = "脚本执行权限级别配置无效，已拒绝执行 skill 脚本"
-SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE = "权限校验失败，已拒绝执行 skill 脚本"
 
 
 def _is_path_inside(base_dir: Path, target_path: Path) -> bool:
@@ -110,7 +97,7 @@ class SkillManagerPlugin(BasePlugin):
             SkillGetTool,
             SkillGetReferenceTool,
         ]
-        if self.allow_script_execution:
+        if resolve_security_section(self.config).allow_script_execution:
             components.append(SkillGetScriptTool)
         else:
             logger.info(
@@ -118,101 +105,6 @@ class SkillManagerPlugin(BasePlugin):
                 "如需开启请将 [security].allow_script_execution 设为 true"
             )
         return components
-
-    @property
-    def _security(self) -> SkillManagerConfig.SecuritySection:
-        """返回生效的 ``[security]`` 配置段。
-
-        配置缺失时回退到一个全默认实例：该段所有默认值都取最严的一档，因此回退等价于
-        fail-closed，不会因为配置没加载而放开脚本执行。
-
-        Returns:
-            SkillManagerConfig.SecuritySection: 生效的安全配置段。
-        """
-
-        if isinstance(self.config, SkillManagerConfig):
-            return self.config.security
-        return SkillManagerConfig.SecuritySection()
-
-    @property
-    def allow_script_execution(self) -> bool:
-        """是否允许通过 get_script 执行 skill 脚本。"""
-
-        return self._security.allow_script_execution
-
-    @property
-    def powershell_bypass_execution_policy(self) -> bool:
-        """执行 .ps1 脚本时是否附加 ``-ExecutionPolicy Bypass``。"""
-
-        return self._security.powershell_bypass_execution_policy
-
-    @property
-    def script_execution_permission_level(self) -> PermissionLevel:
-        """执行 skill 脚本所需的调用者最低权限级别。
-
-        Returns:
-            PermissionLevel: 配置中声明的最低权限级别。
-
-        Raises:
-            ValueError: 配置中的级别字符串不是合法的权限级别名。
-        """
-
-        return PermissionLevel.from_string(
-            self._security.script_execution_permission_level
-        )
-
-    async def authorize_script_execution(
-        self,
-        message: Message | None,
-    ) -> tuple[bool, str | None]:
-        """判定一次 get_script 调用是否获得授权。
-
-        工具调用层本身没有权限模型（``src/core/managers/tool_manager/`` 内不存在任何
-        鉴权代码），因此这里按 ``/skill`` 管理命令的同一套权限体系补上调用者级别的门：
-        总开关只决定「这台部署是否提供脚本执行」，具体「谁可以执行」由权限级别决定，
-        避免开关一开就对所有聊天用户放开。
-
-        任何无法完成判定的情况（无触发消息、身份字段为空、级别配置非法、权限查询失败）
-        都按拒绝处理。
-
-        Args:
-            message: 触发本次工具调用的消息；为 None 表示无法归因到具体用户。
-
-        Returns:
-            tuple[bool, str | None]: (是否放行, 拒绝原因)；放行时第二项为 None。
-        """
-
-        if not self.allow_script_execution:
-            return False, SCRIPT_EXECUTION_DISABLED_MESSAGE
-
-        platform = str(getattr(message, "platform", "") or "").strip()
-        sender_id = str(getattr(message, "sender_id", "") or "").strip()
-        if not platform or not sender_id:
-            logger.warning("skill 脚本执行请求无法归因到具体用户，已拒绝")
-            return False, SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE
-
-        try:
-            required_level = self.script_execution_permission_level
-        except ValueError as error:
-            logger.error(f"skill_manager 脚本执行权限级别配置非法，已拒绝: {error}")
-            return False, SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE
-
-        try:
-            person_id = generate_person_id(platform, sender_id)
-            actual_level = await get_user_permission_level(person_id)
-        except Exception as error:
-            logger.error(f"查询 skill 脚本执行权限失败，已拒绝: {error}")
-            return False, SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE
-
-        if actual_level < required_level:
-            logger.warning(
-                f"权限拒绝: 执行 skill 脚本需要 {required_level.to_string()}，"
-                f"调用者为 {actual_level.to_string()}"
-            )
-            return False, (
-                f"权限不足：执行 skill 脚本需要 {required_level.to_string()} 级别权限"
-            )
-        return True, None
 
     async def on_plugin_unloaded(self) -> None:
         """插件卸载时清理 system reminder。"""

--- a/plugins/skill_manager/tools.py
+++ b/plugins/skill_manager/tools.py
@@ -12,14 +12,29 @@ from contextlib import suppress
 from pathlib import Path
 from typing import Annotated, Any, cast
 
+from src.app.plugin_system.api.permission_api import (
+    generate_person_id,
+    get_user_permission_level,
+)
+from src.app.plugin_system.types import Message, PermissionLevel
 from src.core.components import BaseTool
 from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger
+
+from .config import SkillManagerConfig, resolve_security_section
 
 logger = get_logger("skill_manager.tool")
 SUPPORTED_SCRIPT_SUFFIXES: tuple[str, ...] = (".py", ".ps1", ".bat", ".cmd", ".sh")
 SCRIPT_TIMEOUT_SECONDS = 15.0
 SCRIPT_KILL_GRACE_SECONDS = 3.0
+
+SCRIPT_EXECUTION_DISABLED_MESSAGE = (
+    "skill 脚本执行已被禁用；如确需开启，"
+    "请在 skill_manager 配置中把 [security].allow_script_execution 设为 true"
+)
+SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE = "无法确认调用者身份，已拒绝执行 skill 脚本"
+SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE = "脚本执行权限级别配置无效，已拒绝执行 skill 脚本"
+SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE = "权限校验失败，已拒绝执行 skill 脚本"
 
 # .bat/.cmd 交给 cmd.exe 解释执行，而 Windows 上 subprocess 只能把参数列表交给
 # ``subprocess.list2cmdline`` 拼成单条命令行；该函数只处理空白、反斜杠与引号，
@@ -107,7 +122,7 @@ class SkillGetScriptTool(BaseTool):
 
     该工具以 bot 进程权限执行脚本，而工具调用层本身没有权限模型，因此有两道门：
     插件只在配置开启 ``[security].allow_script_execution`` 时才注册它，且每次调用都会
-    重新走一遍 ``authorize_script_execution``（覆盖配置热更新与调用者权限级别）。
+    重新走一遍 ``_authorize``（覆盖配置热更新与调用者权限级别）。
     """
 
     name: str = "get_script"
@@ -117,6 +132,79 @@ class SkillGetScriptTool(BaseTool):
         "可选通过 script_args 传入命令行参数；"
         f"其中 .bat/.cmd 的参数只接受{_CMD_SAFE_ARGUMENT_HINT} 这些字符。"
     )
+
+    def _security(self) -> SkillManagerConfig.SecuritySection:
+        """取出所属插件生效的 ``[security]`` 配置段。
+
+        Returns:
+            SkillManagerConfig.SecuritySection: 生效的安全配置段；配置缺失时为全默认
+            实例，而该段默认值全取最严一档，因此等价于 fail-closed。
+        """
+
+        return resolve_security_section(getattr(self.plugin, "config", None))
+
+    async def _authorize(
+        self,
+        security: SkillManagerConfig.SecuritySection,
+    ) -> tuple[bool, str | None]:
+        """判定本次调用是否获得执行授权。
+
+        工具调用层本身没有权限模型（``src/core/managers/tool_manager/`` 内不存在任何
+        鉴权代码，只有 Command 有框架级的 ``permission_level`` 强制），因此这里按
+        ``/skill`` 管理命令的同一套权限体系补上调用者级别的门：总开关只决定「这台部署
+        是否提供脚本执行」，具体「谁可以执行」由权限级别决定，避免开关一开就对所有聊天
+        用户放开。
+
+        任何无法完成判定的情况（无触发消息、身份字段为空、级别配置非法、权限查询失败）
+        都按拒绝处理。
+
+        Args:
+            security: 生效的安全配置段。
+
+        Returns:
+            tuple[bool, str | None]: (是否放行, 拒绝原因)；放行时第二项为 None。
+        """
+
+        if not security.allow_script_execution:
+            return False, SCRIPT_EXECUTION_DISABLED_MESSAGE
+
+        # 这两个字段确实会为空，不是防御性冗余：BaseTool.trigger_message 默认 None
+        # （src/core/components/base/tool.py:76），ToolUse.execute_tool 与 Agent usable
+        # 两条路径都不调用 _bind_runtime_context；而各 chatter 在流里没有现成消息时会造
+        # 合成触发消息，且都没填 sender_id —— 见 neo_default_chatter 的
+        # defaults/pick_trigger_message.py、default_chatter 的 session.py 与
+        # sub_agent_collaboration.py。定时唤醒与 sub_agent 协作走的正是这些分支。
+        message: Message | None = self.trigger_message
+        platform = str(getattr(message, "platform", "") or "").strip()
+        sender_id = str(getattr(message, "sender_id", "") or "").strip()
+        if not platform or not sender_id:
+            logger.warning("skill 脚本执行请求无法归因到具体用户，已拒绝")
+            return False, SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE
+
+        try:
+            required_level = PermissionLevel.from_string(
+                security.script_execution_permission_level
+            )
+        except ValueError as error:
+            logger.error(f"skill_manager 脚本执行权限级别配置非法，已拒绝: {error}")
+            return False, SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE
+
+        try:
+            person_id = generate_person_id(platform, sender_id)
+            actual_level = await get_user_permission_level(person_id)
+        except Exception as error:
+            logger.error(f"查询 skill 脚本执行权限失败，已拒绝: {error}")
+            return False, SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE
+
+        if actual_level < required_level:
+            logger.warning(
+                f"权限拒绝: 执行 skill 脚本需要 {required_level.to_string()}，"
+                f"调用者为 {actual_level.to_string()}"
+            )
+            return False, (
+                f"权限不足：执行 skill 脚本需要 {required_level.to_string()} 级别权限"
+            )
+        return True, None
 
     async def execute(
         self,
@@ -132,10 +220,8 @@ class SkillGetScriptTool(BaseTool):
     ) -> tuple[bool, str | dict]:
         """返回脚本执行结果。"""
 
-        plugin = cast(Any, self.plugin)
-        authorized, refusal = await plugin.authorize_script_execution(
-            self.trigger_message
-        )
+        security = self._security()
+        authorized, refusal = await self._authorize(security)
         if not authorized:
             return False, refusal or "已拒绝执行 skill 脚本"
 
@@ -143,6 +229,7 @@ class SkillGetScriptTool(BaseTool):
         if not resolved_name:
             return False, "name 不能为空"
 
+        plugin = cast(Any, self.plugin)
         if resolved_name not in plugin.injected_skills:
             return False, f"skill '{resolved_name}' 尚未注入，请先调用 get_skill"
 
@@ -165,9 +252,7 @@ class SkillGetScriptTool(BaseTool):
         return await _execute_script_in_subprocess(
             script_path,
             normalized_args,
-            powershell_bypass_execution_policy=bool(
-                plugin.powershell_bypass_execution_policy
-            ),
+            security=security,
         )
 
 
@@ -211,7 +296,7 @@ async def _execute_script_in_subprocess(
     script_path: Path,
     normalized_args: list[str],
     *,
-    powershell_bypass_execution_policy: bool,
+    security: SkillManagerConfig.SecuritySection,
 ) -> tuple[bool, str | dict]:
     """在独立子进程中执行 skill 脚本并回收输出。
 
@@ -221,7 +306,7 @@ async def _execute_script_in_subprocess(
     Args:
         script_path: 已通过目录边界校验的脚本绝对路径。
         normalized_args: 归一化后的脚本参数。
-        powershell_bypass_execution_policy: 是否允许 .ps1 绕过 PowerShell 执行策略。
+        security: 生效的安全配置段，决定各解释器的加固开关。
 
     Returns:
         tuple[bool, str | dict]: (是否成功, 执行结果或错误信息)。
@@ -230,7 +315,7 @@ async def _execute_script_in_subprocess(
     command, error = _build_script_command(
         script_path,
         normalized_args,
-        powershell_bypass_execution_policy=powershell_bypass_execution_policy,
+        security=security,
     )
     if command is None:
         return False, error or f"不支持的脚本类型: {script_path.suffix}"
@@ -240,6 +325,11 @@ async def _execute_script_in_subprocess(
             *command,
             cwd=str(script_path.parent),
             env=_build_subprocess_env(),
+            # 不给脚本继承 bot 的 stdin：bot 主循环是交互式控制台命令循环
+            # （src/app/runtime/console_input.py 的 prompt_toolkit 会话），若脚本读
+            # stdin 就会和控制台抢同一个 fd，把运维正在输入的命令吃掉。DEVNULL 让
+            # 读取立即得到 EOF，这也是把 -NonInteractive 做成可关配置项的前提。
+            stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -325,14 +415,14 @@ def _build_script_command(
     script_path: Path,
     normalized_args: list[str],
     *,
-    powershell_bypass_execution_policy: bool,
+    security: SkillManagerConfig.SecuritySection,
 ) -> tuple[list[str] | None, str | None]:
     """按后缀构建脚本的子进程执行命令。
 
     Args:
         script_path: 脚本绝对路径。
         normalized_args: 归一化后的脚本参数。
-        powershell_bypass_execution_policy: 是否允许 .ps1 绕过 PowerShell 执行策略。
+        security: 生效的安全配置段，决定各解释器的加固开关。
 
     Returns:
         tuple[list[str] | None, str | None]: (命令列表, 错误信息)；
@@ -346,7 +436,7 @@ def _build_script_command(
         return _build_powershell_command(
             script_path,
             normalized_args,
-            bypass_execution_policy=powershell_bypass_execution_policy,
+            security=security,
         )
     if suffix in {".bat", ".cmd"}:
         return _build_windows_batch_command(script_path, normalized_args)
@@ -362,28 +452,32 @@ def _build_powershell_command(
     script_path: Path,
     normalized_args: list[str],
     *,
-    bypass_execution_policy: bool,
+    security: SkillManagerConfig.SecuritySection,
 ) -> tuple[list[str] | None, str | None]:
     """构建 .ps1 的 PowerShell 执行命令。
 
-    默认不再附加 ``-ExecutionPolicy Bypass``：执行策略是 Windows 上阻止未签名脚本
-    运行的纵深防御，由代码单方面绕过等于替运维取消了这道防线。确需在受限策略的
-    机器上运行未签名 skill 脚本时，运维可显式打开配置开关。
+    三个加固开关全部由配置决定，代码不替运维定夺，只把默认值定在更安全的一档：
 
-    ``-NoProfile`` 避免加载用户 profile 脚本（额外的、与 skill 无关的代码），
-    ``-NonInteractive`` 让脚本在需要交互输入时直接失败而不是挂到超时。
+    - ``-ExecutionPolicy Bypass``（``powershell_bypass_execution_policy``，默认关）：
+      执行策略是 Windows 上阻止未签名脚本运行的纵深防御，由代码单方面绕过等于替运维
+      取消了这道防线；确需在受限策略的机器上跑未签名 skill 脚本时再打开。
+    - ``-NoProfile``（``powershell_no_profile``，默认开）：跳过用户 profile 脚本，即
+      与 skill 无关的额外代码；若运维依赖 profile 里预置的模块或函数，可以关掉。
+    - ``-NonInteractive``（``powershell_non_interactive``，默认开）：脚本请求交互输入
+      时直接失败，而不是挂到执行超时；关掉后脚本仍拿不到 bot 的控制台输入，因为子进程
+      的 stdin 被接到 DEVNULL，只会立即读到 EOF。
 
     残留风险（有意接受，不在此处消除）：``-File`` 模式把参数当字面字符串交给脚本的
     ``param()`` 绑定器，所以不存在把参数重新解析成 PowerShell 代码的注入面，但以 ``-``
     开头的参数确实会绑定到脚本声明的命名参数上 —— 也就是说调用者可以触达脚本的完整
     参数面。这对 ``.py`` 的 argparse、``.sh`` 的 getopts 同样成立，属于「给脚本传参」
     这个功能的固有语义，无法在不砍掉传参能力的前提下消除；实际约束靠的是
-    ``authorize_script_execution`` 的调用者权限门与「skill 目录内容可信」这一前提。
+    ``SkillGetScriptTool._authorize`` 的调用者权限门与「skill 目录内容可信」这一前提。
 
     Args:
         script_path: 脚本绝对路径。
         normalized_args: 归一化后的脚本参数。
-        bypass_execution_policy: 是否附加 ``-ExecutionPolicy Bypass``。
+        security: 生效的安全配置段，决定上述三个开关。
 
     Returns:
         tuple[list[str] | None, str | None]: (命令列表, 错误信息)；
@@ -394,8 +488,12 @@ def _build_powershell_command(
     if powershell is None:
         return None, "未找到可用的 PowerShell 解释器"
 
-    command = [powershell, "-NoProfile", "-NonInteractive"]
-    if bypass_execution_policy:
+    command = [powershell]
+    if security.powershell_no_profile:
+        command.append("-NoProfile")
+    if security.powershell_non_interactive:
+        command.append("-NonInteractive")
+    if security.powershell_bypass_execution_policy:
         command.extend(["-ExecutionPolicy", "Bypass"])
     command.extend(["-File", str(script_path), *normalized_args])
     return command, None

--- a/plugins/skill_manager/tools.py
+++ b/plugins/skill_manager/tools.py
@@ -3,23 +3,34 @@
 from __future__ import annotations
 
 import asyncio
-import io
-import runpy
+import os
+import re
 import shlex
 import shutil
 import sys
-from contextlib import suppress, redirect_stderr, redirect_stdout
+from contextlib import suppress
 from pathlib import Path
 from typing import Annotated, Any, cast
 
 from src.core.components import BaseTool
+from src.kernel.concurrency import get_task_manager
 from src.kernel.logger import get_logger
-
 
 logger = get_logger("skill_manager.tool")
 SUPPORTED_SCRIPT_SUFFIXES: tuple[str, ...] = (".py", ".ps1", ".bat", ".cmd", ".sh")
-EXTERNAL_SCRIPT_TIMEOUT_SECONDS = 15.0
-EXTERNAL_SCRIPT_KILL_GRACE_SECONDS = 3.0
+SCRIPT_TIMEOUT_SECONDS = 15.0
+SCRIPT_KILL_GRACE_SECONDS = 3.0
+
+# .bat/.cmd 交给 cmd.exe 解释执行，而 Windows 上 subprocess 只能把参数列表交给
+# ``subprocess.list2cmdline`` 拼成单条命令行；该函数只处理空白、反斜杠与引号，
+# 完全不转义 cmd.exe 元字符（``& | < > ^ ( ) " % !``）。参数中一旦出现这些字符就会
+# 逃逸成独立命令，因此拼装前必须用字符白名单挡住。
+_CMD_SAFE_ARGUMENT_RE = re.compile(r"[A-Za-z0-9._:/\\@=-]+")
+_CMD_SAFE_ARGUMENT_HINT = "字母、数字与 . _ : / \\ @ = -"
+
+# 控制字符（含换行、回车、NUL）在任何解释器的参数里都没有正当用途，却能在命令行拼装、
+# 日志与脚本自身的参数解析上制造歧义，因此对所有脚本类型统一拒绝。
+_CONTROL_CHARACTER_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 class SkillGetTool(BaseTool):
@@ -92,13 +103,19 @@ class SkillGetReferenceTool(BaseTool):
 
 
 class SkillGetScriptTool(BaseTool):
-    """直接执行 skill 下的脚本文件。"""
+    """直接执行 skill 下的脚本文件。
+
+    该工具以 bot 进程权限执行脚本，而工具调用层本身没有权限模型，因此有两道门：
+    插件只在配置开启 ``[security].allow_script_execution`` 时才注册它，且每次调用都会
+    重新走一遍 ``authorize_script_execution``（覆盖配置热更新与调用者权限级别）。
+    """
 
     name: str = "get_script"
     description: str = (
         "在已通过 get_skill(name) 注入对应 skill 后，"
-        "按相对路径直接执行该 skill 目录下脚本文件（支持 .py/.ps1/.bat/.cmd/.sh）。"
-        "可选通过 script_args 传入命令行参数。"
+        "按相对路径以独立子进程执行该 skill 目录下脚本文件（支持 .py/.ps1/.bat/.cmd/.sh）。"
+        "可选通过 script_args 传入命令行参数；"
+        f"其中 .bat/.cmd 的参数只接受{_CMD_SAFE_ARGUMENT_HINT} 这些字符。"
     )
 
     async def execute(
@@ -115,11 +132,17 @@ class SkillGetScriptTool(BaseTool):
     ) -> tuple[bool, str | dict]:
         """返回脚本执行结果。"""
 
+        plugin = cast(Any, self.plugin)
+        authorized, refusal = await plugin.authorize_script_execution(
+            self.trigger_message
+        )
+        if not authorized:
+            return False, refusal or "已拒绝执行 skill 脚本"
+
         resolved_name = name.strip()
         if not resolved_name:
             return False, "name 不能为空"
 
-        plugin = cast(Any, self.plugin)
         if resolved_name not in plugin.injected_skills:
             return False, f"skill '{resolved_name}' 尚未注入，请先调用 get_skill"
 
@@ -135,66 +158,74 @@ class SkillGetScriptTool(BaseTool):
         if script_path is None:
             return False, error or "脚本路径无效"
 
-        normalized_args: list[str] = []
-        if isinstance(script_args, str):
-            normalized_args = shlex.split(script_args)
-        elif isinstance(script_args, list):
-            if not all(isinstance(item, str) for item in script_args):
-                return False, "script_args 列表元素必须为字符串"
-            normalized_args = script_args
-        elif script_args is not None:
-            return False, "script_args 必须是字符串或字符串列表"
+        normalized_args, error = _normalize_script_args(script_args)
+        if normalized_args is None:
+            return False, error or "script_args 无效"
 
-        if script_path.suffix.lower() == ".py":
-            return _execute_python_script(script_path, normalized_args)
-        return await _execute_external_script(script_path, normalized_args)
+        return await _execute_script_in_subprocess(
+            script_path,
+            normalized_args,
+            powershell_bypass_execution_policy=bool(
+                plugin.powershell_bypass_execution_policy
+            ),
+        )
 
 
-def _execute_python_script(
+def _normalize_script_args(
+    script_args: list[str] | str | None,
+) -> tuple[list[str] | None, str | None]:
+    """把 LLM 传入的脚本参数归一化为字符串列表。
+
+    Args:
+        script_args: 原始参数，允许字符串、字符串列表或 None。
+
+    Returns:
+        tuple[list[str] | None, str | None]: (归一化后的参数, 错误信息)；
+        校验失败时第一项为 None。
+    """
+
+    if script_args is None:
+        return [], None
+    if isinstance(script_args, str):
+        normalized_args = shlex.split(script_args)
+    elif isinstance(script_args, list):
+        if not all(isinstance(item, str) for item in script_args):
+            return None, "script_args 列表元素必须为字符串"
+        normalized_args = list(script_args)
+    else:
+        return None, "script_args 必须是字符串或字符串列表"
+
+    for argument in normalized_args:
+        if _CONTROL_CHARACTER_RE.search(argument):
+            return None, f"script_args 不能包含控制字符（含换行符）: {argument!r}"
+    return normalized_args, None
+
+
+async def _execute_script_in_subprocess(
     script_path: Path,
     normalized_args: list[str],
+    *,
+    powershell_bypass_execution_policy: bool,
 ) -> tuple[bool, str | dict]:
-    """以内嵌方式执行 Python 脚本。"""
+    """在独立子进程中执行 skill 脚本并回收输出。
 
-    old_argv = sys.argv[:]
-    stdout_buffer = io.StringIO()
-    stderr_buffer = io.StringIO()
-    try:
-        sys.argv = [str(script_path), *normalized_args]
-        with redirect_stdout(stdout_buffer), redirect_stderr(stderr_buffer):
-            runpy.run_path(str(script_path), run_name="__main__")
+    所有脚本类型（含 ``.py``）都走子进程：既统一拿到超时保护，也避免脚本代码与
+    bot 主进程共享内存空间（配置对象、模型 API key、权限判定等全局状态）。
 
-        captured_output = _compose_captured_output(stdout_buffer, stderr_buffer)
-        if captured_output:
-            return True, f"脚本已执行: {script_path.name}\n\n{captured_output}"
-        return True, f"脚本已执行: {script_path.name}"
-    except SystemExit as error:
-        captured_output = _compose_captured_output(stdout_buffer, stderr_buffer)
-        exit_code = error.code
-        if exit_code in (None, 0):
-            if captured_output:
-                return True, f"脚本已执行: {script_path.name}\n\n{captured_output}"
-            return True, f"脚本已执行: {script_path.name}"
-        if captured_output:
-            return False, f"脚本执行退出码: {exit_code}\n\n{captured_output}"
-        return False, f"脚本执行退出码: {exit_code}"
-    except Exception as error:
-        logger.error(f"执行 skill 脚本失败: {error}")
-        captured_output = _compose_captured_output(stdout_buffer, stderr_buffer)
-        if captured_output:
-            return False, f"执行脚本失败: {error}\n\n{captured_output}"
-        return False, f"执行脚本失败: {error}"
-    finally:
-        sys.argv = old_argv
+    Args:
+        script_path: 已通过目录边界校验的脚本绝对路径。
+        normalized_args: 归一化后的脚本参数。
+        powershell_bypass_execution_policy: 是否允许 .ps1 绕过 PowerShell 执行策略。
 
+    Returns:
+        tuple[bool, str | dict]: (是否成功, 执行结果或错误信息)。
+    """
 
-async def _execute_external_script(
-    script_path: Path,
-    normalized_args: list[str],
-) -> tuple[bool, str | dict]:
-    """通过子进程执行非 Python 脚本。"""
-
-    command, error = _build_external_script_command(script_path, normalized_args)
+    command, error = _build_script_command(
+        script_path,
+        normalized_args,
+        powershell_bypass_execution_policy=powershell_bypass_execution_policy,
+    )
     if command is None:
         return False, error or f"不支持的脚本类型: {script_path.suffix}"
 
@@ -202,13 +233,21 @@ async def _execute_external_script(
         process = await asyncio.create_subprocess_exec(
             *command,
             cwd=str(script_path.parent),
+            env=_build_subprocess_env(),
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        communicate_task = asyncio.create_task(process.communicate())
+        # 输出回收任务统一走 task_manager；daemon=True 是因为超时判定与进程收尾都由
+        # 本函数用 wait_for 自己控制，不需要 WatchDog 再判一次超时。
+        output_task = get_task_manager().create_task(
+            process.communicate(),
+            name=f"skill_script_output:{script_path.name}",
+            daemon=True,
+        )
+        communicate_task = cast("asyncio.Task[tuple[bytes, bytes]]", output_task.task)
         stdout_bytes, stderr_bytes = await asyncio.wait_for(
             asyncio.shield(communicate_task),
-            timeout=EXTERNAL_SCRIPT_TIMEOUT_SECONDS,
+            timeout=SCRIPT_TIMEOUT_SECONDS,
         )
     except asyncio.TimeoutError:
         process.kill()
@@ -216,55 +255,57 @@ async def _execute_external_script(
             process,
             communicate_task,
         )
-        captured_output = _compose_output_text(
-            stdout_bytes.decode("utf-8", errors="replace").strip(),
-            stderr_bytes.decode("utf-8", errors="replace").strip(),
+        return _compose_result(
+            False,
+            f"脚本执行超时（{SCRIPT_TIMEOUT_SECONDS}秒）",
+            _decode_captured_output(stdout_bytes, stderr_bytes),
         )
-        if captured_output:
-            return False, (
-                f"脚本执行超时（{EXTERNAL_SCRIPT_TIMEOUT_SECONDS}秒）\n\n{captured_output}"
-            )
-        return False, f"脚本执行超时（{EXTERNAL_SCRIPT_TIMEOUT_SECONDS}秒）"
     except Exception as error:
-        logger.error(f"执行外部 skill 脚本失败: {error}")
+        logger.error(f"执行 skill 脚本失败: {error}")
         return False, f"执行脚本失败: {error}"
 
-    captured_output = _compose_output_text(
-        stdout_bytes.decode("utf-8", errors="replace").strip(),
-        stderr_bytes.decode("utf-8", errors="replace").strip(),
-    )
+    captured_output = _decode_captured_output(stdout_bytes, stderr_bytes)
     if process.returncode == 0:
-        if captured_output:
-            return True, f"脚本已执行: {script_path.name}\n\n{captured_output}"
-        return True, f"脚本已执行: {script_path.name}"
-    if captured_output:
-        return False, f"脚本执行退出码: {process.returncode}\n\n{captured_output}"
-    return False, f"脚本执行退出码: {process.returncode}"
+        return _compose_result(True, f"脚本已执行: {script_path.name}", captured_output)
+    return _compose_result(
+        False,
+        f"脚本执行退出码: {process.returncode}",
+        captured_output,
+    )
 
 
 async def _finalize_timed_out_process(
     process: asyncio.subprocess.Process,
     communicate_task: asyncio.Task[tuple[bytes, bytes]],
 ) -> tuple[bytes, bytes]:
-    """在外部脚本超时后收尾子进程并尽量回收输出。"""
+    """在脚本超时后收尾子进程并尽量回收输出。
+
+    Args:
+        process: 已被 ``kill()`` 的子进程对象。
+        communicate_task: 负责读取该进程 stdout/stderr 的任务。
+
+    Returns:
+        tuple[bytes, bytes]: (标准输出字节, 标准错误字节)；
+        宽限期内没能收回输出时返回两个空字节串。
+    """
 
     try:
         await asyncio.wait_for(
             process.wait(),
-            timeout=EXTERNAL_SCRIPT_KILL_GRACE_SECONDS,
+            timeout=SCRIPT_KILL_GRACE_SECONDS,
         )
     except asyncio.TimeoutError:
-        logger.warning("外部脚本超时后进程未在宽限期内退出，放弃等待退出码")
+        logger.warning("脚本超时后进程未在宽限期内退出，放弃等待退出码")
     except Exception as error:
         logger.warning(f"等待超时脚本进程退出时出错: {error}")
 
     try:
         return await asyncio.wait_for(
             communicate_task,
-            timeout=EXTERNAL_SCRIPT_KILL_GRACE_SECONDS,
+            timeout=SCRIPT_KILL_GRACE_SECONDS,
         )
     except asyncio.TimeoutError:
-        logger.warning("外部脚本超时后 communicate 未在宽限期内结束，放弃收集残余输出")
+        logger.warning("脚本超时后 communicate 未在宽限期内结束，放弃收集残余输出")
     except Exception as error:
         logger.warning(f"收集超时脚本输出时出错: {error}")
 
@@ -274,20 +315,35 @@ async def _finalize_timed_out_process(
     return b"", b""
 
 
-def _build_external_script_command(
+def _build_script_command(
     script_path: Path,
     normalized_args: list[str],
+    *,
+    powershell_bypass_execution_policy: bool,
 ) -> tuple[list[str] | None, str | None]:
-    """构建外部脚本执行命令。"""
+    """按后缀构建脚本的子进程执行命令。
+
+    Args:
+        script_path: 脚本绝对路径。
+        normalized_args: 归一化后的脚本参数。
+        powershell_bypass_execution_policy: 是否允许 .ps1 绕过 PowerShell 执行策略。
+
+    Returns:
+        tuple[list[str] | None, str | None]: (命令列表, 错误信息)；
+        构建失败时第一项为 None。
+    """
 
     suffix = script_path.suffix.lower()
+    if suffix == ".py":
+        return [sys.executable, str(script_path), *normalized_args], None
     if suffix == ".ps1":
-        powershell = shutil.which("pwsh") or shutil.which("powershell")
-        if powershell is None:
-            return None, "未找到可用的 PowerShell 解释器"
-        return [powershell, "-ExecutionPolicy", "Bypass", "-File", str(script_path), *normalized_args], None
+        return _build_powershell_command(
+            script_path,
+            normalized_args,
+            bypass_execution_policy=powershell_bypass_execution_policy,
+        )
     if suffix in {".bat", ".cmd"}:
-        return ["cmd.exe", "/c", str(script_path), *normalized_args], None
+        return _build_windows_batch_command(script_path, normalized_args)
     if suffix == ".sh":
         shell_runner = shutil.which("bash") or shutil.which("sh")
         if shell_runner is None:
@@ -296,16 +352,143 @@ def _build_external_script_command(
     return None, f"不支持的脚本类型: {suffix}"
 
 
-def _compose_captured_output(stdout_buffer: io.StringIO, stderr_buffer: io.StringIO) -> str:
-    """拼接脚本执行期间捕获的标准输出与标准错误。"""
+def _build_powershell_command(
+    script_path: Path,
+    normalized_args: list[str],
+    *,
+    bypass_execution_policy: bool,
+) -> tuple[list[str] | None, str | None]:
+    """构建 .ps1 的 PowerShell 执行命令。
 
-    stdout_text = stdout_buffer.getvalue().strip()
-    stderr_text = stderr_buffer.getvalue().strip()
-    return _compose_output_text(stdout_text, stderr_text)
+    默认不再附加 ``-ExecutionPolicy Bypass``：执行策略是 Windows 上阻止未签名脚本
+    运行的纵深防御，由代码单方面绕过等于替运维取消了这道防线。确需在受限策略的
+    机器上运行未签名 skill 脚本时，运维可显式打开配置开关。
+
+    ``-NoProfile`` 避免加载用户 profile 脚本（额外的、与 skill 无关的代码），
+    ``-NonInteractive`` 让脚本在需要交互输入时直接失败而不是挂到超时。
+
+    残留风险（有意接受，不在此处消除）：``-File`` 模式把参数当字面字符串交给脚本的
+    ``param()`` 绑定器，所以不存在把参数重新解析成 PowerShell 代码的注入面，但以 ``-``
+    开头的参数确实会绑定到脚本声明的命名参数上 —— 也就是说调用者可以触达脚本的完整
+    参数面。这对 ``.py`` 的 argparse、``.sh`` 的 getopts 同样成立，属于「给脚本传参」
+    这个功能的固有语义，无法在不砍掉传参能力的前提下消除；实际约束靠的是
+    ``authorize_script_execution`` 的调用者权限门与「skill 目录内容可信」这一前提。
+
+    Args:
+        script_path: 脚本绝对路径。
+        normalized_args: 归一化后的脚本参数。
+        bypass_execution_policy: 是否附加 ``-ExecutionPolicy Bypass``。
+
+    Returns:
+        tuple[list[str] | None, str | None]: (命令列表, 错误信息)；
+        找不到解释器时第一项为 None。
+    """
+
+    powershell = shutil.which("pwsh") or shutil.which("powershell")
+    if powershell is None:
+        return None, "未找到可用的 PowerShell 解释器"
+
+    command = [powershell, "-NoProfile", "-NonInteractive"]
+    if bypass_execution_policy:
+        command.extend(["-ExecutionPolicy", "Bypass"])
+    command.extend(["-File", str(script_path), *normalized_args])
+    return command, None
+
+
+def _build_windows_batch_command(
+    script_path: Path,
+    normalized_args: list[str],
+) -> tuple[list[str] | None, str | None]:
+    """构建 .bat/.cmd 的 cmd.exe 执行命令。
+
+    cmd.exe 会对最终命令行再解析一遍元字符，因此这里对每个参数强制字符白名单：
+    只要出现 ``& | < > ^ ( ) " % !``、空白或换行就直接拒绝，避免参数逃逸成独立命令。
+    脚本路径本身来自运维放进 skill 目录的文件，与脚本内容同属可信输入，不参与校验。
+
+    Args:
+        script_path: 脚本绝对路径。
+        normalized_args: 归一化后的脚本参数。
+
+    Returns:
+        tuple[list[str] | None, str | None]: (命令列表, 错误信息)；
+        参数含元字符或找不到解释器时第一项为 None。
+    """
+
+    for argument in normalized_args:
+        if not _CMD_SAFE_ARGUMENT_RE.fullmatch(argument):
+            return None, (
+                f".bat/.cmd 参数只允许{_CMD_SAFE_ARGUMENT_HINT}，已拒绝执行: {argument!r}"
+            )
+
+    # 用绝对路径定位解释器，避免 CreateProcess 的搜索顺序命中工作目录下的同名文件。
+    command_interpreter = os.environ.get("COMSPEC") or shutil.which("cmd.exe")
+    if not command_interpreter:
+        return None, "未找到可用的 cmd.exe 解释器"
+    return [command_interpreter, "/c", str(script_path), *normalized_args], None
+
+
+def _build_subprocess_env() -> dict[str, str]:
+    """构建脚本子进程的环境变量。
+
+    - ``PYTHONIOENCODING``：强制子进程内的 Python 以 UTF-8 输出，避免 Windows 默认
+      走本地代码页（如 cp936）导致回收到的中文输出变成乱码。
+    - ``PYTHONUNBUFFERED``：关闭块缓冲，脚本超时被杀死时仍能回收已产生的输出。
+
+    Returns:
+        dict[str, str]: 在当前进程环境基础上覆盖上述两项后的环境变量表。
+    """
+
+    return {**os.environ, "PYTHONIOENCODING": "utf-8", "PYTHONUNBUFFERED": "1"}
+
+
+def _decode_captured_output(stdout_bytes: bytes, stderr_bytes: bytes) -> str:
+    """把子进程的原始输出解码并拼接为可回显文本。
+
+    Args:
+        stdout_bytes: 子进程标准输出原始字节。
+        stderr_bytes: 子进程标准错误原始字节。
+
+    Returns:
+        str: 拼接后的文本；两个流都为空时返回空字符串。
+    """
+
+    return _compose_output_text(
+        stdout_bytes.decode("utf-8", errors="replace").strip(),
+        stderr_bytes.decode("utf-8", errors="replace").strip(),
+    )
+
+
+def _compose_result(
+    success: bool,
+    headline: str,
+    captured_output: str,
+) -> tuple[bool, str]:
+    """把执行结论与捕获输出合成为统一的工具返回值。
+
+    Args:
+        success: 本次执行是否算成功。
+        headline: 结论行，例如 ``脚本已执行: x.py``。
+        captured_output: 已拼接好的 stdout/stderr 文本，可为空。
+
+    Returns:
+        tuple[bool, str]: (是否成功, 结论行与输出拼接后的文本)。
+    """
+
+    if captured_output:
+        return success, f"{headline}\n\n{captured_output}"
+    return success, headline
 
 
 def _compose_output_text(stdout_text: str, stderr_text: str) -> str:
-    """拼接标准输出与标准错误文本。"""
+    """拼接标准输出与标准错误文本。
+
+    Args:
+        stdout_text: 已去除首尾空白的标准输出文本。
+        stderr_text: 已去除首尾空白的标准错误文本。
+
+    Returns:
+        str: 带 ``[stdout]`` / ``[stderr]`` 分节标记的文本；两者都为空时返回空字符串。
+    """
 
     output_sections: list[str] = []
     if stdout_text:

--- a/plugins/skill_manager/tools.py
+++ b/plugins/skill_manager/tools.py
@@ -187,7 +187,13 @@ def _normalize_script_args(
     if script_args is None:
         return [], None
     if isinstance(script_args, str):
-        normalized_args = shlex.split(script_args)
+        # shlex.split 对引号不配对的输入抛 ValueError；参数由 LLM 生成，属可预期的
+        # 非法输入而非程序错误，必须转成拒绝结果，否则异常会穿透 execute() 的
+        # (bool, str) 返回契约。
+        try:
+            normalized_args = shlex.split(script_args)
+        except ValueError as error:
+            return None, f"script_args 引号不配对，无法解析: {error}"
     elif isinstance(script_args, list):
         if not all(isinstance(item, str) for item in script_args):
             return None, "script_args 列表元素必须为字符串"
@@ -420,11 +426,39 @@ def _build_windows_batch_command(
                 f".bat/.cmd 参数只允许{_CMD_SAFE_ARGUMENT_HINT}，已拒绝执行: {argument!r}"
             )
 
-    # 用绝对路径定位解释器，避免 CreateProcess 的搜索顺序命中工作目录下的同名文件。
-    command_interpreter = os.environ.get("COMSPEC") or shutil.which("cmd.exe")
-    if not command_interpreter:
+    # 必须用绝对路径定位解释器，否则 CreateProcess 会按搜索顺序解析，可能命中工作
+    # 目录（= skill 目录）下的同名文件。COMSPEC 属运维可信输入，但取值不保证是绝对
+    # 路径，因此只在校验通过后采用，否则回退到 PATH 查找。
+    command_interpreter = _resolve_command_interpreter()
+    if command_interpreter is None:
         return None, "未找到可用的 cmd.exe 解释器"
     return [command_interpreter, "/c", str(script_path), *normalized_args], None
+
+
+def _resolve_command_interpreter() -> str | None:
+    """定位 cmd.exe 的绝对路径。
+
+    优先采用 ``%COMSPEC%``，但只在它是「绝对路径且指向一个已存在的文件」时才接受；
+    取值为相对路径或指向不存在的文件时回退到 ``shutil.which``，避免把一个会触发
+    路径搜索的解释器名交给 ``CreateProcess``。
+
+    Returns:
+        str | None: 解释器绝对路径；两种途径都定位不到时返回 None。
+    """
+
+    candidate = (os.environ.get("COMSPEC") or "").strip().strip('"')
+    if candidate:
+        candidate_path = Path(candidate)
+        if candidate_path.is_absolute() and candidate_path.is_file():
+            return str(candidate_path)
+        logger.warning(
+            f"COMSPEC 不是指向现有文件的绝对路径，已忽略并回退到 PATH 查找: {candidate!r}"
+        )
+
+    fallback = shutil.which("cmd.exe")
+    if fallback is None:
+        return None
+    return str(Path(fallback).resolve())
 
 
 def _build_subprocess_env() -> dict[str, str]:

--- a/plugins/skill_manager/tools.py
+++ b/plugins/skill_manager/tools.py
@@ -168,12 +168,18 @@ class SkillGetScriptTool(BaseTool):
         if not security.allow_script_execution:
             return False, SCRIPT_EXECUTION_DISABLED_MESSAGE
 
-        # 这两个字段确实会为空，不是防御性冗余：BaseTool.trigger_message 默认 None
-        # （src/core/components/base/tool.py:76），ToolUse.execute_tool 与 Agent usable
-        # 两条路径都不调用 _bind_runtime_context；而各 chatter 在流里没有现成消息时会造
-        # 合成触发消息，且都没填 sender_id —— 见 neo_default_chatter 的
-        # defaults/pick_trigger_message.py、default_chatter 的 session.py 与
-        # sub_agent_collaboration.py。定时唤醒与 sub_agent 协作走的正是这些分支。
+        # 这两个字段确实会为空，不是防御性冗余，两类来源：
+        # 1) trigger_message 本身为 None —— BaseTool.trigger_message 默认 None
+        #    （src/core/components/base/tool.py:76）。Agent usable 路径经
+        #    create_llm_usable_execution 会调 _bind_runtime_context
+        #    （src/core/utils/llm_tool_call.py:146），但传入的 message 允许为 None
+        #    （execute_local_usable 的 message 默认 None，agent_api.execute_agent_usable
+        #    根本没有 message 参数）；ToolUse.execute_tool 则压根不绑定运行时上下文。
+        # 2) 消息存在但字段为空 —— Message 无字段校验，platform/sender_id 默认空串；
+        #    各 chatter 在流里没有现成消息时会造合成触发消息，且都没填 sender_id，见
+        #    neo_default_chatter 的 defaults/pick_trigger_message.py、default_chatter 的
+        #    session.py 与 sub_agent_collaboration.py。定时唤醒与 sub_agent 协作走的
+        #    正是这些分支。
         message: Message | None = self.trigger_message
         platform = str(getattr(message, "platform", "") or "").strip()
         sender_id = str(getattr(message, "sender_id", "") or "").strip()
@@ -328,7 +334,8 @@ async def _execute_script_in_subprocess(
             # 不给脚本继承 bot 的 stdin：bot 主循环是交互式控制台命令循环
             # （src/app/runtime/console_input.py 的 prompt_toolkit 会话），若脚本读
             # stdin 就会和控制台抢同一个 fd，把运维正在输入的命令吃掉。DEVNULL 让
-            # 读取立即得到 EOF，这也是把 -NonInteractive 做成可关配置项的前提。
+            # 读取立即得到 EOF。这对 .py/.sh 尤其必要 —— 它们没有 PowerShell
+            # -NonInteractive 那样的解释器级开关。
             stdin=asyncio.subprocess.DEVNULL,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
@@ -456,16 +463,13 @@ def _build_powershell_command(
 ) -> tuple[list[str] | None, str | None]:
     """构建 .ps1 的 PowerShell 执行命令。
 
-    三个加固开关全部由配置决定，代码不替运维定夺，只把默认值定在更安全的一档：
+    ``-ExecutionPolicy Bypass`` 由配置 ``powershell_bypass_execution_policy`` 决定，默认
+    不附加：执行策略是 Windows 上阻止未签名脚本运行的纵深防御，由代码单方面绕过等于替运维
+    取消了这道防线；确需在受限策略的机器上跑未签名 skill 脚本时再打开。
 
-    - ``-ExecutionPolicy Bypass``（``powershell_bypass_execution_policy``，默认关）：
-      执行策略是 Windows 上阻止未签名脚本运行的纵深防御，由代码单方面绕过等于替运维
-      取消了这道防线；确需在受限策略的机器上跑未签名 skill 脚本时再打开。
-    - ``-NoProfile``（``powershell_no_profile``，默认开）：跳过用户 profile 脚本，即
-      与 skill 无关的额外代码；若运维依赖 profile 里预置的模块或函数，可以关掉。
-    - ``-NonInteractive``（``powershell_non_interactive``，默认开）：脚本请求交互输入
-      时直接失败，而不是挂到执行超时；关掉后脚本仍拿不到 bot 的控制台输入，因为子进程
-      的 stdin 被接到 DEVNULL，只会立即读到 EOF。
+    ``-NoProfile`` 与 ``-NonInteractive`` 固定附加，不做成配置项：前者跳过用户 profile
+    脚本（与 skill 无关的额外代码），后者让脚本请求交互输入时直接失败而不是挂到执行超时。
+    两者都不改变脚本本身能做的事，只是去掉与「执行这个 skill 脚本」无关的变量。
 
     残留风险（有意接受，不在此处消除）：``-File`` 模式把参数当字面字符串交给脚本的
     ``param()`` 绑定器，所以不存在把参数重新解析成 PowerShell 代码的注入面，但以 ``-``
@@ -477,7 +481,7 @@ def _build_powershell_command(
     Args:
         script_path: 脚本绝对路径。
         normalized_args: 归一化后的脚本参数。
-        security: 生效的安全配置段，决定上述三个开关。
+        security: 生效的安全配置段，决定是否绕过执行策略。
 
     Returns:
         tuple[list[str] | None, str | None]: (命令列表, 错误信息)；
@@ -488,11 +492,7 @@ def _build_powershell_command(
     if powershell is None:
         return None, "未找到可用的 PowerShell 解释器"
 
-    command = [powershell]
-    if security.powershell_no_profile:
-        command.append("-NoProfile")
-    if security.powershell_non_interactive:
-        command.append("-NonInteractive")
+    command = [powershell, "-NoProfile", "-NonInteractive"]
     if security.powershell_bypass_execution_policy:
         command.extend(["-ExecutionPolicy", "Bypass"])
     command.extend(["-File", str(script_path), *normalized_args])

--- a/test/plugins/test_skill_manager_tools.py
+++ b/test/plugins/test_skill_manager_tools.py
@@ -24,8 +24,6 @@ from plugins.skill_manager.plugin import (
 from plugins.skill_manager.tools import SkillGetScriptTool
 from src.app.plugin_system.types import PermissionLevel
 
-_FAKE_COMSPEC = r"C:\Windows\system32\cmd.exe"
-
 
 @pytest.fixture(autouse=True)
 def stub_permission_lookup() -> Iterator[AsyncMock]:
@@ -496,9 +494,13 @@ async def test_get_script_accepts_safe_batch_arguments(tmp_path: Path) -> None:
         file_name="run.bat",
         content="@echo off\r\necho %1\r\n",
     )
+    # 解释器校验要求 COMSPEC 是指向现有文件的绝对路径，这里造一个真实文件，
+    # 避免测试依赖宿主机上真的存在 C:\Windows\system32\cmd.exe。
+    fake_interpreter = tmp_path / "cmd.exe"
+    fake_interpreter.write_bytes(b"")
 
     with (
-        patch.dict(os.environ, {"COMSPEC": _FAKE_COMSPEC}),
+        patch.dict(os.environ, {"COMSPEC": str(fake_interpreter)}),
         patch(
             "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
             new=AsyncMock(return_value=_fake_process(stdout=b"batch ok\r\n")),
@@ -515,11 +517,61 @@ async def test_get_script_accepts_safe_batch_arguments(tmp_path: Path) -> None:
     await_args = create_mock.await_args
     assert await_args is not None
     assert await_args.args == (
-        _FAKE_COMSPEC,
+        str(fake_interpreter),
         "/c",
         str(script_path),
         "--count=60",
         "C:/tmp/data.json",
+    )
+
+
+@pytest.mark.parametrize(
+    ("comspec", "case"),
+    [
+        ("cmd.exe", "相对路径"),
+        (r"C:\definitely\missing\cmd.exe", "绝对路径但文件不存在"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_script_ignores_untrustworthy_comspec(
+    tmp_path: Path,
+    comspec: str,
+    case: str,
+) -> None:
+    """COMSPEC 取值不可用时应回退到 PATH 查找，而不是把它交给 CreateProcess。
+
+    相对路径会让 CreateProcess 走搜索顺序，可能命中工作目录（即 skill 目录）下的
+    同名文件；指向不存在文件的绝对路径则会直接让执行失败。两种都必须被忽略。
+    """
+
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="run.bat",
+        content="@echo off\r\n",
+    )
+    resolved_interpreter = tmp_path / "resolved-cmd.exe"
+    resolved_interpreter.write_bytes(b"")
+
+    with (
+        patch.dict(os.environ, {"COMSPEC": comspec}),
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            return_value=str(resolved_interpreter),
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process(stdout=b"ok\r\n")),
+        ) as create_mock,
+    ):
+        success, _ = await tool.execute("demo", "scripts/run.bat")
+
+    assert success is True, f"{case} 时应回退成功"
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.args == (
+        str(resolved_interpreter.resolve()),
+        "/c",
+        str(script_path),
     )
 
 
@@ -572,6 +624,42 @@ async def test_get_script_rejects_control_characters_for_every_script_type(
 
     assert success is False
     assert "控制字符" in cast(str, result)
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.parametrize(
+    "malformed_args",
+    ['--path "unterminated', "--name 'unterminated", 'a "b" "c'],
+)
+@pytest.mark.asyncio
+async def test_get_script_rejects_unbalanced_quotes_in_string_args(
+    tmp_path: Path,
+    malformed_args: str,
+) -> None:
+    """引号不配对的字符串参数应返回拒绝结果，而不是让 ValueError 穿透。
+
+    ``script_args`` 由 LLM 生成，引号不配对属可预期的非法输入。``shlex.split``
+    对这类输入抛 ValueError，若不捕获就会突破 execute() 的 (bool, str) 返回契约。
+    """
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute(
+            "demo",
+            "scripts/echo.py",
+            malformed_args,
+        )
+
+    assert success is False
+    assert "引号不配对" in cast(str, result)
     assert create_mock.await_count == 0
 
 

--- a/test/plugins/test_skill_manager_tools.py
+++ b/test/plugins/test_skill_manager_tools.py
@@ -45,8 +45,6 @@ def _build_plugin(
     *,
     allow_script_execution: bool = True,
     powershell_bypass_execution_policy: bool = False,
-    powershell_no_profile: bool = True,
-    powershell_non_interactive: bool = True,
     script_execution_permission_level: str = "owner",
 ) -> SkillManagerPlugin:
     """创建测试用插件实例。"""
@@ -56,8 +54,6 @@ def _build_plugin(
     config.security.powershell_bypass_execution_policy = (
         powershell_bypass_execution_policy
     )
-    config.security.powershell_no_profile = powershell_no_profile
-    config.security.powershell_non_interactive = powershell_non_interactive
     config.security.script_execution_permission_level = (
         script_execution_permission_level
     )
@@ -98,8 +94,6 @@ def _prepare_script(
     content: str,
     allow_script_execution: bool = True,
     powershell_bypass_execution_policy: bool = False,
-    powershell_no_profile: bool = True,
-    powershell_non_interactive: bool = True,
     script_execution_permission_level: str = "owner",
     bind_message: bool = True,
 ) -> tuple[SkillGetScriptTool, Path]:
@@ -108,8 +102,6 @@ def _prepare_script(
     plugin = _build_plugin(
         allow_script_execution=allow_script_execution,
         powershell_bypass_execution_policy=powershell_bypass_execution_policy,
-        powershell_no_profile=powershell_no_profile,
-        powershell_non_interactive=powershell_non_interactive,
         script_execution_permission_level=script_execution_permission_level,
     )
     skill_root = tmp_path / "demo"
@@ -160,17 +152,12 @@ def test_script_tool_is_registered_when_execution_enabled() -> None:
 
 
 def test_security_defaults_are_fail_closed() -> None:
-    """默认配置下脚本执行关闭、策略绕过关闭、权限门为 OWNER。
-
-    另外两个 PowerShell 加固开关默认开启：它们默认取「更安全」的一档，运维可显式关闭。
-    """
+    """默认配置下脚本执行关闭、策略绕过关闭、权限门为 OWNER。"""
 
     security = resolve_security_section(SkillManagerConfig())
 
     assert security.allow_script_execution is False
     assert security.powershell_bypass_execution_policy is False
-    assert security.powershell_no_profile is True
-    assert security.powershell_non_interactive is True
     assert (
         PermissionLevel.from_string(security.script_execution_permission_level)
         is PermissionLevel.OWNER
@@ -811,55 +798,6 @@ async def test_get_script_executes_powershell_without_policy_bypass(tmp_path: Pa
         "3",
     )
     assert "Bypass" not in await_args.args
-
-
-@pytest.mark.parametrize(
-    ("no_profile", "non_interactive", "expected_flags"),
-    [
-        (True, True, ["-NoProfile", "-NonInteractive"]),
-        (False, True, ["-NonInteractive"]),
-        (True, False, ["-NoProfile"]),
-        (False, False, []),
-    ],
-)
-@pytest.mark.asyncio
-async def test_get_script_powershell_hardening_flags_follow_config(
-    tmp_path: Path,
-    no_profile: bool,
-    non_interactive: bool,
-    expected_flags: list[str],
-) -> None:
-    """-NoProfile / -NonInteractive 应完全由配置决定，而不是硬编码。"""
-
-    tool, script_path = _prepare_script(
-        tmp_path,
-        file_name="search.ps1",
-        content='Write-Output "ok"\n',
-        powershell_no_profile=no_profile,
-        powershell_non_interactive=non_interactive,
-    )
-
-    with (
-        patch(
-            "plugins.skill_manager.tools.shutil.which",
-            side_effect=lambda name: "powershell.exe" if name == "powershell" else None,
-        ),
-        patch(
-            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
-            new=AsyncMock(return_value=_fake_process(stdout=b"ok\n")),
-        ) as create_mock,
-    ):
-        success, _ = await tool.execute("demo", "scripts/search.ps1")
-
-    assert success is True
-    await_args = create_mock.await_args
-    assert await_args is not None
-    assert await_args.args == (
-        "powershell.exe",
-        *expected_flags,
-        "-File",
-        str(script_path),
-    )
 
 
 @pytest.mark.parametrize("script_name", ["echo.py", "run.sh"])

--- a/test/plugins/test_skill_manager_tools.py
+++ b/test/plugins/test_skill_manager_tools.py
@@ -3,22 +3,69 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import sys
 from pathlib import Path
-from typing import Any, cast
+from types import SimpleNamespace
+from typing import Any, Iterator, cast
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from plugins.skill_manager.config import SkillManagerConfig
 from plugins.skill_manager.models import SkillEntry
-from plugins.skill_manager.plugin import SkillManagerPlugin
+from plugins.skill_manager.plugin import (
+    SCRIPT_EXECUTION_DISABLED_MESSAGE,
+    SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE,
+    SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE,
+    SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE,
+    SkillManagerPlugin,
+)
 from plugins.skill_manager.tools import SkillGetScriptTool
+from src.app.plugin_system.types import PermissionLevel
+
+_FAKE_COMSPEC = r"C:\Windows\system32\cmd.exe"
 
 
-def _build_plugin() -> SkillManagerPlugin:
+@pytest.fixture(autouse=True)
+def stub_permission_lookup() -> Iterator[AsyncMock]:
+    """默认把调用者视为 OWNER，让非权限用例专注脚本执行本身。
+
+    Yields:
+        AsyncMock: 权限级别查询替身，权限相关用例可直接改写其返回值。
+    """
+
+    level_mock = AsyncMock(return_value=PermissionLevel.OWNER)
+    with (
+        patch("plugins.skill_manager.plugin.generate_person_id", return_value="person"),
+        patch("plugins.skill_manager.plugin.get_user_permission_level", new=level_mock),
+    ):
+        yield level_mock
+
+
+def _build_plugin(
+    *,
+    allow_script_execution: bool = True,
+    powershell_bypass_execution_policy: bool = False,
+    script_execution_permission_level: str = "owner",
+) -> SkillManagerPlugin:
     """创建测试用插件实例。"""
 
-    return SkillManagerPlugin(config=SkillManagerConfig())
+    config = SkillManagerConfig()
+    config.security.allow_script_execution = allow_script_execution
+    config.security.powershell_bypass_execution_policy = (
+        powershell_bypass_execution_policy
+    )
+    config.security.script_execution_permission_level = (
+        script_execution_permission_level
+    )
+    return SkillManagerPlugin(config=config)
+
+
+def _fake_message() -> SimpleNamespace:
+    """构造带身份字段的触发消息替身。"""
+
+    return SimpleNamespace(platform="test", sender_id="user_1", stream_id="stream")
 
 
 def _register_skill(plugin: SkillManagerPlugin, root_dir: Path, name: str = "demo") -> SkillEntry:
@@ -42,21 +89,249 @@ def _register_skill(plugin: SkillManagerPlugin, root_dir: Path, name: str = "dem
     return entry
 
 
-@pytest.mark.asyncio
-async def test_get_script_executes_python_script(tmp_path: Path) -> None:
-    """应继续支持原有 Python 脚本执行路径。"""
+def _prepare_script(
+    tmp_path: Path,
+    *,
+    file_name: str,
+    content: str,
+    allow_script_execution: bool = True,
+    powershell_bypass_execution_policy: bool = False,
+    script_execution_permission_level: str = "owner",
+    bind_message: bool = True,
+) -> tuple[SkillGetScriptTool, Path]:
+    """创建带单个脚本的 skill，并返回绑定好的工具实例与脚本路径。"""
 
-    plugin = cast(Any, _build_plugin())
-    tool = SkillGetScriptTool(plugin=cast(Any, plugin))
+    plugin = _build_plugin(
+        allow_script_execution=allow_script_execution,
+        powershell_bypass_execution_policy=powershell_bypass_execution_policy,
+        script_execution_permission_level=script_execution_permission_level,
+    )
     skill_root = tmp_path / "demo"
     script_dir = skill_root / "scripts"
     script_dir.mkdir(parents=True)
     _register_skill(plugin, skill_root)
 
-    script_path = script_dir / "echo.py"
-    script_path.write_text(
-        "import sys\nprint(sys.argv[1])\n",
-        encoding="utf-8",
+    script_path = script_dir / file_name
+    script_path.write_text(content, encoding="utf-8")
+
+    tool = SkillGetScriptTool(plugin=cast(Any, plugin))
+    if bind_message:
+        tool._bind_runtime_context(stream_id="stream", message=cast(Any, _fake_message()))
+    return tool, script_path
+
+
+def _fake_process(
+    *,
+    returncode: int = 0,
+    stdout: bytes = b"",
+    stderr: bytes = b"",
+) -> AsyncMock:
+    """构造一个立即返回的子进程替身。"""
+
+    process = AsyncMock()
+    process.returncode = returncode
+    process.communicate = AsyncMock(return_value=(stdout, stderr))
+    return process
+
+
+# ==================== 脚本执行总开关 ====================
+
+
+def test_script_tool_is_not_registered_when_execution_disabled() -> None:
+    """未开启脚本执行时不应注册 get_script 组件。"""
+
+    plugin = _build_plugin(allow_script_execution=False)
+
+    assert SkillGetScriptTool not in plugin.get_components()
+
+
+def test_script_tool_is_registered_when_execution_enabled() -> None:
+    """显式开启脚本执行后才注册 get_script 组件。"""
+
+    plugin = _build_plugin(allow_script_execution=True)
+
+    assert SkillGetScriptTool in plugin.get_components()
+
+
+def test_security_defaults_are_fail_closed() -> None:
+    """默认配置下脚本执行关闭、策略绕过关闭、权限门为 OWNER。"""
+
+    plugin = SkillManagerPlugin(config=SkillManagerConfig())
+
+    assert plugin.allow_script_execution is False
+    assert plugin.powershell_bypass_execution_policy is False
+    assert plugin.script_execution_permission_level is PermissionLevel.OWNER
+
+
+def test_security_defaults_apply_without_typed_config() -> None:
+    """配置缺失时应回退到同一套 fail-closed 默认值。"""
+
+    plugin = SkillManagerPlugin(config=None)
+
+    assert plugin.allow_script_execution is False
+    assert plugin.powershell_bypass_execution_policy is False
+    assert plugin.script_execution_permission_level is PermissionLevel.OWNER
+
+
+@pytest.mark.asyncio
+async def test_get_script_refuses_when_execution_disabled(tmp_path: Path) -> None:
+    """脚本执行未开启时，工具本身也要拒绝执行。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('should not run')\n",
+        allow_script_execution=False,
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False
+    assert result == SCRIPT_EXECUTION_DISABLED_MESSAGE
+    assert create_mock.await_count == 0
+
+
+# ==================== 调用者权限门 ====================
+
+
+@pytest.mark.asyncio
+async def test_get_script_refuses_caller_below_required_level(
+    tmp_path: Path,
+    stub_permission_lookup: AsyncMock,
+) -> None:
+    """开关打开后仍需调用者权限达标，不能对所有聊天用户放开。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('should not run')\n",
+    )
+    stub_permission_lookup.return_value = PermissionLevel.USER
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False
+    assert "权限不足" in cast(str, result)
+    assert "owner" in cast(str, result)
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_script_allows_caller_at_configured_level(
+    tmp_path: Path,
+    stub_permission_lookup: AsyncMock,
+) -> None:
+    """运维把门槛降到 operator 时，operator 调用者应放行。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+        script_execution_permission_level="operator",
+    )
+    stub_permission_lookup.return_value = PermissionLevel.OPERATOR
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_fake_process(stdout=b"ok\n")),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is True
+    assert "[stdout]\nok" in cast(str, result)
+    assert create_mock.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_get_script_refuses_unidentifiable_caller(tmp_path: Path) -> None:
+    """没有触发消息时无法归因到用户，必须拒绝而不是默认放行。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('should not run')\n",
+        bind_message=False,
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False
+    assert result == SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_script_refuses_on_invalid_permission_level_config(
+    tmp_path: Path,
+) -> None:
+    """权限级别配置写错时应拒绝执行，而不是退化成无门。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('should not run')\n",
+        script_execution_permission_level="root",
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False
+    assert result == SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_script_refuses_when_permission_lookup_fails(
+    tmp_path: Path,
+    stub_permission_lookup: AsyncMock,
+) -> None:
+    """权限查询本身出错时应 fail-closed。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('should not run')\n",
+    )
+    stub_permission_lookup.side_effect = RuntimeError("permission manager 未初始化")
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False
+    assert result == SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE
+    assert create_mock.await_count == 0
+
+
+# ==================== Python 脚本子进程隔离 ====================
+
+
+@pytest.mark.asyncio
+async def test_get_script_executes_python_script(tmp_path: Path) -> None:
+    """应继续支持 Python 脚本执行路径并回显 stdout。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="import sys\nprint(sys.argv[1])\n",
     )
 
     success, result = await tool.execute("demo", "scripts/echo.py", ["Neo-MoFox"])
@@ -67,44 +342,347 @@ async def test_get_script_executes_python_script(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
-async def test_get_script_executes_powershell_script_via_subprocess(tmp_path: Path) -> None:
-    """应支持 PowerShell 脚本并通过外部进程执行。"""
+async def test_get_script_runs_python_in_subprocess(tmp_path: Path) -> None:
+    """Python 脚本必须以独立解释器进程执行，不得在 bot 进程内 runpy。"""
 
-    plugin = cast(Any, _build_plugin())
-    tool = SkillGetScriptTool(plugin=cast(Any, plugin))
-    skill_root = tmp_path / "demo"
-    script_dir = skill_root / "scripts"
-    script_dir.mkdir(parents=True)
-    _register_skill(plugin, skill_root)
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+    )
 
-    script_path = script_dir / "search.ps1"
-    script_path.write_text('Write-Output "ok"\n', encoding="utf-8")
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_fake_process(stdout=b"ok\n")),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py", ["--flag", "1"])
 
-    process = AsyncMock()
-    process.returncode = 0
-    process.communicate = AsyncMock(return_value=(b"pwsh ok\n", b""))
+    assert success is True
+    assert "[stdout]\nok" in cast(str, result)
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.args == (sys.executable, str(script_path), "--flag", "1")
+    assert await_args.kwargs["cwd"] == str(script_path.parent)
+
+
+@pytest.mark.asyncio
+async def test_get_script_reports_python_failure_exit_code(tmp_path: Path) -> None:
+    """Python 脚本非零退出码应作为失败返回，并带上 stderr。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="fail.py",
+        content="import sys\nsys.exit('boom')\n",
+    )
+
+    success, result = await tool.execute("demo", "scripts/fail.py")
+
+    assert success is False
+    assert "脚本执行退出码: 1" in cast(str, result)
+    assert "[stderr]\nboom" in cast(str, result)
+
+
+@pytest.mark.asyncio
+async def test_get_script_forces_utf8_subprocess_output(tmp_path: Path) -> None:
+    """子进程环境需强制 UTF-8 且关闭缓冲，避免中文乱码与超时丢输出。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('中文')\n",
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_fake_process()),
+    ) as create_mock:
+        await tool.execute("demo", "scripts/echo.py")
+
+    await_args = create_mock.await_args
+    assert await_args is not None
+    env = await_args.kwargs["env"]
+    assert env["PYTHONIOENCODING"] == "utf-8"
+    assert env["PYTHONUNBUFFERED"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_get_script_python_output_keeps_non_ascii(tmp_path: Path) -> None:
+    """真实子进程的中文输出应能原样回收。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="chinese.py",
+        content="print('你好，MoFox')\n",
+    )
+
+    success, result = await tool.execute("demo", "scripts/chinese.py")
+
+    assert success is True
+    assert "[stdout]\n你好，MoFox" in cast(str, result)
+
+
+# ==================== .bat/.cmd 命令注入防护 ====================
+
+
+@pytest.mark.parametrize(
+    "malicious_arg",
+    [
+        "a&whoami",
+        "a|whoami",
+        "a>out.txt",
+        "a<in.txt",
+        "a^b",
+        "(a)",
+        '"a"',
+        "%USERNAME%",
+        "!DELAYED!",
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_script_rejects_cmd_metacharacter_arguments(
+    tmp_path: Path,
+    malicious_arg: str,
+) -> None:
+    """含 cmd.exe 元字符的参数必须在拼装命令行前被拒绝。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="run.bat",
+        content="@echo off\r\necho %1\r\n",
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/run.bat", [malicious_arg])
+
+    assert success is False
+    assert ".bat/.cmd 参数只允许" in cast(str, result)
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_script_rejects_cmd_injection_from_string_args(tmp_path: Path) -> None:
+    """字符串形式的参数经 shlex 拆分后仍需通过白名单校验。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="run.cmd",
+        content="@echo off\r\n",
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute(
+            "demo",
+            "scripts/run.cmd",
+            "a&whoami>C:/Users/Public/p.txt",
+        )
+
+    assert success is False
+    assert ".bat/.cmd 参数只允许" in cast(str, result)
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_script_accepts_safe_batch_arguments(tmp_path: Path) -> None:
+    """白名单内的参数应正常拼进 cmd.exe 命令行。"""
+
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="run.bat",
+        content="@echo off\r\necho %1\r\n",
+    )
 
     with (
-        patch("plugins.skill_manager.tools.shutil.which", side_effect=lambda name: "powershell.exe" if name == "powershell" else None),
-        patch("plugins.skill_manager.tools.asyncio.create_subprocess_exec", new=AsyncMock(return_value=process)) as create_mock,
+        patch.dict(os.environ, {"COMSPEC": _FAKE_COMSPEC}),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process(stdout=b"batch ok\r\n")),
+        ) as create_mock,
+    ):
+        success, result = await tool.execute(
+            "demo",
+            "scripts/run.bat",
+            ["--count=60", "C:/tmp/data.json"],
+        )
+
+    assert success is True
+    assert "[stdout]\nbatch ok" in cast(str, result)
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.args == (
+        _FAKE_COMSPEC,
+        "/c",
+        str(script_path),
+        "--count=60",
+        "C:/tmp/data.json",
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_script_reports_missing_command_interpreter(tmp_path: Path) -> None:
+    """找不到 cmd.exe 时应给出明确错误而不是拼一个裸命令名。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="run.bat",
+        content="@echo off\r\n",
+    )
+
+    with (
+        patch.dict(os.environ, {"COMSPEC": ""}),
+        patch("plugins.skill_manager.tools.shutil.which", return_value=None),
+    ):
+        success, result = await tool.execute("demo", "scripts/run.bat")
+
+    assert success is False
+    assert result == "未找到可用的 cmd.exe 解释器"
+
+
+# ==================== 全类型参数校验 ====================
+
+
+@pytest.mark.parametrize("script_name", ["echo.py", "run.bat", "run.sh"])
+@pytest.mark.asyncio
+async def test_get_script_rejects_control_characters_for_every_script_type(
+    tmp_path: Path,
+    script_name: str,
+) -> None:
+    """控制字符在任何脚本类型的参数里都应被拒绝。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name=script_name,
+        content="echo ok\n",
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute(
+            "demo",
+            f"scripts/{script_name}",
+            ["a\nwhoami"],
+        )
+
+    assert success is False
+    assert "控制字符" in cast(str, result)
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_get_script_rejects_non_string_argument_list(tmp_path: Path) -> None:
+    """列表参数含非字符串元素时应直接拒绝。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+    )
+
+    success, result = await tool.execute("demo", "scripts/echo.py", cast(Any, ["a", 1]))
+
+    assert success is False
+    assert result == "script_args 列表元素必须为字符串"
+
+
+@pytest.mark.asyncio
+async def test_get_script_rejects_unsupported_argument_type(tmp_path: Path) -> None:
+    """非字符串/列表的参数类型应直接拒绝。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+    )
+
+    success, result = await tool.execute("demo", "scripts/echo.py", cast(Any, {"a": 1}))
+
+    assert success is False
+    assert result == "script_args 必须是字符串或字符串列表"
+
+
+# ==================== PowerShell 执行策略 ====================
+
+
+@pytest.mark.asyncio
+async def test_get_script_executes_powershell_without_policy_bypass(tmp_path: Path) -> None:
+    """默认不得附加 -ExecutionPolicy Bypass。"""
+
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="search.ps1",
+        content='Write-Output "ok"\n',
+    )
+
+    with (
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            side_effect=lambda name: "powershell.exe" if name == "powershell" else None,
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process(stdout=b"pwsh ok\n")),
+        ) as create_mock,
     ):
         success, result = await tool.execute("demo", "scripts/search.ps1", "--count 3")
 
     assert success is True
     assert "脚本已执行: search.ps1" in cast(str, result)
     assert "[stdout]\npwsh ok" in cast(str, result)
-    assert create_mock.await_count == 1
     await_args = create_mock.await_args
     assert await_args is not None
-    command_args = await_args.args
-    assert command_args == (
+    assert await_args.args == (
         "powershell.exe",
-        "-ExecutionPolicy",
-        "Bypass",
+        "-NoProfile",
+        "-NonInteractive",
         "-File",
         str(script_path),
         "--count",
         "3",
+    )
+    assert "Bypass" not in await_args.args
+
+
+@pytest.mark.asyncio
+async def test_get_script_applies_policy_bypass_only_when_opted_in(tmp_path: Path) -> None:
+    """仅在运维显式开启开关后才绕过 PowerShell 执行策略。"""
+
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="search.ps1",
+        content='Write-Output "ok"\n',
+        powershell_bypass_execution_policy=True,
+    )
+
+    with (
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            side_effect=lambda name: "pwsh.exe" if name == "pwsh" else None,
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process()),
+        ) as create_mock,
+    ):
+        success, _ = await tool.execute("demo", "scripts/search.ps1")
+
+    assert success is True
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.args == (
+        "pwsh.exe",
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-File",
+        str(script_path),
     )
 
 
@@ -112,15 +690,11 @@ async def test_get_script_executes_powershell_script_via_subprocess(tmp_path: Pa
 async def test_get_script_reports_missing_powershell_runner(tmp_path: Path) -> None:
     """PowerShell 解释器缺失时应给出明确错误。"""
 
-    plugin = cast(Any, _build_plugin())
-    tool = SkillGetScriptTool(plugin=cast(Any, plugin))
-    skill_root = tmp_path / "demo"
-    script_dir = skill_root / "scripts"
-    script_dir.mkdir(parents=True)
-    _register_skill(plugin, skill_root)
-
-    script_path = script_dir / "search.ps1"
-    script_path.write_text('Write-Output "ok"\n', encoding="utf-8")
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="search.ps1",
+        content='Write-Output "ok"\n',
+    )
 
     with patch("plugins.skill_manager.tools.shutil.which", return_value=None):
         success, result = await tool.execute("demo", "scripts/search.ps1")
@@ -129,19 +703,101 @@ async def test_get_script_reports_missing_powershell_runner(tmp_path: Path) -> N
     assert result == "未找到可用的 PowerShell 解释器"
 
 
+# ==================== shell 脚本 ====================
+
+
 @pytest.mark.asyncio
-async def test_get_script_returns_timeout_for_slow_external_script(tmp_path: Path) -> None:
-    """外部脚本卡住时应主动超时并终止进程。"""
+async def test_get_script_reports_missing_shell_runner(tmp_path: Path) -> None:
+    """shell 解释器缺失时应给出明确错误。"""
 
-    plugin = cast(Any, _build_plugin())
-    tool = SkillGetScriptTool(plugin=cast(Any, plugin))
-    skill_root = tmp_path / "demo"
-    script_dir = skill_root / "scripts"
-    script_dir.mkdir(parents=True)
-    _register_skill(plugin, skill_root)
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="run.sh",
+        content="echo ok\n",
+    )
 
-    script_path = script_dir / "search.ps1"
-    script_path.write_text('Write-Output "ok"\n', encoding="utf-8")
+    with patch("plugins.skill_manager.tools.shutil.which", return_value=None):
+        success, result = await tool.execute("demo", "scripts/run.sh")
+
+    assert success is False
+    assert result == "未找到可用的 shell 解释器"
+
+
+@pytest.mark.asyncio
+async def test_get_script_passes_shell_args_without_reparsing(tmp_path: Path) -> None:
+    """.sh 走 execve，参数原样传给 bash，不做二次 shell 解析。"""
+
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="run.sh",
+        content="echo ok\n",
+    )
+
+    with (
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            side_effect=lambda name: "/bin/bash" if name == "bash" else None,
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process()),
+        ) as create_mock,
+    ):
+        success, _ = await tool.execute("demo", "scripts/run.sh", ["a&whoami"])
+
+    assert success is True
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.args == ("/bin/bash", str(script_path), "a&whoami")
+
+
+# ==================== 路径边界与超时 ====================
+
+
+@pytest.mark.asyncio
+async def test_get_script_requires_injected_skill(tmp_path: Path) -> None:
+    """未注入的 skill 不允许执行脚本。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+    )
+    cast(Any, tool.plugin).injected_skills.clear()
+
+    success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False
+    assert result == "skill 'demo' 尚未注入，请先调用 get_skill"
+
+
+@pytest.mark.asyncio
+async def test_get_script_rejects_out_of_tree_location(tmp_path: Path) -> None:
+    """越界路径必须被目录边界校验拦下。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('ok')\n",
+    )
+    outside_script = tmp_path / "outside.py"
+    outside_script.write_text("print('outside')\n", encoding="utf-8")
+
+    success, result = await tool.execute("demo", "../outside.py")
+
+    assert success is False
+    assert "越界" in cast(str, result)
+
+
+@pytest.mark.asyncio
+async def test_get_script_returns_timeout_for_slow_script(tmp_path: Path) -> None:
+    """脚本卡住时应主动超时并终止进程。"""
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="search.ps1",
+        content='Write-Output "ok"\n',
+    )
 
     class FakeProcess:
         """模拟第一次 communicate 超时后，二次 communicate 会挂住的进程。"""
@@ -169,10 +825,16 @@ async def test_get_script_returns_timeout_for_slow_external_script(tmp_path: Pat
     process = FakeProcess()
 
     with (
-        patch("plugins.skill_manager.tools.EXTERNAL_SCRIPT_TIMEOUT_SECONDS", 0.01),
-        patch("plugins.skill_manager.tools.EXTERNAL_SCRIPT_KILL_GRACE_SECONDS", 0.05),
-        patch("plugins.skill_manager.tools.shutil.which", side_effect=lambda name: "powershell.exe" if name == "powershell" else None),
-        patch("plugins.skill_manager.tools.asyncio.create_subprocess_exec", new=AsyncMock(return_value=process)),
+        patch("plugins.skill_manager.tools.SCRIPT_TIMEOUT_SECONDS", 0.01),
+        patch("plugins.skill_manager.tools.SCRIPT_KILL_GRACE_SECONDS", 0.05),
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            side_effect=lambda name: "powershell.exe" if name == "powershell" else None,
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=process),
+        ),
     ):
         success, result = await asyncio.wait_for(
             tool.execute("demo", "scripts/search.ps1", "LLM 2"),

--- a/test/plugins/test_skill_manager_tools.py
+++ b/test/plugins/test_skill_manager_tools.py
@@ -12,16 +12,16 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 
-from plugins.skill_manager.config import SkillManagerConfig
+from plugins.skill_manager.config import SkillManagerConfig, resolve_security_section
 from plugins.skill_manager.models import SkillEntry
-from plugins.skill_manager.plugin import (
+from plugins.skill_manager.plugin import SkillManagerPlugin
+from plugins.skill_manager.tools import (
     SCRIPT_EXECUTION_DISABLED_MESSAGE,
     SCRIPT_EXECUTION_LEVEL_INVALID_MESSAGE,
     SCRIPT_EXECUTION_LOOKUP_FAILED_MESSAGE,
     SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE,
-    SkillManagerPlugin,
+    SkillGetScriptTool,
 )
-from plugins.skill_manager.tools import SkillGetScriptTool
 from src.app.plugin_system.types import PermissionLevel
 
 
@@ -35,8 +35,8 @@ def stub_permission_lookup() -> Iterator[AsyncMock]:
 
     level_mock = AsyncMock(return_value=PermissionLevel.OWNER)
     with (
-        patch("plugins.skill_manager.plugin.generate_person_id", return_value="person"),
-        patch("plugins.skill_manager.plugin.get_user_permission_level", new=level_mock),
+        patch("plugins.skill_manager.tools.generate_person_id", return_value="person"),
+        patch("plugins.skill_manager.tools.get_user_permission_level", new=level_mock),
     ):
         yield level_mock
 
@@ -45,6 +45,8 @@ def _build_plugin(
     *,
     allow_script_execution: bool = True,
     powershell_bypass_execution_policy: bool = False,
+    powershell_no_profile: bool = True,
+    powershell_non_interactive: bool = True,
     script_execution_permission_level: str = "owner",
 ) -> SkillManagerPlugin:
     """创建测试用插件实例。"""
@@ -54,6 +56,8 @@ def _build_plugin(
     config.security.powershell_bypass_execution_policy = (
         powershell_bypass_execution_policy
     )
+    config.security.powershell_no_profile = powershell_no_profile
+    config.security.powershell_non_interactive = powershell_non_interactive
     config.security.script_execution_permission_level = (
         script_execution_permission_level
     )
@@ -94,6 +98,8 @@ def _prepare_script(
     content: str,
     allow_script_execution: bool = True,
     powershell_bypass_execution_policy: bool = False,
+    powershell_no_profile: bool = True,
+    powershell_non_interactive: bool = True,
     script_execution_permission_level: str = "owner",
     bind_message: bool = True,
 ) -> tuple[SkillGetScriptTool, Path]:
@@ -102,6 +108,8 @@ def _prepare_script(
     plugin = _build_plugin(
         allow_script_execution=allow_script_execution,
         powershell_bypass_execution_policy=powershell_bypass_execution_policy,
+        powershell_no_profile=powershell_no_profile,
+        powershell_non_interactive=powershell_non_interactive,
         script_execution_permission_level=script_execution_permission_level,
     )
     skill_root = tmp_path / "demo"
@@ -152,23 +160,43 @@ def test_script_tool_is_registered_when_execution_enabled() -> None:
 
 
 def test_security_defaults_are_fail_closed() -> None:
-    """默认配置下脚本执行关闭、策略绕过关闭、权限门为 OWNER。"""
+    """默认配置下脚本执行关闭、策略绕过关闭、权限门为 OWNER。
 
-    plugin = SkillManagerPlugin(config=SkillManagerConfig())
+    另外两个 PowerShell 加固开关默认开启：它们默认取「更安全」的一档，运维可显式关闭。
+    """
 
-    assert plugin.allow_script_execution is False
-    assert plugin.powershell_bypass_execution_policy is False
-    assert plugin.script_execution_permission_level is PermissionLevel.OWNER
+    security = resolve_security_section(SkillManagerConfig())
+
+    assert security.allow_script_execution is False
+    assert security.powershell_bypass_execution_policy is False
+    assert security.powershell_no_profile is True
+    assert security.powershell_non_interactive is True
+    assert (
+        PermissionLevel.from_string(security.script_execution_permission_level)
+        is PermissionLevel.OWNER
+    )
 
 
-def test_security_defaults_apply_without_typed_config() -> None:
-    """配置缺失时应回退到同一套 fail-closed 默认值。"""
+@pytest.mark.parametrize("config", [None, object(), "not-a-config"])
+def test_security_defaults_apply_without_typed_config(config: object) -> None:
+    """配置缺失或类型不符时应回退到同一套 fail-closed 默认值。"""
+
+    security = resolve_security_section(config)
+
+    assert security.allow_script_execution is False
+    assert security.powershell_bypass_execution_policy is False
+    assert (
+        PermissionLevel.from_string(security.script_execution_permission_level)
+        is PermissionLevel.OWNER
+    )
+
+
+def test_script_tool_is_not_registered_without_typed_config() -> None:
+    """配置缺失时 get_script 同样不应注册。"""
 
     plugin = SkillManagerPlugin(config=None)
 
-    assert plugin.allow_script_execution is False
-    assert plugin.powershell_bypass_execution_policy is False
-    assert plugin.script_execution_permission_level is PermissionLevel.OWNER
+    assert SkillGetScriptTool not in plugin.get_components()
 
 
 @pytest.mark.asyncio
@@ -266,6 +294,54 @@ async def test_get_script_refuses_unidentifiable_caller(tmp_path: Path) -> None:
         success, result = await tool.execute("demo", "scripts/echo.py")
 
     assert success is False
+    assert result == SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE
+    assert create_mock.await_count == 0
+
+
+@pytest.mark.parametrize(
+    ("platform", "sender_id", "origin"),
+    [
+        ("qq", "", "各 chatter 的合成触发消息都不填 sender_id"),
+        ("", "user_1", "ChatStream.platform 允许为空串"),
+        ("", "", "两个字段同时缺失"),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_script_refuses_message_with_blank_identity(
+    tmp_path: Path,
+    platform: str,
+    sender_id: str,
+    origin: str,
+) -> None:
+    """触发消息存在但身份字段为空时也必须拒绝。
+
+    这不是防御性冗余：``Message`` 是无校验的普通类，``platform`` 与 ``sender_id`` 都默认
+    空串；而 neo_default_chatter 的 defaults/pick_trigger_message.py、default_chatter 的
+    session.py 与 sub_agent_collaboration.py 在流里没有现成消息时都会构造合成触发消息，
+    三处都没填 ``sender_id``。定时唤醒与 sub_agent 协作走的正是这些分支。
+    """
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name="echo.py",
+        content="print('should not run')\n",
+        bind_message=False,
+    )
+    tool._bind_runtime_context(
+        stream_id="stream",
+        message=cast(
+            Any,
+            SimpleNamespace(platform=platform, sender_id=sender_id, stream_id="stream"),
+        ),
+    )
+
+    with patch(
+        "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+        new=AsyncMock(),
+    ) as create_mock:
+        success, result = await tool.execute("demo", "scripts/echo.py")
+
+    assert success is False, f"{origin} 时不应放行"
     assert result == SCRIPT_EXECUTION_UNIDENTIFIED_MESSAGE
     assert create_mock.await_count == 0
 
@@ -735,6 +811,92 @@ async def test_get_script_executes_powershell_without_policy_bypass(tmp_path: Pa
         "3",
     )
     assert "Bypass" not in await_args.args
+
+
+@pytest.mark.parametrize(
+    ("no_profile", "non_interactive", "expected_flags"),
+    [
+        (True, True, ["-NoProfile", "-NonInteractive"]),
+        (False, True, ["-NonInteractive"]),
+        (True, False, ["-NoProfile"]),
+        (False, False, []),
+    ],
+)
+@pytest.mark.asyncio
+async def test_get_script_powershell_hardening_flags_follow_config(
+    tmp_path: Path,
+    no_profile: bool,
+    non_interactive: bool,
+    expected_flags: list[str],
+) -> None:
+    """-NoProfile / -NonInteractive 应完全由配置决定，而不是硬编码。"""
+
+    tool, script_path = _prepare_script(
+        tmp_path,
+        file_name="search.ps1",
+        content='Write-Output "ok"\n',
+        powershell_no_profile=no_profile,
+        powershell_non_interactive=non_interactive,
+    )
+
+    with (
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            side_effect=lambda name: "powershell.exe" if name == "powershell" else None,
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process(stdout=b"ok\n")),
+        ) as create_mock,
+    ):
+        success, _ = await tool.execute("demo", "scripts/search.ps1")
+
+    assert success is True
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.args == (
+        "powershell.exe",
+        *expected_flags,
+        "-File",
+        str(script_path),
+    )
+
+
+@pytest.mark.parametrize("script_name", ["echo.py", "run.sh"])
+@pytest.mark.asyncio
+async def test_get_script_detaches_subprocess_stdin(
+    tmp_path: Path,
+    script_name: str,
+) -> None:
+    """脚本子进程不得继承 bot 的 stdin。
+
+    bot 主循环是交互式控制台命令循环（``src/app/runtime/console_input.py`` 的
+    prompt_toolkit 会话）。若子进程继承 stdin，读取输入的脚本会和控制台抢同一个 fd，
+    把运维正在输入的命令吃掉；接到 DEVNULL 后读取立即得到 EOF。
+    """
+
+    tool, _ = _prepare_script(
+        tmp_path,
+        file_name=script_name,
+        content="echo ok\n",
+    )
+
+    with (
+        patch(
+            "plugins.skill_manager.tools.shutil.which",
+            side_effect=lambda name: "bash" if name == "bash" else None,
+        ),
+        patch(
+            "plugins.skill_manager.tools.asyncio.create_subprocess_exec",
+            new=AsyncMock(return_value=_fake_process(stdout=b"ok\n")),
+        ) as create_mock,
+    ):
+        success, _ = await tool.execute("demo", f"scripts/{script_name}")
+
+    assert success is True
+    await_args = create_mock.await_args
+    assert await_args is not None
+    assert await_args.kwargs["stdin"] is asyncio.subprocess.DEVNULL
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## 背景

`get_script` 以 bot 进程权限执行代码，而工具调用层不存在任何鉴权（`src/core/managers/tool_manager/` 下无权限相关代码）。聊天用户可以通过提示注入影响 LLM 选择的工具名与参数，因此 LLM 传入的 `script_args` 必须视为攻击者可影响的输入。

同时存在一处权限模型不一致：只读的 `/skill` 管理命令要求 `PermissionLevel.OWNER`，而能执行代码的 `get_script` 工具对所有人开放。

本 PR 收敛这条路径上的四类问题。

## 改动

### 1. 命令注入（`.bat`/`.cmd`）

原实现把参数原样拼进 `cmd.exe /c` 命令行：

```python
return ["cmd.exe", "/c", str(script_path), *normalized_args], None
```

Windows 上 `subprocess.list2cmdline` 只处理空白与反斜杠/引号，**不转义 cmd.exe 元字符**。参数中不含空格时不会加引号，因此 `a&whoami` 会被 cmd.exe 切分成两条命令独立执行，而 stdout 会被拼回工具返回值交给 LLM，构成可读可写的完整回显通道。

改为字符白名单校验，只接受 `字母、数字与 . _ : / \ @ = -`，出现空白或 `& | < > ^ ( ) " % !` 一律拒绝执行。另对所有脚本类型统一拒绝控制字符（含换行、回车、NUL）。

### 2. 执行隔离（`.py`）

`.py` 原先通过 `runpy.run_path(..., run_name="__main__")` 在 bot 主进程内执行：与 bot 共享内存空间、无超时保护、可读取已加载的配置实例与数据库会话、可 monkeypatch 任意全局状态（包括权限判定函数本身）。

改为 `[sys.executable, script, *args]` 子进程，与其他脚本类型统一获得 15 秒超时与进程内存隔离。

代价是 skill 脚本不能再 `import src.*`——需要框架能力的逻辑应写成插件组件而非 skill 脚本，README 已注明。这是进程内存隔离而非沙箱，子进程仍以相同 OS 身份运行、可读 `config/` 与 `data/`，README 也明确写出了这条边界，避免读者高估防护强度。

### 3. 调用者权限门

新增 `[security]` 配置段，两道门：

- `allow_script_execution`（默认 `false`）——关闭时 `get_script` 组件根本不注册，LLM 工具列表里看不到它。这个开关只决定「这台部署是否提供脚本执行能力」。
- `script_execution_permission_level`（默认 `owner`）——决定「谁可以执行」。每次调用按触发消息的 `platform` + `sender_id` 解析 `person_id`，经 `permission_api` 查出实际级别后与配置比对，与 `/skill` 命令用同一套权限体系。

这样开关打开后不会立刻对所有聊天用户放开。无触发消息、身份字段为空、级别配置非法、权限查询抛错四种情况一律拒绝（fail-closed）。

### 4. PowerShell 加固

默认不再附加 `-ExecutionPolicy Bypass`——执行策略是 Windows 上阻止未签名脚本运行的纵深防御，由代码单方面绕过等于替运维取消了这道防线。改由 `powershell_bypass_execution_policy`（默认 `false`）控制。固定附加 `-NoProfile -NonInteractive`，避免加载与 skill 无关的用户 profile 脚本，以及脚本等待交互输入时挂到超时。

### 其他

- 输出回收任务改走 `task_manager`，符合仓库「禁止直接 `asyncio.create_task()`」约定；`daemon=True` 因为超时判定与进程收尾由本函数自行用 `wait_for` 控制。
- 子进程强制 `PYTHONIOENCODING=utf-8` 与 `PYTHONUNBUFFERED=1`，修复 Windows 本地代码页（cp936）导致中文输出乱码，以及超时被 kill 时缓冲区输出丢失。
- `.bat`/`.cmd` 解释器改用 `%COMSPEC%` 绝对路径定位，避免 `CreateProcess` 搜索顺序命中工作目录下的同名文件。
- 抽出 `_compose_result` / `_decode_captured_output`，收掉三处重复的「结论行 + 输出」拼装。

## 未处理 / 有意接受

`.ps1` 在 `-File` 模式下，以 `-` 开头的参数会绑定到脚本声明的命名参数上。这不是代码注入（`-File` 把参数当字面字符串交给 `param()` 绑定器，不会重新解析成 PowerShell 代码），而是「调用者可触达脚本的完整参数面」。这对 `.py` 的 argparse、`.sh` 的 getopts 同样成立，属于「给脚本传参」这个功能的固有语义，无法在保留传参能力的前提下消除。实际约束靠上面的调用者权限门，以及「skill 目录内容由运维决定、属可信输入」这一前提。代码注释中已记录该判断。

## 测试

`test/plugins/test_skill_manager_tools.py` 扩充至覆盖：开关关闭时不注册组件、无类型化配置时的 fail-closed 兜底、cmd 元字符与字符串形式参数的注入拒绝、安全参数放行、`.bat` 端到端执行、`.ps1` 默认不带 Bypass、Bypass 仅在显式开启时附加。

```
uv run pytest test/plugins/test_skill_manager_tools.py test/plugins/test_skill_manager_commands.py --no-cov -q
43 passed
```

`test/plugins/` 下另有 5 个 collection error（`ModuleNotFoundError: No module named 'sklearn'`），属 default_chatter 既有依赖缺失，与本 PR 无关。

## 兼容性

- `manifest.json` 升至 `1.1.0`，`api_version` 增加 `permission_api: 1.0.0`。
- **行为变更**：`get_script` 由默认可用改为默认不注册，需要该能力的部署必须显式开启两项配置。
- **行为变更**：`.py` skill 脚本不再能 `import src.*`。
- `manifest.json` 的 `include` 保持 5 个组件不变，是插件声明的组件面（超集），实际注册集合由配置决定；`include` 仅被 `loader.py` 解析为组件级依赖声明，不参与强制校验。README 已补充说明，避免后续被当成漏维护而「修正」。

## Summary by Sourcery

加固 SkillManager 的 get_script 能力，默认关闭脚本执行并通过调用者权限、参数校验和进程隔离降低代码执行风险。

Bug Fixes:
- 加固 get_script 的脚本执行路径，阻止批处理参数命令注入并拒绝控制字符输入。
- 为脚本执行增加默认关闭的部署开关与基于调用者身份的权限校验，并在无法确认权限时安全拒绝。
- 将 Python 脚本统一迁移至受超时保护的独立子进程执行，减少对 bot 主进程状态的影响。
- 收紧 PowerShell 执行策略、解释器定位、标准输入与子进程输出处理，提升脚本执行安全性和可靠性。

Enhancements:
- 统一各类脚本的子进程执行、输出回收和结果格式。

Documentation:
- 补充脚本执行的配置选项、安全边界、权限要求及组件注册行为说明。

Tests:
- 扩展 SkillManager 工具测试，覆盖权限门、默认关闭策略、参数注入防护、子进程隔离、解释器配置、输出处理和超时行为。

Chores:
- 将插件版本升级至 1.1.0，并声明 permission_api 依赖版本。