### PR TITLE
fix(onebot_adapter): 修复转发消息引用预览丢失与内联嵌套转发被丢弃

### DIFF
--- a/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
+++ b/plugins/onebot_adapter/src/handlers/to_core/message_handler.py
@@ -725,6 +725,10 @@ class MessageHandler:
                     )
                     if ref_result:
                         reply_segments.append(ref_result)
+            elif reply_data.get("text"):
+                # 未能定位被引用消息：回退使用 reply 段自带的内嵌文本预览
+                embedded_text = str(reply_data["text"])
+                reply_segments.append({"type": "text", "data": embedded_text})
 
             prefix_text = f"[回复<{sender_nickname}({sender_id})>：" if sender_id else f"[回复<{sender_nickname}>："
             brief_segments = [

--- a/plugins/onebot_adapter/src/handlers/utils.py
+++ b/plugins/onebot_adapter/src/handlers/utils.py
@@ -2,7 +2,7 @@ import asyncio
 import io
 import time
 import weakref
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 import httpx
 import orjson
@@ -443,6 +443,16 @@ async def get_forward_message(
     if not forward_message_data:
         logger.warning("转发消息内容为空")
         return None
+
+    # 内联 content 优先：本地/离线转发段会直接携带完整节点列表且通常没有
+    # data.id，此时按 id 调 API 拉取必然失败，直接使用内联内容即可。
+    inline_content = forward_message_data.get("content")
+    if isinstance(inline_content, dict):
+        inline_content = [inline_content]
+    if isinstance(inline_content, list) and inline_content:
+        logger.debug("转发消息携带内联 content，跳过 API 拉取")
+        return cast("list[dict[str, Any]]", inline_content)
+
     forward_message_id = forward_message_data.get("id")
 
     try:


### PR DESCRIPTION
## 问题

`991fb39` 随转发消息配置功能一起新增的 `test/plugins/test_onebot_adapter_forward_message.py` 中有 5 个测试自落地起就是失败的，对应两个真实缺陷：

### 1. 转发内引用（reply）预览丢失内嵌文本

`message_handler.py` 的 `_handle_forward_single_segment` reply 分支注释承诺「无法定位时回退使用 reply 段自带的内嵌 text/qq 预览」，但实现只读取了 `qq` 作为发送者展示，`text` 字段从未被读取。转发记录内定位不到被引用消息时，预览固定退化为 `[回复<x(x)>：[无法获取被引用的消息]]`，被引用原文丢失。

**修复**：定位失败且 reply 段携带内嵌 `text` 时，用内嵌文本构建预览；两者皆无时保持原有占位符行为。

### 2. 内联嵌套转发（`data.content`）被整体丢弃

`get_forward_message` 只支持 `data.id` 走 API 拉取。本地/离线转发段直接携带完整节点列表（`data.content`）且通常没有 `data.id`，此前会拿 `message_id=None` 去调 API，失败后整段嵌套内容静默消失。

**修复**：`get_forward_message` 优先使用内联 `content`（兼容单节点 dict 形态），仅在无内联内容时按 `data.id` 走 API 拉取；`forward_max_depth` 深度限制行为不变。

## 验证

- `test/plugins/test_onebot_adapter_forward_message.py`：16/16 通过（修复前 11 通过 / 5 失败）
- `test/plugins` + `test/core/transport` 全量对比：失败集与修复前完全一致（均为既有失败，与本 PR 无关），无新增回归

## Summary by Sourcery

修复 OneBot 转发消息的引用预览缺失和内联嵌套转发内容丢失问题。

Bug Fixes:
- 保留无法定位引用消息时由转发段提供的内嵌文本预览。
- 支持直接处理携带内联内容的嵌套转发消息，避免其内容被丢弃。