### PR TITLE
feat(transport): 新增 BEFORE_CHATTER_DISPATCH 前置分发门控（零副作用 Tick 阻断 + 完整处理租约）

### DIFF
--- a/docs/core/transport/README.md
+++ b/docs/core/transport/README.md
@@ -35,7 +35,7 @@
 3. MessageReceiver 使用 MessageConverter 解析为 Message。
 4. MessageReceiver 发布 ON_MESSAGE_RECEIVED 事件。
 5. distribution/distributor 订阅该事件，写入 StreamManager 并启动流驱动器。
-6. StreamLoopManager 驱动 run_chat_stream，推进 chatter 执行。
+6. StreamLoopManager 驱动 run_chat_stream：先发布 BEFORE_CHATTER_DISPATCH 门控，再推进 chatter 执行。
 
 ### 出站链路（Core -> Adapter）
 
@@ -51,7 +51,8 @@
 - ON_MESSAGE_RECEIVED: 入站消息进入 core 分发主链路。
 - ON_RECEIVED_OTHER_MESSAGE: 非标准 envelope 的二次处理入口。
 - ON_ALL_PLUGIN_LOADED: 启动 StreamLoopManager。
-- ON_CHATTER_STEP: 每个 tick 前的对话步进钩子。
+- BEFORE_CHATTER_DISPATCH: 每个 tick 最前端的分发门控，continue=False 时无副作用跳过本 tick，详见 distribution.md。
+- ON_CHATTER_STEP: 每 tick 内、chatter 单步执行前的对话步进钩子。
 - ON_MESSAGE_SENT: 出站消息下发前的拦截与补充入口。
 
 ## 运行时协作关系

--- a/docs/core/transport/distribution.md
+++ b/docs/core/transport/distribution.md
@@ -42,11 +42,20 @@ initialize_distribution 会订阅两个关键事件：
 ## run_chat_stream 核心逻辑
 
 1. 消费 conversation_loop 产出的 tick。
-2. 执行 wait_state_check 和 message_buffer_check。
-3. 获取或创建 chatter 生成器。
-4. 发布 ON_CHATTER_STEP 事件（支持 continue=False 中断本 tick）。
-5. 执行 anext(chatter_gene) 并处理 Success/Failure/Wait/Stop。
-6. 异常时回收生成器并更新失败统计。
+2. 发布 BEFORE_CHATTER_DISPATCH 事件（分发前置门控，支持 continue=False 无副作用跳过本 tick）。
+3. 执行 wait_state_check 和 message_buffer_check。
+4. 获取或创建 chatter 生成器。
+5. 发布 ON_CHATTER_STEP 事件（支持 continue=False 中断本 tick）。
+6. 执行 anext(chatter_gene) 并处理 Success/Failure/Wait/Stop。
+7. 异常时回收生成器并更新失败统计。
+
+## BEFORE_CHATTER_DISPATCH 门控语义
+
+- 触发时机：每个 tick 的最前端，先于 wait_state_check、message_buffer_check 与生成器获取/创建。
+- 事件参数：`stream_id`、`context`、`tick`、`continue`（默认 True）、`reason`（阻断原因文案）。
+- 阻断语义：处理器将 `continue` 置为 False 时，本 tick 整体跳过；等待状态、resume 事件、消息缓冲计数、生成器与 `triggering_user_id` 均保持原状，不产生任何状态消费。
+- 处理租约：`is_chatter_processing` 从本事件发布开始置为 True，覆盖分发决策到 chatter 单步结束的完整区间，`finally` 中统一释放；接收侧可依据该标记避免在同一流上并发干预。
+- 与 ON_CHATTER_STEP 的区别：ON_CHATTER_STEP 位于链路末端，阻断时等待状态与 resume 事件已被消费，并触发 `_discard_blocked_messages` 丢弃积压消息；BEFORE_CHATTER_DISPATCH 用于需要无损阻断的场景。
 
 ## 性能与稳定性要点
 

--- a/docs/guides/plugin-authoring/15-event-system.md
+++ b/docs/guides/plugin-authoring/15-event-system.md
@@ -239,12 +239,15 @@ weight = 0
 - `EventType.ON_MESSAGE_SENT`
 - `EventType.ON_ALL_PLUGIN_LOADED`
 - `EventType.ON_RECEIVED_OTHER_MESSAGE`
+- `EventType.BEFORE_CHATTER_DISPATCH`
 
 这类事件的价值在于：
 
 > **插件可以在框架已经定义好的关键时刻插进去。**
 
 比如 notice 收集、消息拦截、插件加载后补初始化，都是这一类。
+
+其中 `BEFORE_CHATTER_DISPATCH` 值得单独一提：它在每个会话 Tick 的最前端发布，把 `continue` 置为 `False` 可以让本轮分发整体跳过——等待状态、恢复事件、消息缓冲与生成器全部原样保留，不会消耗任何流状态。适合做专注度门控、优先级压制这类“本轮先别说话”的判断；如果阻断逻辑需要消费消息或状态，应该用 `ON_CHATTER_STEP` 而不是它。
 
 ### 自定义事件
 

--- a/src/core/components/types.py
+++ b/src/core/components/types.py
@@ -54,6 +54,7 @@ class EventType(str, Enum):
     ON_MESSAGE_RECEIVED = "on_message_received"
     ON_MESSAGE_SENT = "on_message_sent"
     AFTER_MESSAGE_SENT = "after_message_sent"
+    BEFORE_CHATTER_DISPATCH = "before_chatter_dispatch"
     ON_CHATTER_STEP = "on_chatter_step"
     AFTER_CHATTER_STEP = "after_chatter_step"
     ON_INTERNAL_CONTEXT_REQUESTED = "on_internal_context_requested"

--- a/src/core/models/stream.py
+++ b/src/core/models/stream.py
@@ -29,7 +29,7 @@ class StreamContext:
         unread_messages: 未读消息列表
         history_messages: 历史消息列表
         is_active: 是否活跃
-        is_chatter_processing: Chatter 是否正在处理
+        is_chatter_processing: 当前流是否处于 Chatter 分发决策或单步处理租约中
         is_context_compressing: 是否正在执行上下文压缩
         message_cache: 消息缓存队列
         is_cache_enabled: 是否启用消息缓存
@@ -43,6 +43,7 @@ class StreamContext:
     unread_messages: list["Message"] = field(default_factory=list)
     history_messages: list["Message"] = field(default_factory=list)
     is_active: bool = True
+    # 覆盖 pre-dispatch gate 到 Chatter step 结束的完整不可并发切换区间。
     is_chatter_processing: bool = False
     is_context_compressing: bool = False
 

--- a/src/core/transport/distribution/loop.py
+++ b/src/core/transport/distribution/loop.py
@@ -264,183 +264,204 @@ async def run_chat_stream(
                     )
                     break
 
-                # 1. 检查并处理等待状态
-                wait_state = manager._wait_state_check(stream_id, context)
-                if not wait_state:
-                    # 处于等待中且未满足条件，跳过本次 Tick
-                    continue
-
-                resume_event = _take_wait_resume_event(manager, stream_id)
-
-                # 2. 消息缓冲机制检查
-                # 若距上次收到消息未超过缓冲窗口，则跳过本次 Tick（等待用户连续消息合并），
-                # 但当连续跳过次数已达上限时强制继续，防止高压群聊导致 Bot 始终无法响应。
-                if resume_event is None and not manager._message_buffer_check(stream_id, context):
-                    continue
-
-                # 3. 获取或创建 chatter_gene
-                chatter_gene = manager._chatter_genes.get(stream_id)
-                chatter_gene_just_created = False
-                
-                if not chatter_gene:
-                    # 如果没有生成器，只有在有未处理消息或外部恢复事件时才尝试创建
-                    if not context.unread_messages and resume_event is None:
-                        continue
-
-                    # 查找或绑定 Chatter
-                    chat_stream = None
-                    chatter = chatter_manager.get_chatter_by_stream(stream_id)
-                    if not chatter:
-                        from src.core.managers import get_stream_manager
-
-                        sm = get_stream_manager()
-                        chat_stream = await sm.get_or_create_stream(stream_id)
-                        if not chat_stream:
-                            continue
-
-                        chatter = chatter_manager.get_or_create_chatter_for_stream(
-                            stream_id, chat_stream.chat_type, chat_stream.platform
-                        )
-
-                    if chatter:
-                        if chat_stream is not None:
-                            chatter.apply_stream_runtime_options(chat_stream)
-                        logger.debug(f"[驱动器] stream={stream_id[:8]}, 创建新会话生成器")
-                        
-                        # 设置触发用户 ID (从最后一条未读消息)
-                        if context.unread_messages:
-                            context.triggering_user_id = context.unread_messages[-1].sender_id
-                            
-                        chatter_gene = chatter.execute()
-                        if asyncio.iscoroutine(chatter_gene):
-                            chatter_gene = await _await_stream_step(
-                                chatter_gene,
-                                stream_id=stream_id,
-                                stage="创建 Chatter 生成器",
-                            )
-                        manager._chatter_genes[stream_id] = chatter_gene
-                        chatter_gene_just_created = True
-                
-                if not chatter_gene:
-                    continue
-
-                # 3. 执行单步 Tick
+                # 该租约覆盖 pre-dispatch 决策、状态消费和 Chatter step 的所有出口。
                 try:
-                    # 并发保护：标记正在处理
                     context.is_chatter_processing = True
 
-                    step_event_result = await event_manager.publish_event(
-                        EventType.ON_CHATTER_STEP,
+                    dispatch_event_result = await event_manager.publish_event(
+                        EventType.BEFORE_CHATTER_DISPATCH,
                         {
                             "stream_id": stream_id,
                             "context": context,
                             "tick": tick,
-                            "chatter_gene": chatter_gene,
                             "continue": True,
+                            "reason": "",
                         },
                     )
-                    step_event_params = step_event_result.get("params", {})
-                    if step_event_params.get("continue") is False:
-                        discarded_count = _discard_blocked_messages(context)
+                    dispatch_event_params = dispatch_event_result.get("params", {})
+                    if dispatch_event_params.get("continue") is False:
+                        reason = dispatch_event_params.get("reason", "")
                         logger.debug(
                             f"[驱动器] stream={stream_id[:8]}, "
-                            f"on_chatter_step continue=False，跳过本 Tick，"
-                            f"丢弃积压消息={discarded_count}"
+                            f"before_chatter_dispatch continue=False，跳过本 Tick，"
+                            f"reason={reason}"
                         )
                         continue
-                    
-                    # 新建的异步生成器首次只能 anext()/asend(None)，
-                    # 避免 Wait 恢复事件在首次步进时触发协议错误。
-                    if chatter_gene_just_created and resume_event is not None:
-                        primed_result = await _await_stream_step(
-                            anext(chatter_gene),
-                            stream_id=stream_id,
-                            stage="预激 Chatter 生成器",
+
+                    # 1. 检查并处理等待状态
+                    wait_state = manager._wait_state_check(stream_id, context)
+                    if not wait_state:
+                        # 处于等待中且未满足条件，跳过本次 Tick
+                        continue
+
+                    resume_event = _take_wait_resume_event(manager, stream_id)
+
+                    # 2. 消息缓冲机制检查
+                    # 若距上次收到消息未超过缓冲窗口，则跳过本次 Tick（等待用户连续消息合并），
+                    # 但当连续跳过次数已达上限时强制继续，防止高压群聊导致 Bot 始终无法响应。
+                    if resume_event is None and not manager._message_buffer_check(stream_id, context):
+                        continue
+
+                    # 3. 获取或创建 chatter_gene
+                    chatter_gene = manager._chatter_genes.get(stream_id)
+                    chatter_gene_just_created = False
+
+                    if not chatter_gene:
+                        # 如果没有生成器，只有在有未处理消息或外部恢复事件时才尝试创建
+                        if not context.unread_messages and resume_event is None:
+                            continue
+
+                        # 查找或绑定 Chatter
+                        chat_stream = None
+                        chatter = chatter_manager.get_chatter_by_stream(stream_id)
+                        if not chatter:
+                            from src.core.managers import get_stream_manager
+
+                            sm = get_stream_manager()
+                            chat_stream = await sm.get_or_create_stream(stream_id)
+                            if not chat_stream:
+                                continue
+
+                            chatter = chatter_manager.get_or_create_chatter_for_stream(
+                                stream_id, chat_stream.chat_type, chat_stream.platform
+                            )
+
+                        if chatter:
+                            if chat_stream is not None:
+                                chatter.apply_stream_runtime_options(chat_stream)
+                            logger.debug(f"[驱动器] stream={stream_id[:8]}, 创建新会话生成器")
+
+                            # 设置触发用户 ID (从最后一条未读消息)
+                            if context.unread_messages:
+                                context.triggering_user_id = context.unread_messages[-1].sender_id
+
+                            chatter_gene = chatter.execute()
+                            if asyncio.iscoroutine(chatter_gene):
+                                chatter_gene = await _await_stream_step(
+                                    chatter_gene,
+                                    stream_id=stream_id,
+                                    stage="创建 Chatter 生成器",
+                                )
+                            manager._chatter_genes[stream_id] = chatter_gene
+                            chatter_gene_just_created = True
+
+                    if not chatter_gene:
+                        continue
+
+                    # 3. 执行单步 Tick
+                    try:
+                        step_event_result = await event_manager.publish_event(
+                            EventType.ON_CHATTER_STEP,
+                            {
+                                "stream_id": stream_id,
+                                "context": context,
+                                "tick": tick,
+                                "chatter_gene": chatter_gene,
+                                "continue": True,
+                            },
                         )
-                        if not isinstance(primed_result, Wait):
-                            result = primed_result
+                        step_event_params = step_event_result.get("params", {})
+                        if step_event_params.get("continue") is False:
+                            discarded_count = _discard_blocked_messages(context)
+                            logger.debug(
+                                f"[驱动器] stream={stream_id[:8]}, "
+                                f"on_chatter_step continue=False，跳过本 Tick，"
+                                f"丢弃积压消息={discarded_count}"
+                            )
+                            continue
+
+                        # 新建的异步生成器首次只能 anext()/asend(None)，
+                        # 避免 Wait 恢复事件在首次步进时触发协议错误。
+                        if chatter_gene_just_created and resume_event is not None:
+                            primed_result = await _await_stream_step(
+                                anext(chatter_gene),
+                                stream_id=stream_id,
+                                stage="预激 Chatter 生成器",
+                            )
+                            if not isinstance(primed_result, Wait):
+                                result = primed_result
+                            else:
+                                result = await _await_stream_step(
+                                    chatter_gene.asend(resume_event),
+                                    stream_id=stream_id,
+                                    stage="执行 Chatter 单步",
+                                )
                         else:
+                            step_awaitable = (
+                                chatter_gene.asend(resume_event)
+                                if resume_event is not None
+                                else anext(chatter_gene)
+                            )
                             result = await _await_stream_step(
-                                chatter_gene.asend(resume_event),
+                                step_awaitable,
                                 stream_id=stream_id,
                                 stage="执行 Chatter 单步",
                             )
-                    else:
-                        step_awaitable = (
-                            chatter_gene.asend(resume_event)
-                            if resume_event is not None
-                            else anext(chatter_gene)
-                        )
-                        result = await _await_stream_step(
-                            step_awaitable,
+
+                        refreshed_context = await manager._get_stream_context(stream_id)
+                        if not refreshed_context:
+                            break
+
+                        if not _is_task_current(refreshed_context):
+                            logger.debug(
+                                f"[驱动器] stream={stream_id[:8]}, 任务ID={task_id}, Chatter 步进完成后发现已被新任务接管，丢弃旧结果并退出"
+                            )
+                            break
+
+                        context = refreshed_context
+
+                        # 4. 根据执行结果处理状态
+                        if isinstance(result, Success):
+                            # 执行成功，等待下一 Tick 继续
+                            pass
+                        elif isinstance(result, Failure):
+                            # 执行失败，输出警告并等待下一 Tick
+                            logger.warning(f"[驱动器] stream={stream_id[:8]}, Chatter 返回 Failure: {result.error}")
+                        elif isinstance(result, Wait):
+                            # 记录等待状态（直接保存上次 yield 对象）
+                            manager._wait_states[stream_id] = (
+                                result,
+                                time.time(),
+                                len(context.unread_messages),
+                            )
+                            logger.debug(f"[驱动器] stream={stream_id[:8]}, 进入 Wait 状态 (time={result.time})")
+                        elif isinstance(result, Stop):
+                            # 记录等待状态并销毁生成器。
+                            # Stop 语义：经过冷却后，仅当出现“新的未读消息”才重启对话。
+                            manager._wait_states[stream_id] = (
+                                result,
+                                time.time(),
+                                len(context.unread_messages),
+                            )
+                            logger.debug(
+                                f"[驱动器] stream={stream_id[:8]}, 进入 Stop 状态 "
+                                f"(time={result.time}, "
+                                f"direct_wake={result.direct_message_wake_enabled}, "
+                                f"probability={result.direct_message_wake_probability:.2f})，销毁生成器"
+                            )
+                            manager._chatter_genes.pop(stream_id, None)
+
+                        get_chatter = getattr(chatter_manager, "get_chatter_by_stream", None)
+                        chatter = get_chatter(stream_id) if callable(get_chatter) else None
+                        await _publish_after_chatter_step_notification(
                             stream_id=stream_id,
-                            stage="执行 Chatter 单步",
+                            context=context,
+                            tick=tick,
+                            chatter_name=str(getattr(chatter, "chatter_name", "") or ""),
+                            result=result,
+                            event_manager=event_manager,
                         )
 
-                    refreshed_context = await manager._get_stream_context(stream_id)
-                    if not refreshed_context:
-                        break
+                        manager._stats["total_process_cycles"] += 1
 
-                    if not _is_task_current(refreshed_context):
-                        logger.debug(
-                            f"[驱动器] stream={stream_id[:8]}, 任务ID={task_id}, Chatter 步进完成后发现已被新任务接管，丢弃旧结果并退出"
-                        )
-                        break
-
-                    context = refreshed_context
-                    
-                    # 4. 根据执行结果处理状态
-                    if isinstance(result, Success):
-                        # 执行成功，等待下一 Tick 继续
-                        pass
-                    elif isinstance(result, Failure):
-                        # 执行失败，输出警告并等待下一 Tick
-                        logger.warning(f"[驱动器] stream={stream_id[:8]}, Chatter 返回 Failure: {result.error}")
-                    elif isinstance(result, Wait):
-                        # 记录等待状态（直接保存上次 yield 对象）
-                        manager._wait_states[stream_id] = (
-                            result,
-                            time.time(),
-                            len(context.unread_messages),
-                        )
-                        logger.debug(f"[驱动器] stream={stream_id[:8]}, 进入 Wait 状态 (time={result.time})")
-                    elif isinstance(result, Stop):
-                        # 记录等待状态并销毁生成器。
-                        # Stop 语义：经过冷却后，仅当出现“新的未读消息”才重启对话。
-                        manager._wait_states[stream_id] = (
-                            result,
-                            time.time(),
-                            len(context.unread_messages),
-                        )
-                        logger.debug(
-                            f"[驱动器] stream={stream_id[:8]}, 进入 Stop 状态 "
-                            f"(time={result.time}, "
-                            f"direct_wake={result.direct_message_wake_enabled}, "
-                            f"probability={result.direct_message_wake_probability:.2f})，销毁生成器"
-                        )
+                    except StopAsyncIteration:
+                        # 生成器结束，销毁记录以便下次重新创建
+                        logger.debug(f"[驱动器] stream={stream_id[:8]}, 会话生成器已结束 (return)")
                         manager._chatter_genes.pop(stream_id, None)
-
-                    get_chatter = getattr(chatter_manager, "get_chatter_by_stream", None)
-                    chatter = get_chatter(stream_id) if callable(get_chatter) else None
-                    await _publish_after_chatter_step_notification(
-                        stream_id=stream_id,
-                        context=context,
-                        tick=tick,
-                        chatter_name=str(getattr(chatter, "chatter_name", "") or ""),
-                        result=result,
-                        event_manager=event_manager,
-                    )
-                        
-                    manager._stats["total_process_cycles"] += 1
-
-                except StopAsyncIteration:
-                    # 生成器结束，销毁记录以便下次重新创建
-                    logger.debug(f"[驱动器] stream={stream_id[:8]}, 会话生成器已结束 (return)")
-                    manager._chatter_genes.pop(stream_id, None)
-                except Exception as e:
-                    logger.error(f"[驱动器] stream={stream_id[:8]}, 执行 Chatter 出错: {e}")
-                    manager._chatter_genes.pop(stream_id, None)
-                    manager._stats["total_failures"] += 1
+                    except Exception as e:
+                        logger.error(f"[驱动器] stream={stream_id[:8]}, 执行 Chatter 出错: {e}")
+                        manager._chatter_genes.pop(stream_id, None)
+                        manager._stats["total_failures"] += 1
                 finally:
                     context.is_chatter_processing = False
 

--- a/test/core/models/test_stream.py
+++ b/test/core/models/test_stream.py
@@ -26,6 +26,7 @@ class TestStreamContext:
         assert context.unread_messages == []
         assert context.history_messages == []
         assert context.is_active is True
+        # 字段默认值定义了 dispatch/processing lease 的空闲状态。
         assert context.is_chatter_processing is False
         assert context.current_message is None
         assert context.triggering_user_id is None

--- a/test/core/test_components_types.py
+++ b/test/core/test_components_types.py
@@ -54,6 +54,7 @@ class TestEventType:
         assert EventType.BEFORE_MESSAGE_RECEIVED.value == "before_message_received"
         assert EventType.ON_MESSAGE_RECEIVED.value == "on_message_received"
         assert EventType.ON_MESSAGE_SENT.value == "on_message_sent"
+        assert EventType.BEFORE_CHATTER_DISPATCH.value == "before_chatter_dispatch"
         assert EventType.ON_CHATTER_STEP.value == "on_chatter_step"
         assert EventType.AFTER_CHATTER_STEP.value == "after_chatter_step"
         assert EventType.ON_ALL_PLUGIN_LOADED.value == "on_all_plugin_loaded"

--- a/test/core/transport/test_stream_loop_chatter_step_event.py
+++ b/test/core/transport/test_stream_loop_chatter_step_event.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections import deque
 import time
 from types import SimpleNamespace
 from typing import cast
@@ -10,6 +11,7 @@ import pytest
 
 from src.core.components.types import Success, Wait, WaitResumeEvent
 from src.core.components.types import EventType
+from src.core.models.stream import StreamContext
 from src.core.transport.distribution.loop import run_chat_stream
 from src.core.transport.distribution.stream_loop_manager import StreamLoopManager
 
@@ -18,6 +20,14 @@ async def _two_ticks(*_args, **_kwargs):
     """产出两个 Tick 供 run_chat_stream 消费。"""
     yield SimpleNamespace(stream_id="stream-001", tick_count=1)
     yield SimpleNamespace(stream_id="stream-001", tick_count=2)
+
+
+async def _four_ticks(*_args, **_kwargs):
+    """产出四个 Tick，用于验证连续阻断后放行与后续普通分发。"""
+    yield SimpleNamespace(stream_id="stream-gate", tick_count=1)
+    yield SimpleNamespace(stream_id="stream-gate", tick_count=2)
+    yield SimpleNamespace(stream_id="stream-gate", tick_count=3)
+    yield SimpleNamespace(stream_id="stream-gate", tick_count=4)
 
 
 @pytest.mark.asyncio
@@ -124,10 +134,320 @@ async def test_on_chatter_step_continue_false_skips_current_tick_then_recovers(
 
     await run_chat_stream(stream_id=stream_id, manager=manager)
 
-    assert publish_event_mock.await_count == 3
+    assert publish_event_mock.await_count == 5
     assert step_call_count == 1
     assert manager._stats["total_process_cycles"] == 1
     assert manager._stats["total_failures"] == 0
+
+
+@pytest.mark.asyncio
+async def test_before_chatter_dispatch_blocks_ticks_without_consuming_stream_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """pre-dispatch 阻断应无损保留消息、等待状态、resume 和 generator。"""
+    stream_id = "stream-gate"
+    operations: list[str] = []
+    busy_snapshots: list[bool] = []
+    generator_present_at_gate: list[bool] = []
+    received_resumes: list[WaitResumeEvent | None] = []
+    execute_calls = 0
+
+    message = SimpleNamespace(sender_id="u1")
+    cached_message = SimpleNamespace(sender_id="u2")
+    context = StreamContext(stream_id=stream_id)
+    context.unread_messages = [message]  # type: ignore[list-item]
+    context.message_cache = deque([cached_message])  # type: ignore[list-item]
+    context.stream_loop_task = None
+
+    async def chatter_generator():
+        resume_event = yield Wait(time=None)
+        operations.append("generator")
+        received_resumes.append(resume_event)
+        yield Success(message="ok")
+
+    chatter_gene = chatter_generator()
+    first_wait = await anext(chatter_gene)
+
+    def _execute():
+        nonlocal execute_calls
+        execute_calls += 1
+        return chatter_generator()
+
+    chatter = SimpleNamespace(execute=_execute)
+    chatter_manager = SimpleNamespace(
+        get_chatter_by_stream=lambda _sid: chatter,
+        get_or_create_chatter_for_stream=lambda *_args, **_kwargs: chatter,
+    )
+
+    async def _publish_event(event_name: object, params: dict[str, object]) -> dict[str, object]:
+        if event_name == EventType.BEFORE_CHATTER_DISPATCH:
+            tick = cast(SimpleNamespace, params["tick"])
+            operations.append(f"before:{tick.tick_count}")
+            busy_snapshots.append(cast(StreamContext, params["context"]).is_chatter_processing)
+            generator_present_at_gate.append(stream_id in manager._chatter_genes)
+            allowed = tick.tick_count >= 3
+            return {
+                "decision": "SUCCESS",
+                "params": {
+                    **params,
+                    "continue": allowed,
+                    "reason": "" if allowed else "not focused",
+                },
+            }
+        if event_name == EventType.ON_CHATTER_STEP:
+            operations.append("on-step")
+        return {"decision": "SUCCESS", "params": params}
+
+    event_manager = SimpleNamespace(publish_event=AsyncMock(side_effect=_publish_event))
+
+    monkeypatch.setattr("src.core.transport.distribution.loop.conversation_loop", _four_ticks)
+    monkeypatch.setattr(
+        "src.core.transport.distribution.loop.get_core_config",
+        lambda: SimpleNamespace(bot=SimpleNamespace(stream_step_timeout=60.0)),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.get_chatter_manager",
+        lambda: chatter_manager,
+    )
+    monkeypatch.setattr(
+        "src.core.managers.get_event_manager",
+        lambda: event_manager,
+    )
+    monkeypatch.setattr(
+        "src.core.transport.distribution.loop.get_watchdog",
+        lambda: SimpleNamespace(
+            feed_dog=lambda stream_id: None,
+            unregister_stream=lambda stream_id: None,
+        ),
+    )
+
+    pending_resume = WaitResumeEvent(source="sub_agent")
+    manager = StreamLoopManager()
+    manager.is_running = True
+    manager._chatter_genes[stream_id] = chatter_gene
+    manager._wait_states[stream_id] = (first_wait, time.time(), 0)
+    manager._pending_wait_resume_events[stream_id] = pending_resume
+
+    async def _get_context(_stream_id: str):
+        if context.stream_loop_task is None:
+            context.stream_loop_task = asyncio.current_task()
+        return context
+
+    def _wait_state_check(_stream_id: str, _context: StreamContext) -> bool:
+        operations.append("wait-check")
+        return True
+
+    def _take_wait_resume_event(_stream_id: str) -> WaitResumeEvent | None:
+        operations.append("take-resume")
+        return manager._pending_wait_resume_events.pop(_stream_id, None)
+
+    def _message_buffer_check(_stream_id: str, _context: StreamContext) -> bool:
+        operations.append("buffer-check")
+        return True
+
+    manager._get_stream_context = _get_context  # type: ignore[method-assign]
+    manager._flush_cached_messages_to_unread = AsyncMock(return_value=[])  # type: ignore[method-assign]
+    manager._wait_state_check = _wait_state_check  # type: ignore[method-assign]
+    manager.take_wait_resume_event = _take_wait_resume_event  # type: ignore[method-assign]
+    manager._message_buffer_check = _message_buffer_check  # type: ignore[method-assign]
+
+    wait_state_before = manager._wait_states[stream_id]
+    unread_before = list(context.unread_messages)
+    cache_before = deque(context.message_cache)
+
+    await run_chat_stream(stream_id=stream_id, manager=manager)
+
+    assert operations == [
+        "before:1",
+        "before:2",
+        "before:3",
+        "wait-check",
+        "take-resume",
+        "on-step",
+        "generator",
+        "before:4",
+        "wait-check",
+        "take-resume",
+        "buffer-check",
+        "on-step",
+    ]
+    assert busy_snapshots == [True, True, True, True]
+    assert generator_present_at_gate == [True, True, True, True]
+    assert received_resumes == [pending_resume]
+    assert execute_calls == 0
+    assert manager._chatter_genes == {}
+    assert manager._wait_states[stream_id] is wait_state_before
+    assert context.unread_messages == unread_before
+    assert context.message_cache == cache_before
+    assert context.is_chatter_processing is False
+
+
+@pytest.mark.asyncio
+async def test_before_chatter_dispatch_lease_recovers_on_reject_and_exception(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """dispatch/processing lease 在 gate 阻断和前置检查异常后都必须释放。"""
+    stream_id = "stream-gate-lease"
+    busy_snapshots: list[bool] = []
+    context = StreamContext(stream_id=stream_id)
+    context.stream_loop_task = None
+
+    async def _publish_event(event_name: object, params: dict[str, object]) -> dict[str, object]:
+        if event_name == EventType.BEFORE_CHATTER_DISPATCH:
+            tick = cast(SimpleNamespace, params["tick"])
+            busy_snapshots.append(context.is_chatter_processing)
+            return {
+                "decision": "SUCCESS",
+                "params": {
+                    **params,
+                    "continue": tick.tick_count != 1,
+                    "reason": "" if tick.tick_count != 1 else "blocked",
+                },
+            }
+        return {"decision": "SUCCESS", "params": params}
+
+    event_manager = SimpleNamespace(publish_event=AsyncMock(side_effect=_publish_event))
+
+    monkeypatch.setattr("src.core.transport.distribution.loop.conversation_loop", _two_ticks)
+    monkeypatch.setattr(
+        "src.core.transport.distribution.loop.get_core_config",
+        lambda: SimpleNamespace(bot=SimpleNamespace(stream_step_timeout=60.0)),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.get_chatter_manager",
+        lambda: SimpleNamespace(),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.get_event_manager",
+        lambda: event_manager,
+    )
+    monkeypatch.setattr(
+        "src.core.transport.distribution.loop.get_watchdog",
+        lambda: SimpleNamespace(
+            feed_dog=lambda stream_id: None,
+            unregister_stream=lambda stream_id: None,
+        ),
+    )
+
+    async def _get_context(_stream_id: str):
+        if context.stream_loop_task is None:
+            context.stream_loop_task = asyncio.current_task()
+        return context
+
+    def _wait_state_check(_stream_id: str, _context: StreamContext) -> bool:
+        raise RuntimeError("gate passed")
+
+    manager = cast(
+        StreamLoopManager,
+        SimpleNamespace(
+            is_running=True,
+            _chatter_genes={},
+            _wait_states={},
+            _stats={"total_failures": 0, "total_process_cycles": 0},
+            _get_stream_context=_get_context,
+            _flush_cached_messages_to_unread=AsyncMock(return_value=[]),
+            _wait_state_check=_wait_state_check,
+            _message_buffer_check=lambda _stream_id, _context: True,
+        ),
+    )
+
+    await run_chat_stream(stream_id=stream_id, manager=manager)
+
+    assert busy_snapshots == [True, True]
+    assert context.is_chatter_processing is False
+    assert manager._stats["total_failures"] == 1
+
+
+@pytest.mark.asyncio
+async def test_before_chatter_dispatch_blocks_chatter_selection_and_generator_creation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """阻断 tick 不得查找 Chatter，也不得创建新的会话生成器。"""
+    stream_id = "stream-gate-no-generator"
+    busy_snapshots: list[bool] = []
+    selection_calls = 0
+    execute_calls = 0
+
+    async def _one_tick(*_args, **_kwargs):
+        yield SimpleNamespace(stream_id=stream_id, tick_count=1)
+
+    message = SimpleNamespace(sender_id="u1")
+    context = StreamContext(stream_id=stream_id)
+    context.unread_messages = [message]  # type: ignore[list-item]
+    context.stream_loop_task = None
+
+    def _get_chatter(_stream_id: str):
+        nonlocal selection_calls
+        selection_calls += 1
+        return None
+
+    def _create_chatter(*_args, **_kwargs):
+        nonlocal execute_calls
+        execute_calls += 1
+        return None
+
+    async def _publish_event(event_name: object, params: dict[str, object]) -> dict[str, object]:
+        if event_name == EventType.BEFORE_CHATTER_DISPATCH:
+            busy_snapshots.append(context.is_chatter_processing)
+            return {
+                "decision": "SUCCESS",
+                "params": {**params, "continue": False, "reason": "not focused"},
+            }
+        return {"decision": "SUCCESS", "params": params}
+
+    event_manager = SimpleNamespace(publish_event=AsyncMock(side_effect=_publish_event))
+
+    monkeypatch.setattr("src.core.transport.distribution.loop.conversation_loop", _one_tick)
+    monkeypatch.setattr(
+        "src.core.transport.distribution.loop.get_core_config",
+        lambda: SimpleNamespace(bot=SimpleNamespace(stream_step_timeout=60.0)),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.get_chatter_manager",
+        lambda: SimpleNamespace(
+            get_chatter_by_stream=_get_chatter,
+            get_or_create_chatter_for_stream=_create_chatter,
+        ),
+    )
+    monkeypatch.setattr(
+        "src.core.managers.get_event_manager",
+        lambda: event_manager,
+    )
+    monkeypatch.setattr(
+        "src.core.transport.distribution.loop.get_watchdog",
+        lambda: SimpleNamespace(
+            feed_dog=lambda stream_id: None,
+            unregister_stream=lambda stream_id: None,
+        ),
+    )
+
+    async def _get_context(_stream_id: str):
+        if context.stream_loop_task is None:
+            context.stream_loop_task = asyncio.current_task()
+        return context
+
+    manager = cast(
+        StreamLoopManager,
+        SimpleNamespace(
+            is_running=True,
+            _chatter_genes={},
+            _wait_states={},
+            _stats={"total_failures": 0, "total_process_cycles": 0},
+            _get_stream_context=_get_context,
+            _flush_cached_messages_to_unread=AsyncMock(return_value=[]),
+            _wait_state_check=lambda _stream_id, _context: True,
+            _message_buffer_check=lambda _stream_id, _context: True,
+        ),
+    )
+
+    await run_chat_stream(stream_id=stream_id, manager=manager)
+
+    assert busy_snapshots == [True]
+    assert selection_calls == 0
+    assert execute_calls == 0
+    assert manager._chatter_genes == {}
+    assert context.unread_messages == [message]
+    assert context.is_chatter_processing is False
 
 
 @pytest.mark.asyncio
@@ -614,12 +934,17 @@ async def test_after_chatter_step_is_published_after_result_without_affecting_ex
                     "continue": True,
                 },
             }
+        if event_name == EventType.AFTER_CHATTER_STEP:
+            return {
+                "decision": "STOP",
+                "params": {
+                    **params,
+                    "continue": False,
+                },
+            }
         return {
-            "decision": "STOP",
-            "params": {
-                **params,
-                "continue": False,
-            },
+            "decision": "SUCCESS",
+            "params": params,
         }
 
     event_manager = SimpleNamespace(publish_event=AsyncMock(side_effect=_publish_event))
@@ -666,8 +991,8 @@ async def test_after_chatter_step_is_published_after_result_without_affecting_ex
 
     await run_chat_stream(stream_id=stream_id, manager=manager)
 
-    assert len(publish_calls) == 2
-    after_event_name, after_params = publish_calls[1]
+    assert len(publish_calls) == 3
+    after_event_name, after_params = publish_calls[2]
     assert after_event_name == EventType.AFTER_CHATTER_STEP
     assert after_params["result_type"] == "wait"
     assert after_params["step_scope"] == "actor_round"


### PR DESCRIPTION
## 概述

为传输分发链路新增前置门控事件 `EventType.BEFORE_CHATTER_DISPATCH`，在每个会话 Tick 的最前端发布。处理器将 `continue` 置为 `False` 时本 Tick 整体跳过，且**不产生任何状态消费**；同时将 `is_chatter_processing` 租约起点提前，覆盖分发决策到 Chatter 单步结束的完整不可并发区间。

## 动机

旧的 `ON_CHATTER_STEP` 钩子位于分发链路末端：阻断时等待状态已被判断、resume 事件已被取走、消息缓冲窗口已计数、生成器可能已创建，且会触发 `_discard_blocked_messages` 丢弃积压消息。需要"专注度门控、优先级压制、流级限流"这类**无损阻断**能力的插件（首个消费者为 serial_chat_flow，独立仓库）缺乏一个零副作用的介入点。

## 新事件语义

| 参数 | 说明 |
|---|---|
| `stream_id` / `context` / `tick` | 目标流与当前 Tick |
| `continue` | 默认 `True`；置 `False` 则本 Tick 整体跳过 |
| `reason` | 阻断原因文案，仅用于日志 |

**零副作用保证**（`continue=False` 时）：

- 等待状态、resume 事件、消息缓冲计数、已存在生成器、`triggering_user_id` 全部原样保留
- 不触发 Chatter 查找与新生成器创建，不丢积压消息

`ON_CHATTER_STEP` 原有语义保持不变，向后兼容。

## 租约扩展

`is_chatter_processing` 置位起点从 `ON_CHATTER_STEP` 发布前提前到 `BEFORE_CHATTER_DISPATCH` 发布前，阻断与异常路径均经测试验证租约必然释放。

> 唯一可观察变化：分发决策期间该标记即为 `True`（原先为 `False`），使依赖该标记的并发判断语义更保守一致。

## 文件清单（9 个）

- **src**：`types.py`（新枚举）、`loop.py`（gate 发布 + 租约上提 + 结构重构）、`stream.py`（注释）
- **test**：`test_stream_loop_chatter_step_event.py`（新增 3 测试 + 断言修正）、`test_components_types.py`、`test_stream.py`
- **docs**：`distribution.md`（新章节"门控语义"）、transport `README.md`、`15-event-system.md`

## 测试

- ✅ 相关 3 个测试文件：65 passed
- ✅ 全量 pytest（固定顺序）与干净 `dev` 基线逐项对比：失败集合**完全一致**（42 个存量失败，集中在 permission/prompt/command 管理器共享状态），**零新增回归**
- ✅ `ruff check src/`：5 个报告项经基线对照确认为存量问题，改动文件无告警

## 验证方法

1. 订阅 `BEFORE_CHATTER_DISPATCH`，向处于 Wait 状态的流返回 `continue=False`：流跳过响应，但 `unread_messages`/`message_cache`/`_wait_states` 不变；恢复放行后积压的 resume 事件仍被正常消费
2. 带 `reason` 阻断时驱动器日志出现 `before_chatter_dispatch continue=False，跳过本 Tick，reason=...`

## 备注

- `.github/copilot-instructions.md` 的文档重写与本功能无关，另行提交 `docs` PR

## Summary by Sourcery

Introduce a lossless pre-dispatch gate that can skip individual chatter ticks while preserving stream state and enforcing a complete processing lease.

New Features:
- Add the `BEFORE_CHATTER_DISPATCH` event for plugins to gate each stream tick before any dispatch state is consumed.

Bug Fixes:
- Ensure blocked ticks preserve wait state, resume events, message buffers, existing generators, and triggering user information without discarding pending messages.

Enhancements:
- Extend the chatter-processing lease to cover dispatch decisions through completion of the chatter step, including blocked and exceptional paths.
- Preserve the existing `ON_CHATTER_STEP` behavior while distinguishing it from the new lossless pre-dispatch gate.

Documentation:
- Document the new pre-dispatch gate, its lossless blocking semantics, and its relationship to `ON_CHATTER_STEP`.

Tests:
- Add coverage for lossless tick blocking, lease cleanup, and prevention of chatter selection or generator creation.